### PR TITLE
i2615: add git information to the schema

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: R support for montagu-reports
-Version: 0.5.15
+Version: 0.5.16
 Description: Order, create and store reports from R.
 License: MIT + file LICENSE
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# 0.5.16
+
+* The database schema now stores basic git information alongside report versions, if the report source archive uses git (VIMC-2615)
+
 # 0.5.15
 
 * `orderly` now prompts to install missing packages and offers code to help with this (VIMC-2384)

--- a/R/db2.R
+++ b/R/db2.R
@@ -14,7 +14,7 @@ ORDERLY_SCHEMA_TABLE <- "orderly_schema"
 ORDERLY_MAIN_TABLE <- "report_version"
 ORDERLY_TABLE_LIST <- "orderly_schema_tables"
 
-orderly_schema_prepare <- function(fields = NULL, dialect = "sqlite") {
+report_db2_schema_read <- function(fields = NULL, dialect = "sqlite") {
   d <- yaml_read(orderly_file("database/schema.yml"))
 
   preprepare <- function(nm) {
@@ -109,6 +109,15 @@ orderly_schema_prepare <- function(fields = NULL, dialect = "sqlite") {
 }
 
 
+report_db2_schema <- function(fields = NULL, dialect = "sqlite") {
+  key <- hash_object(list(fields, dialect))
+  if (is.null(cache$schema[[key]])) {
+    cache$schema[[key]] <- report_db2_schema_read(fields, dialect)
+  }
+  cache$schema[[key]]
+}
+
+
 ## Same pattern as existing db.R version but with
 report_db2_init <- function(con, config, must_create = FALSE, validate = TRUE) {
   sqlite_pragma_fk(con, TRUE)
@@ -124,7 +133,7 @@ report_db2_init <- function(con, config, must_create = FALSE, validate = TRUE) {
 
 
 report_db2_init_create <- function(con, config, dialect) {
-  dat <- orderly_schema_prepare(config$fields, dialect)
+  dat <- report_db2_schema(config$fields, dialect)
   dat$values$changelog_label <- config$changelog
 
   DBI::dbBegin(con)
@@ -151,12 +160,9 @@ report_db2_open_existing <- function(con, config) {
                  paste(squote(msg), collapse = ", ")))
   }
 
-  ## TODO: this should be dealt with in a more sustainable way; the
-  ## report_db_cols() function duplicates information already
-  ## present in the yml and that should be the source of truth here
-  ## but we shuold only load that once in a session.
-  extra <- setdiff(setdiff(names(d), names(report_db_cols())),
-                   c("report", "connection", custom_name))
+  schema <- report_db2_schema(config$fields, report_db2_dialect(con))
+  cols <- names(schema$tables[[ORDERLY_MAIN_TABLE]]$columns)
+  extra <- setdiff(names(d), cols)
   if (length(extra) > 0L) {
     stop(sprintf("custom fields %s in database not present in config",
                  paste(squote(extra), collapse = ", ")))

--- a/R/db2.R
+++ b/R/db2.R
@@ -6,7 +6,7 @@
 ## namespace/module feature so that implementation details can be
 ## hidden away a bit further.
 
-ORDERLY_SCHEMA_VERSION <- "0.0.4"
+ORDERLY_SCHEMA_VERSION <- "0.0.5"
 
 ## These will be used in a few places and even though they're not
 ## super likely to change it would be good
@@ -252,6 +252,12 @@ report_data_import <- function(con, workdir, config) {
     }
   }
 
+  if (is.null(dat_rds$git$sha)) {
+    git_clean <- NA
+  } else {
+    git_clean <- is.null(dat_rds$git$status)
+  }
+
   report_version <- data_frame(
     id = id,
     report = dat_rds$meta$name,
@@ -259,7 +265,11 @@ report_data_import <- function(con, workdir, config) {
     displayname = dat_in$displayname %||% NA_character_,
     description = dat_in$description %||% NA_character_,
     published = published,
-    connection = dat_rds$meta$connection)
+    connection = dat_rds$meta$connection,
+    git_sha = dat_rds$git$sha %||% NA_character_,
+    git_branch = dat_rds$git$branch %||% NA_character_,
+    git_clean = git_clean)
+
   if (nrow(config$fields) > 0L) {
     extra <- drop_null(set_names(
       lapply(config$fields$name, function(x) dat_in[[x]]),

--- a/R/slack.R
+++ b/R/slack.R
@@ -16,14 +16,15 @@ slack_data <- function(dat, remote_name, remote_url, remote_is_primary) {
   if (is.null(dat$git)) {
     git <- NULL
   } else {
-    git <- sprintf("%s@%s", dat$git$branch, dat$git$sha_short)
-    if (is.null(dat$git$github_url)) {
-      git <- sprintf("%s@%s", dat$git$branch, dat$git$sha_short)
-    } else {
-      git <- sprintf("<%s/tree/%s|%s>@<%s/tree/%s|%s>",
-                     dat$git$github_url, dat$git$branch, dat$git$branch,
-                     dat$git$github_url, dat$git$sha_short, dat$git$sha_short)
+    branch <- dat$git$branch %||% "(detached)"
+    sha <- dat$git$sha_short
+    if (!is.null(dat$git$github_url)) {
+      sha <- sprintf("<%s/tree/%s|%s>", dat$git$github_url, sha, sha)
     }
+    if (!is.null(dat$git$github_url) && !is.null(dat$git$branch)) {
+      branch <- sprintf("<%s/tree/%s|%s>", dat$git$github_url, branch, branch)
+    }
+    git <- sprintf("%s@%s", branch, sha)
   }
   id <- dat$id
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -6,4 +6,5 @@ cache <- new.env(parent = emptyenv())
     utils::tail(migrations[migrations <= utils::packageVersion("orderly")], 1L)
   cache$default_remote <- list()
   cache$remotes <- list()
+  cache$schema <- list()
 }

--- a/inst/database/schema.yml
+++ b/inst/database/schema.yml
@@ -35,6 +35,9 @@ report_version:
     - description: {type: TEXT, nullable: true}
     - connection: {type: BOOLEAN}
     - published: {type: BOOLEAN}
+    - git_sha: {type: TEXT, nullable: true}
+    - git_branch: {type: TEXT, nullable: true}
+    - git_clean: {type: BOOLEAN, nullable: true}
     # NOTE: fields listed in orderly_config.yml will also be
     # included here.
 

--- a/tests/testthat/test-db.R
+++ b/tests/testthat/test-db.R
@@ -127,8 +127,8 @@ test_that("avoid unserialisable parameters", {
 
 test_that("dialects", {
   skip_on_cran() # likely platform dependent
-  s <- orderly_schema_prepare(NULL, "sqlite")
-  p <- orderly_schema_prepare(NULL, "postgres")
+  s <- report_db2_schema_read(NULL, "sqlite")
+  p <- report_db2_schema_read(NULL, "postgres")
   expect_false(isTRUE(all.equal(s, p)))
 
   path <- prepare_orderly_example("minimal")

--- a/tests/testthat/test-git.R
+++ b/tests/testthat/test-git.R
@@ -208,3 +208,18 @@ test_that("handle failure", {
     git_run("unknown-command", root = path[["origin"]], check = TRUE),
     r$output, fixed = TRUE)
 })
+
+
+test_that("git into db", {
+  path <- unzip_git_demo()
+  id <- orderly_run("minimal", config = path, echo = FALSE)
+  orderly_commit(id, config = path)
+
+  con <- orderly_db("destination", config = path)
+  on.exit(DBI::dbDisconnect(con))
+  d <- DBI::dbReadTable(con, "report_version")
+
+  expect_equal(d$git_sha, git_ref_to_sha("HEAD", path))
+  expect_equal(d$git_branch, "master")
+  expect_equal(d$git_clean, 1)
+})

--- a/tests/testthat/test-slack.R
+++ b/tests/testthat/test-slack.R
@@ -76,6 +76,23 @@ test_that("git information is collected correctly", {
 })
 
 
+test_that("git information works in detached head mode", {
+  server_url <- "https://example.com"
+  server_is_primary <- FALSE
+  server_name <- "myserver"
+
+  dat <- list(elapsed = 10,
+              git = list(branch = NULL, sha_short = "abcdefg",
+                         github_url = "https://github.com/vimc/repo"),
+              id = "20181213-123456-fedcba98",
+              name = "example")
+  d <- slack_data(dat, server_name, server_url, server_is_primary)
+  expect_equal(
+    d$attachments[[1]]$fields[[2]]$value,
+    "(detached)@<https://github.com/vimc/repo/tree/abcdefg|abcdefg>")
+})
+
+
 test_that("primary server changes colour", {
   server_url <- "https://example.com"
   server_is_primary <- FALSE


### PR DESCRIPTION
This creates new columns in the db schema and populates them with git information that we already have (so no data migrations are needed).

Because I was poking about with the git structure I've fixed the failure we were seeing where reports on science with the runner do not have version information printed in the slack message