### PR TITLE
Add name variable to fix link in slack message

### DIFF
--- a/R/slack.R
+++ b/R/slack.R
@@ -4,7 +4,6 @@ slack_post_success <- function(dat, config) {
     server <- config$api_server[[config$api_server_identity]]
     slack_url <- resolve_secrets(server$slack_url, config)[[1L]]
     if (!is.null(slack_url)) {
-      elapsed <- format(as.difftime(dat$elapsed, units = "secs"), digits = 2)
       data <- slack_data(dat, server$server$name, server$server$url_www,
                          isTRUE(server$primary))
       do_slack_post_success(slack_url, data)
@@ -50,6 +49,7 @@ slack_data <- function(dat, server_name, server_url, server_is_primary) {
          fallback = fallback,
          fields = fields,
          actions = list(list(
+           name = "link",
            type = "button",
            text = ":clipboard: View report",
            style = "primary",

--- a/tests/testthat/test-slack.R
+++ b/tests/testthat/test-slack.R
@@ -25,7 +25,7 @@ test_that("slack payload is correct", {
         fields = list(list(
           title = "id", value = sprintf("`%s`", dat$id), short = TRUE)),
         actions = list(list(
-          type = "button", text = ":clipboard: View report",
+          name = "link", type = "button", text = ":clipboard: View report",
           style = "primary", url = report_url))))))
 
   skip_if_no_internet()


### PR DESCRIPTION
This should fix the problem where the slack message didn't include the link to the report.

It still might be temperamental about whether or not it includes time elapsed information, this seems related to `config$api_server$<SERVER_ID>$server$server$name` not being set I think.