### PR TITLE
i2642: Prevent git reference switching on production

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: R support for montagu-reports
-Version: 0.5.15
+Version: 0.5.16
 Description: Order, create and store reports from R.
 License: MIT + file LICENSE
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# 0.5.16
+
+* The runner now recognises the `master_only` configuration option and can prevent running reports with references other than `master`.  This is now enforced entirely on the server (VIMC-2642)
+
 # 0.5.15
 
 * `orderly` now prompts to install missing packages and offers code to help with this (VIMC-2384)

--- a/R/config.R
+++ b/R/config.R
@@ -61,6 +61,9 @@ orderly_config_read_yaml <- function(filename, path) {
   if (nzchar(remote_identity)) {
     info$remote_identity <-
       match_value(remote_identity, names(info$remote))
+    excl <- c("driver", "args", "name")
+    server_options <- info$remote[[remote_identity]]
+    info$server_options <- server_options[setdiff(names(server_options), excl)]
   }
 
   if (!is.null(info$global_resources)) {

--- a/man/orderly_runner.Rd
+++ b/man/orderly_runner.Rd
@@ -4,12 +4,16 @@
 \alias{orderly_runner}
 \title{Orderly runner}
 \usage{
-orderly_runner(path, allow_ref = TRUE)
+orderly_runner(path, allow_ref = NULL)
 }
 \arguments{
 \item{path}{Path to use}
 
-\item{allow_ref}{Allow git to change branches/ref for run}
+\item{allow_ref}{Allow git to change branches/ref for run.  If not
+given, then we will look to see if the orderly configuration
+disallows branch changes (based on the
+\code{ORDERLY_API_SERVER_IDENTITY} environment variable and the
+\code{master_only} setting of the relevant server block.}
 }
 \description{
 An orderly runner.  This is used to run reports remotely.  It's

--- a/tests/testthat/test-z-runner.R
+++ b/tests/testthat/test-z-runner.R
@@ -191,14 +191,14 @@ test_that("prevent git change", {
   path <- unzip_git_demo()
   runner <- orderly_runner(path, FALSE)
   expect_error(runner$queue("other", ref = "other"),
-               "Reference switching is disabled in this runner")
+               "Reference switching is disallowed in this runner")
 })
 
 test_that("Can't git change", {
   path <- prepare_orderly_example("interactive")
   runner <- orderly_runner(path)
   expect_error(runner$queue("other", ref = "other"),
-               "Reference switching is disabled in this runner")
+               "Reference switching is disallowed in this runner")
 })
 
 

--- a/tests/testthat/test-z-runner.R
+++ b/tests/testthat/test-z-runner.R
@@ -351,3 +351,50 @@ test_that("queue status", {
   expect_equal(runner$status(key3)$output$stdout,
                sprintf("queued:%s:%s", key2, "interactive"))
 })
+
+
+test_that("prevent git changes", {
+  skip_on_windows()
+  path <- prepare_orderly_git_example()
+
+  cfg <- list(
+    source = list(
+      driver = "RSQLite::SQLite",
+      dbname = "dbname: source.sqlite"),
+    remote = list(
+      main = list(
+        driver = "orderly::orderly_remote_path",
+        primary = TRUE,
+        master_only = TRUE,
+        args = list(path = path[["origin"]])),
+      other = list(
+        driver = "orderly::orderly_remote_path",
+        args = list(path = path[["origin"]]))))
+
+  path_local <- path[["local"]]
+  writeLines(yaml::as.yaml(cfg), file.path(path_local, "orderly_config.yml"))
+
+  runner <- withr::with_envvar(
+    c("ORDERLY_API_SERVER_IDENTITY" = "main"),
+    orderly_runner(path_local))
+  expect_false(runner$allow_ref)
+  expect_error(
+    runner$queue("example", ref = "origin/other", parameters = list(nmin = 0)),
+    "Reference switching is disallowed in this runner")
+
+  runner <- withr::with_envvar(
+    c("ORDERLY_API_SERVER_IDENTITY" = "other"),
+    orderly_runner(path_local))
+  expect_true(runner$allow_ref)
+  r <- runner$queue("example", ref = "origin/other",
+                    parameters = list(nmin = 0))
+  expect_equal(nrow(runner$queue_status()$queue), 1L)
+
+  runner <- withr::with_envvar(
+    c("ORDERLY_API_SERVER_IDENTITY" = NA_character_),
+    orderly_runner(path_local))
+  expect_true(runner$allow_ref)
+  r <- runner$queue("example", ref = "origin/other",
+                    parameters = list(nmin = 0))
+  expect_equal(nrow(runner$queue_status()$queue), 1L)
+})

--- a/tests/testthat/test-z-runner.R
+++ b/tests/testthat/test-z-runner.R
@@ -398,3 +398,26 @@ test_that("prevent git changes", {
                     parameters = list(nmin = 0))
   expect_equal(nrow(runner$queue_status()$queue), 1L)
 })
+
+
+test_that("allow ref logic", {
+  path <- unzip_git_demo()
+  config <- list(server_options = list(master_only = FALSE),
+                 path = path)
+
+  expect_false(runner_allow_ref(FALSE, config))
+  expect_true(runner_allow_ref(TRUE, config))
+  expect_true(runner_allow_ref(NULL, config))
+
+  config <- list(server_options = list(master_only = TRUE),
+                 path = path)
+  expect_false(runner_allow_ref(FALSE, config))
+  expect_true(runner_allow_ref(TRUE, config))
+  expect_false(runner_allow_ref(NULL, config))
+
+  config <- list(server_options = list(master_only = FALSE),
+                 path = tempfile())
+  expect_false(runner_allow_ref(FALSE, config))
+  expect_false(runner_allow_ref(TRUE, config))
+  expect_false(runner_allow_ref(NULL, config))
+})


### PR DESCRIPTION
This honours a configuration already present in montagu-reports, but currently ignored by orderly