### PR TITLE
i1875: allow multiple versions of a report to be used at once

### DIFF
--- a/R/recipe_read.R
+++ b/R/recipe_read.R
@@ -251,14 +251,14 @@ recipe_read_check_depends <- function(x, filename, config) {
                                    must_work = TRUE)
     assert_named(el$use, TRUE, sprintf("%s:depends:%s:use", filename, name))
     ## TODO: should check that these are not listed as resources I think
-    err <- !vapply(el$use, function(x) is.character(x) && length(x) == 1, TRUE)
+    err <- !vlapply(el$use, function(x) is.character(x) && length(x) == 1)
     if (any(err)) {
       stop(sprintf("%s:depends:%s:use must all be scalar character",
                    filename, name))
     }
 
-    el$filename = vapply(el$use, identity, character(1), USE.NAMES = FALSE)
-    el$as = names(el$use)
+    el$filename <- vcapply(el$use, identity, USE.NAMES = FALSE)
+    el$as <- names(el$use)
     el$use <- NULL
 
     filename_full <- file.path(el$path, el$filename)

--- a/R/recipe_read.R
+++ b/R/recipe_read.R
@@ -231,7 +231,9 @@ recipe_read_check_depends <- function(x, filename, config) {
   if (is.null(x)) {
     return(NULL)
   }
-  assert_named(x, TRUE, sprintf("%s:%s", filename, "depends"))
+  if (is.null(names(x))) {
+    x <- ordered_map_to_list(x)
+  }
 
   check_use1 <- function(i) {
     name <- names(x)[[i]]

--- a/R/recipe_run.R
+++ b/R/recipe_run.R
@@ -431,7 +431,7 @@ recipe_unexpected_artefacts <- function(info, id) {
   # expected dependencies
   dependencies <- c()
   if (!is.null(info$depends)) {
-    dependencies <- unlist(info$depends[, "filename"], use.names = FALSE)
+    dependencies <- info$depends$as
   }
   # we expect to see all artefacts from the config, the source file and the yml
   # config

--- a/R/util.R
+++ b/R/util.R
@@ -486,3 +486,18 @@ list_all_files <- function(path) {
   sort_c(dir(path, recursive = TRUE, full.names = TRUE, all.files = TRUE,
              no.. = TRUE))
 }
+
+
+ordered_map_to_list <- function(x) {
+  ## This should not happen, but this is what would happen if we had
+  ## a corrupted ordered map.  I think that the yaml parrsers will
+  ## fix that for us though.  See similar faff in
+  ## recipe_read_check_artefacts.
+  stopifnot(all(lengths(x) == 1L),
+            vlapply(x, function(el) !is.null(names(el))))
+  if (!all(lengths(x) == 1L)) {
+    stop("I am confused here")
+  }
+  set_names(lapply(x, function(x) x[[1]]),
+            vcapply(x, names))
+}

--- a/inst/examples/depends/src/depend2/orderly.yml
+++ b/inst/examples/depends/src/depend2/orderly.yml
@@ -1,0 +1,20 @@
+data: ~
+depends:
+  - example:
+      id: latest
+      draft: true
+      use:
+        previous1.rds: data.rds
+  - example:
+      id: latest
+      draft: false
+      use:
+        previous2.rds: data.rds
+script: script.R
+artefacts:
+  - data:
+      description: results
+      filenames: results.rds
+  - data:
+      description: some data
+      filenames: output.rds

--- a/inst/examples/depends/src/depend2/script.R
+++ b/inst/examples/depends/src/depend2/script.R
@@ -1,0 +1,5 @@
+dat1 <- readRDS("previous1.rds")
+dat2 <- readRDS("previous2.rds")
+
+saveRDS(list(dat1, dat2), "results.rds")
+saveRDS(orderly::orderly_run_info(), "output.rds")

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -564,3 +564,23 @@ test_that("multiple non-existent packages", {
                paste("Missing packages:",
                      "'non_existent_package', 'non_existent_package_2'"))
 })
+
+
+test_that("use multiple versions of an artefact", {
+  path <- prepare_orderly_example("depends")
+
+  id1 <- orderly_run("example", config = path, echo = FALSE)
+  id2 <- orderly_run("example", config = path, echo = FALSE)
+  orderly_commit(id2, config = path)
+
+  id3 <- orderly_run("depend2", config = path, echo = FALSE)
+
+  p1 <- file.path(path, "draft", "depend2", id3,
+                  c("previous1.rds", "previous2.rds"))
+  expect_true(all(file.exists(p1)))
+
+  p2 <- file.path(path, c("draft", "archive"), "example", c(id1, id2),
+                  "data.rds")
+  expect_equal(hash_files(p1, FALSE),
+               hash_files(p2, FALSE))
+})

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -495,6 +495,16 @@ test_that("no unexpected artefact", {
   expect_false(any(grep("unexpected", messages)))
 })
 
+
+test_that("renamed dependencies are expected", {
+  path <- prepare_orderly_example("depends")
+  orderly_run("example", config = path, echo = FALSE)
+  messages <- capture_messages(
+    orderly_run("depend", config = path, echo = FALSE))
+  expect_false(any(grep("unexpected", messages)))
+})
+
+
 test_that("shiny app", {
   path <- prepare_orderly_example("shiny")
   id <- orderly_run("example", config = path, echo = FALSE)


### PR DESCRIPTION
I thought this was possible but it turns out not to be, as found by @tinigarske 

The format here follows that if the artefacts.  It's not very beautiful because it means you have to use the ordered map syntax but I think that's unavoidable.  So we have

```yaml
depends:
  - example:
      id: latest
      draft: true
      use:
        previous1.rds: data.rds
  - example:
      id: latest
      draft: false
      use:
        previous2.rds: data.rds
```

In the case where only one copy of `example` is used one may specify:

```yaml
depends:
    example:
      id: latest
      draft: true
      use:
        previous1.rds: data.rds
```

(but including the dash before `example` would also be OK)


An alternative would have been to have done:

```yaml
depends:
  example:
    - id: latest
      draft: true
      use:
        previous1.rds: data.rds
    - id: latest
      draft: false
      use:
        previous2.rds: data.rds
```

but this is harder to validate and easier (I think) to get wrong at the user end with more cryptic errors