### PR TITLE
i2553: fix orderly slack handling

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: R support for montagu-reports
-Version: 0.5.13
+Version: 0.5.14
 Description: Order, create and store reports from R.
 License: MIT + file LICENSE
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# 0.5.14
+
+* Fix handling of remote environment variables (VIMC-2553)
+
 # 0.5.13
 
 * Removes support for shiny apps as this was poorly tested and not used by us (VIMC-2544, VIMC-2538).

--- a/R/config.R
+++ b/R/config.R
@@ -125,6 +125,7 @@ config_check_remote <- function(dat, filename) {
     }
     assert_scalar_character(remote$driver, field_name("driver"))
     assert_named(remote$args, name = field_name("args"))
+    remote <- resolve_env(remote, error = FALSE)
     remote$args <- resolve_env(remote$args, error = FALSE, default = NULL)
 
     ## optionals:

--- a/R/slack.R
+++ b/R/slack.R
@@ -70,7 +70,7 @@ do_slack_post_success <- function(slack_url, data) {
     r
   }, error = function(e) {
     message("NOTE: running slack hook failed\n", e$message)
-    r
+    NULL
   })
   invisible(r)
 }

--- a/R/util.R
+++ b/R/util.R
@@ -348,7 +348,7 @@ resolve_driver_config <- function(args, config) {
 
 resolve_env <- function(x, error = TRUE, default = NULL) {
   f <- function(x) {
-    if (grepl("^\\$[0-9A-Z_]+$", x)) {
+    if (length(x) == 1L && is.character(x) && grepl("^\\$[0-9A-Z_]+$", x)) {
       Sys_getenv(substr(x, 2, nchar(x)), error = error, default = NULL)
     } else {
       x

--- a/tests/testthat/test-slack.R
+++ b/tests/testthat/test-slack.R
@@ -106,7 +106,7 @@ test_that("sending messages is not a failure", {
   d <- slack_data(dat, server_name, server_url, server_is_primary)
 
   slack_url <- "https://httpbin.org/status/403"
-  expect_message(r <- do_slack_post_success(slack_url, d),
+  expect_message(do_slack_post_success(slack_url, d),
                  "NOTE: running slack hook failed")
 })
 

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -53,6 +53,20 @@ test_that("resolve_env", {
                    list("value"))
 })
 
+
+test_that("resolve_env skips non-scalars", {
+  set.seed(1)
+  v <- paste(sample(c(LETTERS, 0:9, "_"), 20, replace = TRUE), collapse = "")
+  vv <- paste0("$", v)
+  expect_identical(resolve_env(v), list(v))
+
+  env <- setNames("value", v)
+  expect_identical(
+    withr::with_envvar(env,
+                       resolve_env(list(a = vv, b = list(a = 1, b = 2)))),
+    list(a = "value", b = list(a = 1, b = 2)))
+})
+
 test_that("val_to_bytes", {
   x <- sort(runif(10, 0.1, 0.15)) + 100
   y <- vcapply(x, val_to_bytes, 2)


### PR DESCRIPTION
Two errors in here:

* we throw on catching an error (:upside_down_face:)
* we never resolved the SLACK_URL env var (or any other used in the remote configuration outside of the args)