### PR TITLE
i1794: Fix specification of remotes

### DIFF
--- a/R/remote.R
+++ b/R/remote.R
@@ -185,5 +185,23 @@ get_default_remote <- function(config = NULL, locate = TRUE) {
 
 
 get_remote <- function(remote, config) {
-  remote %||% get_default_remote(config)
+  if (is.null(remote)) {
+    get_default_remote(config)
+  } else if (inherits(remote, c("montagu_server", "orderly_remote_path"))) {
+    remote
+  } else if (is.character(remote)) {
+    assert_scalar(remote)
+    if (remote %in% names(config$api_server)) {
+      config$api_server[[remote]]
+    } else if (file.exists(remote)) {
+      orderly_remote_path(remote)
+    } else {
+      stop(sprintf("Unknown remote '%s'", remote),
+           call. = FALSE)
+    }
+  } else {
+    stop("Unknown remote type ",
+         paste(squote(class(remote)), collapse = " / "),
+         call. = FALSE)
+  }
 }

--- a/tests/testthat/test-remote.R
+++ b/tests/testthat/test-remote.R
@@ -11,6 +11,25 @@ test_that("defaults: null", {
 })
 
 
+test_that("get_remote", {
+  config <- list(api_server = list(foo = "foo", bar = "bar"))
+  class(config) <- "orderly_config"
+  expect_equal(get_remote(NULL, config), "foo")
+  expect_equal(get_remote("foo", config), "foo")
+  expect_equal(get_remote("bar", config), "bar")
+  expect_error(get_remote("other", config),
+               "Unknown remote 'other'",
+               fixed = TRUE)
+
+  p <- prepare_orderly_example("minimal")
+  expect_equal(get_remote(p, config), orderly_remote_path(p))
+
+  expect_error(get_remote(TRUE, config),
+               "Unknown remote type 'logical'",
+               fixed = TRUE)
+})
+
+
 test_that("defaults: envvar", {
   path <- prepare_orderly_example("minimal")
   tmp <- tempfile()


### PR DESCRIPTION
This one is at least much smaller, probably do before #14 

Turns out that passing `remote = <whatever>` really didn't work properly.  This tries to resolve things properly, so there's quite a bit more logic in `get_remote()`, with accompanying tests