### PR TITLE
i1814: better workaround for file.copy

### DIFF
--- a/R/init.R
+++ b/R/init.R
@@ -35,7 +35,7 @@ orderly_init <- function(root, doc = TRUE, quiet = FALSE) {
     file_copy(orderly_file("readme_root.md"),
               file.path(root, "README.md"))
   }
-  file.copy(orderly_file("orderly_config_example.yml"),
+  file_copy(orderly_file("orderly_config_example.yml"),
             path_orderly_config_yml(root))
   if (!quiet) {
     message(sprintf("Now, edit the file 'orderly_config.yml' within '%s'",

--- a/R/main.R
+++ b/R/main.R
@@ -139,7 +139,7 @@ main_do_run <- function(x) {
     ## we should run this with try() so that we can capture logs there
     id <- capture_log(main_run(), log, TRUE)
     dest <- (if (commit) path_archive else path_draft)(config$path)
-    file.copy(log, file.path(dest, name, id, "orderly.log"))
+    file_copy(log, file.path(dest, name, id, "orderly.log"))
   }
 
   ## TODO: is it useful to write this to some location (rather than

--- a/R/new.R
+++ b/R/new.R
@@ -17,7 +17,7 @@ orderly_new <- function(name, config = NULL, locate = TRUE, quiet = FALSE) {
   }
   dir.create(dest)
   yml <- file.path(dest, "orderly.yml")
-  file.copy(orderly_file("orderly_example.yml"), yml)
+  file_copy(orderly_file("orderly_example.yml"), yml)
 
   if (nrow(config$fields) > 0L) {
     txt <- readLines(yml)

--- a/R/recipe_commit.R
+++ b/R/recipe_commit.R
@@ -81,7 +81,7 @@ copy_report <- function(workdir, name, config) {
   }
   dir_create(parent)
   orderly_log("copy", "")
-  ok <- file.copy(workdir, parent, recursive = TRUE)
+  ok <- file_copy(workdir, parent, recursive = TRUE)
   if (!ok) {
     try(unlink(dest, recursive = TRUE), silent = TRUE)
     stop("Error copying file")

--- a/R/recipe_commit.R
+++ b/R/recipe_commit.R
@@ -81,11 +81,7 @@ copy_report <- function(workdir, name, config) {
   }
   dir_create(parent)
   orderly_log("copy", "")
-  ok <- file_copy(workdir, parent, recursive = TRUE)
-  if (!ok) {
-    try(unlink(dest, recursive = TRUE), silent = TRUE)
-    stop("Error copying file")
-  }
+  file_copy(workdir, parent, recursive = TRUE)
   dest
 }
 

--- a/R/recipe_run.R
+++ b/R/recipe_run.R
@@ -358,7 +358,7 @@ recipe_prepare_workdir <- function(info) {
                    info$depends$filename,
                    info$depends$as)
     orderly_log("depends", str)
-    file.copy(src, dst)
+    file_copy(src, dst)
   }
 
   owd

--- a/R/remote_api.R
+++ b/R/remote_api.R
@@ -27,7 +27,7 @@ pull_archive_api <- function(name, id, config, remote) {
 
     ## R's file.copy is exceedingly rubbish
     dir.create(dirname(dest), FALSE, TRUE)
-    file.copy(file.path(tmp2, basename(dest)),
+    file_copy(file.path(tmp2, basename(dest)),
               dirname(dest), recursive = TRUE)
   }
 }

--- a/R/remote_path.R
+++ b/R/remote_path.R
@@ -41,10 +41,7 @@ pull_archive_path <- function(name, id, config, from, overwrite = FALSE) {
     ## This little dance means that in the event of a failure we don't
     ## get partial copies.
     on.exit(unlink(dest, recursive = TRUE))
-    ok <- file_copy(src, dest_dir, recursive = TRUE)
-    if (!ok) {
-      stop("Some sort of error copying %s => %s", src, dest)
-    }
+    file_copy(src, dest_dir, recursive = TRUE)
     on.exit()
   }
 }

--- a/R/remote_path.R
+++ b/R/remote_path.R
@@ -41,7 +41,7 @@ pull_archive_path <- function(name, id, config, from, overwrite = FALSE) {
     ## This little dance means that in the event of a failure we don't
     ## get partial copies.
     on.exit(unlink(dest, recursive = TRUE))
-    ok <- file.copy(src, dest_dir, recursive = TRUE)
+    ok <- file_copy(src, dest_dir, recursive = TRUE)
     if (!ok) {
       stop("Some sort of error copying %s => %s", src, dest)
     }

--- a/R/runner.R
+++ b/R/runner.R
@@ -215,7 +215,7 @@ R6_orderly_runner <- R6::R6Class(
         base <- if (state == RUNNER_SUCCESS) path_archive else path_draft
         p <- file.path(base(self$path), process$name, id)
         if (file.exists(p)) {
-          file.copy(c(process$stdout, process$stderr), p)
+          file_copy(c(process$stdout, process$stderr), p)
         }
       } else {
         id <- NA_character_

--- a/R/testing.R
+++ b/R/testing.R
@@ -57,7 +57,7 @@ prepare_orderly_example <- function(name, path = tempfile()) {
   src <- orderly_file(file.path("examples", name))
   orderly_init(path, quiet = TRUE)
   src_files <- dir(src, full.names = TRUE)
-  file.copy(src_files, path, overwrite = TRUE, recursive = TRUE)
+  file_copy(src_files, path, overwrite = TRUE, recursive = TRUE)
 
   if (file.exists(file.path(path, "source.R"))) {
     generator <- source(file.path(path, "source.R"), local = TRUE)$value
@@ -168,7 +168,7 @@ unzip_git_demo <- function(path = tempfile()) {
   dir.create(path, FALSE, TRUE)
   src <- dir(file.path(tmp, "demo"), full.names = TRUE, all.files = TRUE,
              no.. = TRUE)
-  file.copy(src, path, recursive = TRUE)
+  file_copy(src, path, recursive = TRUE)
   unlink(tmp, recursive = TRUE)
   path
 }

--- a/R/util.R
+++ b/R/util.R
@@ -174,6 +174,7 @@ file_copy <- function(..., overwrite = TRUE) {
   if (any(!ok)) {
     stop("Error copying files")
   }
+  ok
 }
 
 is_directory <- function(x) {

--- a/R/util.R
+++ b/R/util.R
@@ -169,8 +169,8 @@ list_dirs <- function(path) {
   files[file.info(files, extra_cols = FALSE)$isdir]
 }
 
-file_copy <- function(...) {
-  ok <- file.copy(...)
+file_copy <- function(..., overwrite = TRUE) {
+  ok <- file.copy(..., overwrite = overwrite)
   if (any(!ok)) {
     stop("Error copying files")
   }

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -27,7 +27,8 @@ test_that("copy failure", {
   writeLines("a", path1)
   writeLines("b", path2)
   on.exit(file.remove(path1, path2))
-  expect_error(file_copy(path1, path2), "Error copying files")
+  expect_error(file_copy(path1, path2, overwrite = FALSE),
+               "Error copying files")
   expect_equal(readLines(path2), "b")
 })
 


### PR DESCRIPTION
The deluge continues...

DYK that if `file.copy` fails it doesn't tell you or error?  And that it does not overwrite by default?  Neither of these are useful for our needs here.  This PR fixes that