### PR TITLE
i2517: Better behaviour with report timeout

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: R support for montagu-reports
-Version: 0.5.16
+Version: 0.5.17
 Description: Order, create and store reports from R.
 License: MIT + file LICENSE
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# 0.5.17
+
+* Fix passing of `timeout` through to remote runners when using the `montagu` package (VIMC-2517)
+
 # 0.5.16
 
 * The `changelog` table includes the attributable *public* report version attributable to each changelog entry

--- a/R/remote.R
+++ b/R/remote.R
@@ -114,7 +114,13 @@ push_archive <- function(name, id = "latest", config = NULL, locate = TRUE,
 ##'
 ##' @param parameters Parameters for the reprt
 ##'
-##' @param timeout Time to wait for the report to be returned (in seconds)
+##' @param timeout Time to tell the server to wait before killing the
+##'   report.
+##'
+##' @param wait Time to wait for the report to be run; if the report
+##'   takes longer than this time to run but \code{timeout} is longer
+##'   it will remain running on the server but we will stop waiting
+##'   for it and instead thrown an error.
 ##'
 ##' @param poll Period to poll the server for results (in seconds)
 ##'
@@ -136,14 +142,14 @@ push_archive <- function(name, id = "latest", config = NULL, locate = TRUE,
 ##'
 ##' @export
 orderly_run_remote <- function(name, parameters = NULL, ref = NULL,
-                               timeout = 3600, poll = 1,
+                               timeout = NULL, wait = 3600, poll = 1,
                                open = TRUE, stop_on_error = TRUE,
                                progress = TRUE,
                                config = NULL, locate = TRUE, remote = NULL) {
   remote <- get_remote(remote, orderly_config_get(config, locate))
   remote$run(name, parameters = parameters, ref = ref,
              timeout = timeout, poll = poll, progress = progress,
-             stop_on_error = stop_on_error)
+             stop_on_error = stop_on_error, open = open)
 }
 
 ##' Publish a report on a remote server

--- a/R/remote.R
+++ b/R/remote.R
@@ -129,7 +129,13 @@ push_archive <- function(name, id = "latest", config = NULL, locate = TRUE,
 ##'
 ##' @param stop_on_error Logical, indicating if we should throw an
 ##'   error if the report fails.  If you set this to \code{FALSE} it
-##'   will be much easier to debug, but more annoying in scripts.
+##'   will be much easier to debug, but more annoying in scripts.  If
+##'   the times out on the server (i.e., takes longer than
+##'   \code{timeout}) that counts as an error.
+##'
+##' @param stop_on_timeout Logical, indicating if we should throw an
+##'   error if the report takes longer than \code{wait} seconds to
+##'   complete.
 ##'
 ##' @param progress Logical, indicating if a progress spinner should
 ##'   be included.
@@ -144,12 +150,14 @@ push_archive <- function(name, id = "latest", config = NULL, locate = TRUE,
 orderly_run_remote <- function(name, parameters = NULL, ref = NULL,
                                timeout = NULL, wait = 3600, poll = 1,
                                open = TRUE, stop_on_error = TRUE,
+                               stop_on_timeout = TRUE,
                                progress = TRUE,
                                config = NULL, locate = TRUE, remote = NULL) {
   remote <- get_remote(remote, orderly_config_get(config, locate))
   remote$run(name, parameters = parameters, ref = ref,
-             timeout = timeout, poll = poll, progress = progress,
-             stop_on_error = stop_on_error, open = open)
+             timeout = timeout, wait = wait, poll = poll, progress = progress,
+             stop_on_error = stop_on_error, stop_on_timeout = stop_on_timeout,
+             open = open)
 }
 
 ##' Publish a report on a remote server

--- a/man/orderly_run_remote.Rd
+++ b/man/orderly_run_remote.Rd
@@ -5,8 +5,9 @@
 \title{Run a report on a remote server}
 \usage{
 orderly_run_remote(name, parameters = NULL, ref = NULL,
-  timeout = 3600, poll = 1, open = TRUE, stop_on_error = TRUE,
-  progress = TRUE, config = NULL, locate = TRUE, remote = NULL)
+  timeout = NULL, wait = 3600, poll = 1, open = TRUE,
+  stop_on_error = TRUE, progress = TRUE, config = NULL,
+  locate = TRUE, remote = NULL)
 }
 \arguments{
 \item{name}{Name of the report}
@@ -17,7 +18,13 @@ orderly_run_remote(name, parameters = NULL, ref = NULL,
 used.  This cannot be used if the remote has \code{master_only}
 set.}
 
-\item{timeout}{Time to wait for the report to be returned (in seconds)}
+\item{timeout}{Time to tell the server to wait before killing the
+report.}
+
+\item{wait}{Time to wait for the report to be run; if the report
+takes longer than this time to run but \code{timeout} is longer
+it will remain running on the server but we will stop waiting
+for it and instead thrown an error.}
 
 \item{poll}{Period to poll the server for results (in seconds)}
 

--- a/man/orderly_run_remote.Rd
+++ b/man/orderly_run_remote.Rd
@@ -6,8 +6,8 @@
 \usage{
 orderly_run_remote(name, parameters = NULL, ref = NULL,
   timeout = NULL, wait = 3600, poll = 1, open = TRUE,
-  stop_on_error = TRUE, progress = TRUE, config = NULL,
-  locate = TRUE, remote = NULL)
+  stop_on_error = TRUE, stop_on_timeout = TRUE, progress = TRUE,
+  config = NULL, locate = TRUE, remote = NULL)
 }
 \arguments{
 \item{name}{Name of the report}
@@ -33,7 +33,13 @@ a browser on completion}
 
 \item{stop_on_error}{Logical, indicating if we should throw an
 error if the report fails.  If you set this to \code{FALSE} it
-will be much easier to debug, but more annoying in scripts.}
+will be much easier to debug, but more annoying in scripts.  If
+the times out on the server (i.e., takes longer than
+\code{timeout}) that counts as an error.}
+
+\item{stop_on_timeout}{Logical, indicating if we should throw an
+error if the report takes longer than \code{wait} seconds to
+complete.}
 
 \item{progress}{Logical, indicating if a progress spinner should
 be included.}


### PR DESCRIPTION
This PR does very little towards the ticket, just updating a few arguments as they're passed through to the runner.

We have a new `wait` parameter: that's the _client-side_ timeout as opposed to `timeout` which is for the server.  The PR in `montagu-r` will forward that appropriately

See https://github.com/vimc/montagu-r/pull/20 and https://github.com/vimc/orderly.server/pull/10