### PR TITLE
i2445: upgrade vaultr

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,18 +9,10 @@ before_script:
 after_success:
   - Rscript -e 'covr::codecov()'
 r_github_packages:
-  - ropensci/cyphr
   - vimc/montagu-r
   - vimc/vaultr
 env:
   global:
     - VAULTR_TEST_SERVER_INSTALL=true
     - VAULTR_TEST_SERVER_PORT=18200
-    - VAULT_BIN_PATH=$PWD/.vault
-addons:
-  apt:
-    sources:
-      - sourceline: 'ppa:chris-lea/libsodium'
-    packages:
-      - libsodium-dev
-      - libssl-dev
+    - VAULTR_TEST_SERVER_BIN_PATH=$PWD/.vault

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ after_success:
   - Rscript -e 'covr::codecov()'
 r_github_packages:
   - vimc/montagu-r
-  - vimc/vaultr@refactor
+  - vimc/vaultr
 env:
   global:
     - VAULTR_TEST_SERVER_INSTALL=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ after_success:
   - Rscript -e 'covr::codecov()'
 r_github_packages:
   - vimc/montagu-r
-  - vimc/vaultr
+  - vimc/vaultr@refactor
 env:
   global:
     - VAULTR_TEST_SERVER_INSTALL=true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: R support for montagu-reports
-Version: 0.5.9
+Version: 0.5.10
 Description: Order, create and store reports from R.
 License: MIT + file LICENSE
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,6 +27,6 @@ Suggests:
     processx,
     rmarkdown,
     testthat,
-    vaultr (>= 0.0.3)
+    vaultr (>= 0.2.0)
 RoxygenNote: 6.1.1
 VignetteBuilder: knitr

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# 0.5.10
+
+* Requires `vaultr` 0.2.0, which is a major overhaul of that package.
+
 # 0.5.8
 
 * Better error messages when unexpected files are found in the orderly archive (VIMC-1761)

--- a/R/vault.R
+++ b/R/vault.R
@@ -11,7 +11,7 @@ resolve_secrets <- function(x, config) {
       loadNamespace("vaultr")
       vault <- withr::with_envvar(
         orderly_envir_read(config$path),
-        vaultr::vault_client(addr = config$vault_server))
+        vaultr::vault_client(login = TRUE, addr = config$vault_server))
       key <- unname(sub(re, "\\1", x[i]))
       field <- unname(sub(re, "\\2", x[i]))
       x[i] <- unname(Map(vault$read, key, field))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@ before_test:
 
 build_script:
   - travis-tool.sh install_deps
-  - travis-tool.sh install_github vimc/vaultr@refactor
+  - travis-tool.sh install_github vimc/vaultr
   - travis-tool.sh install_github vimc/montagu-r
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@ before_test:
 
 build_script:
   - travis-tool.sh install_deps
-  - travis-tool.sh install_github vimc/vaultr
+  - travis-tool.sh install_github vimc/vaultr@refactor
   - travis-tool.sh install_github vimc/montagu-r
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,7 @@
 environment:
   global:
     R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
+    USE_RTOOLS: true
 
 # Download script file from GitHub
 init:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,6 @@ before_test:
 
 build_script:
   - travis-tool.sh install_deps
-  - travis-tool.sh install_github ropensci/cyphr
   - travis-tool.sh install_github vimc/vaultr
   - travis-tool.sh install_github vimc/montagu-r
 

--- a/tests/testthat/helper-orderly.R
+++ b/tests/testthat/helper-orderly.R
@@ -21,30 +21,6 @@ skip_on_windows <- function() {
   testthat::skip_on_os("windows")
 }
 
-skip_if_no_vault_server <- function() {
-  testthat::skip_if_not_installed("vaultr")
-  if (is.null(vaultr::vault_test_server())) {
-    testthat::skip("vault test server not running")
-  }
-}
-
-start_vault <- function() {
-  Sys.unsetenv("VAULTR_CACHE_DIR")
-  Sys.unsetenv("VAULT_ADDR")
-  with_vault <- !is.null(vaultr::vault_test_server_start())
-  if (with_vault) {
-    cl <- vaultr::vault_test_client()
-    message("Writing test data")
-    ## Some test data to use
-    cl$write("/secret/users/alice", list(password = "ALICE"))
-    cl$write("/secret/users/bob", list(password = "BOB"))
-  }
-}
-
-reset_vault <- function() {
-  cache$vault <- NULL
-  vaultr::vault_clear_token_cache(session = TRUE, persistent = FALSE)
-}
 
 ## Via wikimedia:
 MAGIC_PNG <- as.raw(c(0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a))

--- a/tests/testthat/test-aaa.R
+++ b/tests/testthat/test-aaa.R
@@ -1,2 +1,0 @@
-context("startup")
-start_vault()

--- a/tests/testthat/test-zzz.R
+++ b/tests/testthat/test-zzz.R
@@ -1,1 +1,0 @@
-vaultr::vault_test_server_stop()


### PR DESCRIPTION
There are breaking changes in the next version of vaultr - this updates the package to use them.  There are a group of these PRs and they should be merged together, followed by updating the drat in order to minimise disruption.