### PR TITLE
I1772 - support basic auth and non-montagu servers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ after_success:
   - Rscript -e 'covr::codecov()'
 r_github_packages:
   - ropensci/cyphr
-  - vimc/montagu-r@i1772
+  - vimc/montagu-r
   - vimc/vaultr
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ after_success:
   - Rscript -e 'covr::codecov()'
 r_github_packages:
   - ropensci/cyphr
-  - vimc/montagu-r
-  - vimc/vaultr@i600
+  - vimc/montagu-r@i1772
+  - vimc/vaultr
 env:
   global:
     - VAULTR_TEST_SERVER_INSTALL=true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: R support for montagu-reports
-Version: 0.4.1
+Version: 0.4.2
 Description: Order, create and store reports from R.
 License: MIT + file LICENSE
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ Imports:
     yaml
 Suggests:
     knitr,
-    montagu (>= 0.1.7),
+    montagu (>= 0.1.8),
     png,
     processx,
     rmarkdown,

--- a/R/config.R
+++ b/R/config.R
@@ -112,7 +112,19 @@ config_check_api_server <- function(dat, filename) {
       }
     }
 
-    server <- resolve_env(server)
+    ## NOTE: it would be ideal here to check that the variables are
+    ## all set up, but this seems somewhat restrictive.  So we just
+    ## send a message indicating that this has failed.
+    server <- tryCatch(
+      resolve_env(server),
+      error = function(e) {
+        message(sprintf("Failed to resolve api_server '%s':\n\t%s",
+                        name, e$message))
+        message(
+          "\tContacting this server will fail (e.g., fetching dependencies)")
+        message("\tbut otherwise orderly will work, so continuing")
+        server
+      })
 
     check_field("basic", TRUE, assert_scalar_logical)
     ## check_field("port", TRUE, assert_scalar_integer)

--- a/R/config.R
+++ b/R/config.R
@@ -94,16 +94,16 @@ config_check_api_server <- function(dat, filename) {
 
   assert_named(dat, unique = TRUE)
 
-  check1 <- function(key) {
-    server <- dat[[key]]
+  check1 <- function(name) {
+    server <- dat[[name]]
     check_fields(server,
-                 sprintf("%s:api_server:%s", filename, key),
+                 sprintf("%s:api_server:%s", filename, name),
                  c("host", "port", "basic"),
                  c("username", "password"))
     check_field <- function(nm, required, fn) {
       x <- server[[nm]]
       if (required || !is.null(x)) {
-        fn(x, sprintf("%s:api_server:key:%s", filename, key, nm))
+        fn(x, sprintf("%s:api_server:%s:%s", filename, name, nm))
       }
     }
 
@@ -116,13 +116,14 @@ config_check_api_server <- function(dat, filename) {
     check_field("password", FALSE, assert_scalar_character)
 
     if (requireNamespace("montagu", quietly = TRUE)) {
-      montagu::montagu_add_location(nm, x$hostname, x$port, x$basic)
+      montagu::montagu_add_location(
+        name, server$host, server$port, server$basic)
     }
 
     server
   }
 
-  lapply(dat, check1)
+  lapply(names(dat), check1)
 }
 
 sql_type <- function(type, name) {

--- a/R/config.R
+++ b/R/config.R
@@ -128,7 +128,7 @@ config_check_api_server <- function(dat, filename) {
     server
   }
 
-  lapply(names(dat), check1)
+  set_names(lapply(names(dat), check1), names(dat))
 }
 
 sql_type <- function(type, name) {

--- a/R/config.R
+++ b/R/config.R
@@ -12,7 +12,7 @@ orderly_config_read_yaml <- function(filename, path) {
   info <- yaml_read(filename)
   check_fields(info, filename, "source",
                c("destination", "fields", "minimum_orderly_version",
-                 "api_server"))
+                 "api_server", "vault_server"))
 
   ## There's heaps of really boring validation to do here that I am
   ## going to skip.  The drama that we will have is that there are
@@ -41,6 +41,11 @@ orderly_config_read_yaml <- function(filename, path) {
     stop(sprintf(
       "Orderly version '%s' is required, but only '%s' installed",
       v, utils::packageVersion("orderly")))
+  }
+
+  if (!is.null(info$vault_server)) {
+    assert_scalar_character(info$vault_server,
+                            sprintf("%s:vault_server", filename))
   }
 
   api_server <- info$api_server

--- a/R/db.R
+++ b/R/db.R
@@ -30,7 +30,7 @@ orderly_db_args <- function(type, config) {
 
   args <- withr::with_envvar(
     orderly_envir_read(config$path),
-    args <- resolve_driver_config(x$args))
+    args <- resolve_driver_config(x$args), config$vault_server)
 
   if (x$driver[[2]] == "SQLite") {
     dbname <- args$dbname

--- a/R/db.R
+++ b/R/db.R
@@ -30,7 +30,7 @@ orderly_db_args <- function(type, config) {
 
   args <- withr::with_envvar(
     orderly_envir_read(config$path),
-    args <- resolve_driver_config(x$args), config$vault_server)
+    args <- resolve_driver_config(x$args, config$vault_server))
 
   if (x$driver[[2]] == "SQLite") {
     dbname <- args$dbname

--- a/R/remote.R
+++ b/R/remote.R
@@ -167,10 +167,12 @@ set_default_remote <- function(value) {
 
 
 ##' @rdname default_remote
-get_default_remote <- function(config) {
+##' @inheritParams orderly_list
+get_default_remote <- function(config = NULL, locate = TRUE) {
   if (!is.null(cache$default_remote)) {
     return(cache$default_remote)
   }
+  config <- orderly_config_get(config, locate)
   if (length(config$api_server) > 0L) {
     return(names(config$api_server)[[1]])
   }

--- a/R/remote.R
+++ b/R/remote.R
@@ -62,7 +62,7 @@ pull_archive <- function(name, id = "latest", config = NULL, locate = TRUE,
                          remote = NULL) {
   config <- orderly_config_get(config, locate)
 
-  remote <- get_remote(remote)
+  remote <- get_remote(remote, config)
   if (inherits(remote, "orderly_api_server")) {
     pull_archive_api(name, id, config, remote)
   } else if (inherits(remote, "orderly_remote_path")) {
@@ -107,13 +107,16 @@ pull_archive <- function(name, id = "latest", config = NULL, locate = TRUE,
 orderly_run_remote <- function(name, parameters = NULL, ref = NULL,
                                timeout = 3600, poll = 1,
                                open = TRUE, stop_on_error = TRUE,
-                               progress = TRUE, remote = NULL) {
-  remote <- get_remote()
+                               progress = TRUE,
+                               config = NULL, locate = TRUE, remote = NULL) {
+  config <- orderly_config_get(config, locate)
+  remote <- get_remote(remote, config)
   if (inherits(remote, "orderly_api_server")) {
     orderly_run_remote_api(name = name, parameters = parameters, ref = ref,
                            timeout = timeout, poll = poll, open = open,
                            stop_on_error = stop_on_error,
-                           progress = progress, remote = remote)
+                           progress = progress,
+                           config = config, remote = remote)
   } else if (inherits(remote, "orderly_remote_path")) {
     stop("Can't run reports with remote type ",
          paste(squote(class(remote)), collapse = " / "))
@@ -134,11 +137,13 @@ orderly_run_remote <- function(name, parameters = NULL, ref = NULL,
 ##'
 ##' @inheritParams orderly_run_remote
 ##' @export
-orderly_publish_remote <- function(name, id, value = TRUE, remote = NULL) {
-  remote <- get_remote()
+orderly_publish_remote <- function(name, id, value = TRUE,
+                                   config = NULL, locate = TRUE, remote = NULL) {
+  config <- orderly_config_get(config, locate)
+  remote <- get_remote(remote, config)
   if (inherits(remote, "orderly_api_server")) {
-    orderly_publish_remote_api(name = name, id = id, value = value,
-                               remote = remote)
+    orderly_publish_remote_api(name = name, id = id, config = config,
+                               value = value, remote = remote)
   } else if (inherits(remote, "orderly_remote_path")) {
     ## This one can actually be done over disk too
     stop("Can't publish reports with remote type ",
@@ -162,9 +167,12 @@ set_default_remote <- function(value) {
 
 
 ##' @rdname default_remote
-get_default_remote <- function() {
+get_default_remote <- function(config) {
   if (!is.null(cache$default_remote)) {
     return(cache$default_remote)
+  }
+  if (length(config$api_server) > 0L) {
+    return(names(config$api_server)[[1]])
   }
   default_remote_path <- Sys.getenv("ORDERLY_DEFAULT_REMOTE_PATH", NA_character_)
   if (!is.na(default_remote_path)) {
@@ -174,6 +182,6 @@ get_default_remote <- function() {
 }
 
 
-get_remote <- function(remote) {
-  remote %||% get_default_remote()
+get_remote <- function(remote, config) {
+  remote %||% get_default_remote(config)
 }

--- a/R/remote_api.R
+++ b/R/remote_api.R
@@ -77,7 +77,7 @@ orderly_remote_api_server <- function(config, remote) {
   remote <- monagu::montagu_location(remote %||% names(api_server)[[1L]])
 
   ## Look up the secrets in the vault
-  server_data <- resolve_secrets(api_server[[remote]])
+  server_data <- resolve_secrets(api_server[[remote]], config$vault_server)
 
   ## Then set the username/password varibles so that they can be found
   ## easily:

--- a/R/remote_api.R
+++ b/R/remote_api.R
@@ -38,10 +38,11 @@ pull_archive_api <- function(name, id, config, remote) {
 }
 
 
-orderly_run_remote_api <- function(name, parameters = NULL, ref = NULL,
+orderly_run_remote_api <- function(name, config, parameters = NULL, ref = NULL,
                                    timeout = 3600, poll = 1,
                                    open = TRUE, stop_on_error = TRUE,
                                    progress = TRUE, remote = NULL) {
+  assert_is(config, "orderly_config")
   loadNamespace("montagu")
   remote <- orderly_remote_api_server(config, remote)
 
@@ -55,7 +56,9 @@ orderly_run_remote_api <- function(name, parameters = NULL, ref = NULL,
 }
 
 
-orderly_publish_remote_api <- function(name, id, value = TRUE, remote = NULL) {
+orderly_publish_remote_api <- function(name, id, config, value = TRUE,
+                                       remote = NULL) {
+  assert_is(config, "orderly_config")
   ## This one can actually be done over disk too
   loadNamespace("montagu")
   remote <- orderly_remote_api_server(config, remote)

--- a/R/remote_api.R
+++ b/R/remote_api.R
@@ -7,12 +7,13 @@ orderly_api_server <- function(location) {
 ## without a working copy of the montagu reporting api.  I guess the
 ## simplest solution will be to have a copy running on support that we
 ## can point this at.
-pull_archive_api <- function(name, id, config, server) {
+pull_archive_api <- function(name, id, config, remote) {
   loadNamespace("montagu")
   assert_is(config, "orderly_config")
+  remote <- orderly_remote_api_server(config, remote)
   if (id == "latest") {
     ## Resolve id
-    v <- montagu::montagu_reports_report_versions(name, server)
+    v <- montagu::montagu_reports_report_versions(name, remote)
     ## TODO: more work needed here if we have two identical timestamps!
     id <- last(v)
   }
@@ -22,7 +23,7 @@ pull_archive_api <- function(name, id, config, server) {
   } else {
     orderly_log("pull", sprintf("%s:%s", name, id))
     tmp <- montagu::montagu_reports_report_download(name, id,
-                                                    location = server)
+                                                    location = remote)
     cat("\n") # httr's progress bar is rubbish
     on.exit(file.remove(tmp))
     tmp2 <- tempfile()
@@ -42,6 +43,8 @@ orderly_run_remote_api <- function(name, parameters = NULL, ref = NULL,
                                    open = TRUE, stop_on_error = TRUE,
                                    progress = TRUE, remote = NULL) {
   loadNamespace("montagu")
+  remote <- orderly_remote_api_server(config, remote)
+
   if (remote == "production" && !is.null(ref)) {
     stop("Can't specify 'ref' on production")
   }
@@ -55,8 +58,35 @@ orderly_run_remote_api <- function(name, parameters = NULL, ref = NULL,
 orderly_publish_remote_api <- function(name, id, value = TRUE, remote = NULL) {
   ## This one can actually be done over disk too
   loadNamespace("montagu")
+  remote <- orderly_remote_api_server(config, remote)
   assert_scalar_character(name)
   assert_scalar_character(id)
   assert_scalar_logical(value)
   montagu::montagu_reports_publish(name, id, value, remote)
+}
+
+
+orderly_remote_api_server <- function(config, remote) {
+  api_server <- config$api_server
+  if (is.null(api_server)) {
+    ## If there is no api_server section then none of this matters at all.
+    return()
+  }
+
+  ## This is the server that we're going to go for
+  remote <- monagu::montagu_location(remote %||% names(api_server)[[1L]])
+
+  ## Look up the secrets in the vault
+  server_data <- resolve_secrets(api_server[[remote]])
+
+  ## Then set the username/password varibles so that they can be found
+  ## easily:
+  for (nm in c("username", "password")) {
+    key <- sprintf("montagu.%s.%s", remote, nm)
+    if (!is.null(server_data[[nm]]) && is.null(getOption(key))) {
+      do.call("options", set_names(server_data[nm], key))
+    }
+  }
+
+  remote
 }

--- a/R/remote_api.R
+++ b/R/remote_api.R
@@ -74,19 +74,15 @@ orderly_remote_api_server <- function(config, remote) {
   }
 
   ## This is the server that we're going to go for
-  remote <- monagu::montagu_location(remote %||% names(api_server)[[1L]])
+  remote <- montagu::montagu_location(remote %||% names(api_server)[[1L]])
 
   ## Look up the secrets in the vault
   server_data <- resolve_secrets(api_server[[remote]], config$vault_server)
 
   ## Then set the username/password varibles so that they can be found
   ## easily:
-  for (nm in c("username", "password")) {
-    key <- sprintf("montagu.%s.%s", remote, nm)
-    if (!is.null(server_data[[nm]]) && is.null(getOption(key))) {
-      do.call("options", set_names(server_data[nm], key))
-    }
-  }
+  type <- c("username", "password")
+  options(set_names(server_data[type], sprintf("montagu.%s.%s", remote, type)))
 
   remote
 }

--- a/R/util.R
+++ b/R/util.R
@@ -302,8 +302,8 @@ indent <- function(x, n) {
   paste0(strrep(" ", n), strsplit(x, "\n", fixed = TRUE)[[1]])
 }
 
-resolve_driver_config <- function(args) {
-  resolve_secrets(resolve_env(args))
+resolve_driver_config <- function(args, vault_server) {
+  resolve_secrets(resolve_env(args), vault_server)
 }
 
 resolve_env <- function(x) {

--- a/R/vault.R
+++ b/R/vault.R
@@ -1,15 +1,15 @@
-resolve_secrets <- function(x) {
+resolve_secrets <- function(x, vault_server) {
   re <- "^VAULT:(.+):(.+)"
   if (is.list(x)) {
     i <- vlapply(x, function(el) is.character(el) && grepl(re, el))
     if (any(i)) {
-      x[i] <- resolve_secrets(vcapply(x[i], identity))
+      x[i] <- resolve_secrets(vcapply(x[i], identity), vault_server)
     }
   } else {
     i <- grepl(re, x)
     if (any(i)) {
       loadNamespace("vaultr")
-      vault <- vaultr::vault_client()
+      vault <- vaultr::vault_client(addr = vault_server)
       key <- unname(sub(re, "\\1", x[i]))
       field <- unname(sub(re, "\\2", x[i]))
       x[i] <- unname(Map(vault$read, key, field))

--- a/man/default_remote.Rd
+++ b/man/default_remote.Rd
@@ -7,10 +7,18 @@
 \usage{
 set_default_remote(value)
 
-get_default_remote(config)
+get_default_remote(config = NULL, locate = TRUE)
 }
 \arguments{
 \item{value}{An \code{orderly_remote_location} object.}
+
+\item{config}{An orderly configuration, or the path to one (or
+\code{NULL} to locate one if \code{locate} is \code{TRUE}).}
+
+\item{locate}{Logical, indicating if the configuration should be
+searched for.  If \code{TRUE} and \code{config} is not given,
+then orderly looks in the working directory and up through its
+parents until it finds an \code{orderly_config.yml} file.}
 }
 \description{
 Set and get default remote locations

--- a/man/default_remote.Rd
+++ b/man/default_remote.Rd
@@ -7,7 +7,7 @@
 \usage{
 set_default_remote(value)
 
-get_default_remote()
+get_default_remote(config)
 }
 \arguments{
 \item{value}{An \code{orderly_remote_location} object.}

--- a/man/orderly_publish_remote.Rd
+++ b/man/orderly_publish_remote.Rd
@@ -4,7 +4,8 @@
 \alias{orderly_publish_remote}
 \title{Publish orderly report on remote server}
 \usage{
-orderly_publish_remote(name, id, value = TRUE, remote = NULL)
+orderly_publish_remote(name, id, value = TRUE, config = NULL,
+  locate = TRUE, remote = NULL)
 }
 \arguments{
 \item{name}{Name of the report (unlike
@@ -14,6 +15,14 @@ orderly_publish_remote(name, id, value = TRUE, remote = NULL)
 
 \item{value}{As \code{\link{orderly_publish}}, \code{TRUE} or
 \code{FALSE} to publish or unpublish a report (respectively)}
+
+\item{config}{An orderly configuration, or the path to one (or
+\code{NULL} to locate one if \code{locate} is \code{TRUE}).}
+
+\item{locate}{Logical, indicating if the configuration should be
+searched for.  If \code{TRUE} and \code{config} is not given,
+then orderly looks in the working directory and up through its
+parents until it finds an \code{orderly_config.yml} file.}
 
 \item{remote}{Description of the location.  This must be an
 \code{orderly_remote} object.}

--- a/man/orderly_run_remote.Rd
+++ b/man/orderly_run_remote.Rd
@@ -6,7 +6,7 @@
 \usage{
 orderly_run_remote(name, parameters = NULL, ref = NULL, timeout = 3600,
   poll = 1, open = TRUE, stop_on_error = TRUE, progress = TRUE,
-  remote = NULL)
+  config = NULL, locate = TRUE, remote = NULL)
 }
 \arguments{
 \item{name}{Name of the report}
@@ -29,6 +29,14 @@ will be much easier to debug, but more annoying in scripts.}
 
 \item{progress}{Logical, indicating if a progress spinner should
 be included.}
+
+\item{config}{An orderly configuration, or the path to one (or
+\code{NULL} to locate one if \code{locate} is \code{TRUE}).}
+
+\item{locate}{Logical, indicating if the configuration should be
+searched for.  If \code{TRUE} and \code{config} is not given,
+then orderly looks in the working directory and up through its
+parents until it finds an \code{orderly_config.yml} file.}
 
 \item{remote}{Description of the location.  This must be an
 \code{orderly_remote} object.}

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -93,3 +93,22 @@ test_that("minimum version is a less than relationship", {
   expect_is(cfg, "orderly_config")
   expect_equal(cfg$minimum_orderly_version, dat$minimum_orderly_version)
 })
+
+
+test_that("support declaring api server", {
+  path <- tempfile()
+  dir.create(path)
+  dat <- list(source = list(driver = "RSQLite::SQLite"),
+              api_server = list(
+                myhost = list(
+                  host = "myhost.com",
+                  port = 443,
+                  basic = TRUE,
+                  username = "orderly",
+                  password = "secert")))
+  writeLines(yaml::as.yaml(dat), path_orderly_config_yml(path))
+  cfg <- orderly_config(path)
+
+  expect_is(cfg$api_server, "list")
+  expect_equal(cfg$api_server, dat$api_server)
+})

--- a/tests/testthat/test-remote.R
+++ b/tests/testthat/test-remote.R
@@ -3,9 +3,9 @@ context("remote")
 
 test_that("defaults: null", {
   expect_null(set_default_remote(NULL))
-  expect_error(get_default_remote(),
+  expect_error(get_default_remote(NULL),
                "default remote has not been set yet")
-  expect_error(get_remote(NULL),
+  expect_error(get_remote(NULL, NULL),
                "default remote has not been set yet")
 })
 
@@ -16,7 +16,7 @@ test_that("defaults: envvar", {
   writeLines("", path_orderly_config_yml(tmp))
   withr::with_envvar(
     c("ORDERLY_DEFAULT_REMOTE_PATH" = tmp),
-    expect_equal(get_default_remote(),
+    expect_equal(get_default_remote(NULL),
                  orderly_remote_path(tmp)))
 })
 

--- a/tests/testthat/test-remote.R
+++ b/tests/testthat/test-remote.R
@@ -2,21 +2,23 @@ context("remote")
 
 
 test_that("defaults: null", {
+  path <- prepare_orderly_example("minimal")
   expect_null(set_default_remote(NULL))
-  expect_error(get_default_remote(NULL),
+  expect_error(get_default_remote(path, FALSE),
                "default remote has not been set yet")
-  expect_error(get_remote(NULL, NULL),
+  expect_error(get_remote(NULL, path),
                "default remote has not been set yet")
 })
 
 
 test_that("defaults: envvar", {
+  path <- prepare_orderly_example("minimal")
   tmp <- tempfile()
   dir.create(tmp)
   writeLines("", path_orderly_config_yml(tmp))
   withr::with_envvar(
     c("ORDERLY_DEFAULT_REMOTE_PATH" = tmp),
-    expect_equal(get_default_remote(NULL),
+    expect_equal(get_default_remote(path, FALSE),
                  orderly_remote_path(tmp)))
 })
 

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -64,17 +64,18 @@ test_that("secrets", {
             password = "VAULT:/secret/users/alice:password")
   vaultr::vault_clear_token_cache()
   withr::with_envvar(c(VAULTR_AUTH_METHOD = NA_character_), {
-    expect_error(resolve_secrets(x), "Have not authenticated against vault")
+    expect_error(resolve_secrets(x, NULL),
+                 "Have not authenticated against vault")
   })
   withr::with_envvar(c(VAULTR_AUTH_METHOD = "token", VAULT_TOKEN = NA), {
-    expect_error(resolve_secrets(x), "token not found")
+    expect_error(resolve_secrets(x, NULL), "token not found")
   })
   withr::with_envvar(c(VAULTR_AUTH_METHOD = "token", VAULT_TOKEN = "fake"), {
-    expect_error(resolve_secrets(x), "Token verification failed with code")
+    expect_error(resolve_secrets(x, NULL), "Token verification failed with code")
   })
-  expect_equal(resolve_secrets(x),
+  expect_equal(resolve_secrets(x, NULL),
                list(name = "alice", password = "ALICE"))
-  expect_equal(resolve_secrets(unlist(x)),
+  expect_equal(resolve_secrets(unlist(x), NULL),
                list(name = "alice", password = "ALICE"))
 })
 
@@ -90,7 +91,7 @@ test_that("resolve secret env", {
   vars <- c("ORDERLY_PASSWORD"="VAULT:/secret/users/alice:password",
             "ORDERLY_USER"="alice")
 
-  res <- withr::with_envvar(vars, resolve_driver_config(x))
+  res <- withr::with_envvar(vars, resolve_driver_config(x, NULL))
   expect_equal(res,
                list(user = "alice", password = "ALICE", other = "string"))
 })


### PR DESCRIPTION
This work needs https://github.com/vimc/montagu-r/pull/5

This is primarily to support the ebola response and extends the orderly remote functions a bit to support non-VIMC servers.  It's going to need a further round of rationalisation once we really disentangle montagu and orderly.

The `orderly_config.yml` picks up additional options

- `vault_server` - the address of the vault that we should use
- `api_server` - a set of remote api servers

Most of the logic is within the validation function in config.R and also in `orderly_remote_api_server`