### PR TITLE
i2374: Don't redocument on build

### DIFF
--- a/scripts/build_website
+++ b/scripts/build_website
@@ -61,6 +61,7 @@ docker run --rm \
        $ORDERLY_DEV \
        ./create_schema
 
+rm -rf $DOCS_DIR
 mkdir -p $DOCS_DIR
 docker run --rm \
        --network=$DB_NW \
@@ -68,7 +69,7 @@ docker run --rm \
        -v $DOCS_DIR:/orderly/docs \
        --user "$USER_STR" \
        $ORDERLY_DEV \
-       Rscript -e 'pkgdown::build_site()'
+       Rscript -e 'pkgdown::build_site(document = FALSE)'
 
 SCHEMA_DEST=${DOCS_DIR}/schema
 if [ -f $DEST/index.html ]; then


### PR DESCRIPTION
This somehow has worked:
http://teamcity.montagu.dide.ic.ac.uk:8111/viewLog.html?buildId=26494&buildTypeId=montagu_Orderly_BuildContainer&tab=buildLog&_focus=502#_state=502

but I don't actually see how. Because we run the container with
user permissions but copy the sources in with root, the document
step that pkgdown runs can't possibly succeed.

I am also opportunistically clearing out the docs directory before
build, which will mean that deleted files are not included