### PR TITLE
i2769: remove old db schema

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: R support for montagu-reports
-Version: 0.5.17
+Version: 0.5.18
 Description: Order, create and store reports from R.
 License: MIT + file LICENSE
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# 0.5.18
+
+* Remove old db schema (VIMC-2769)
+
 # 0.5.17
 
 * Fix passing of `timeout` through to remote runners when using the `montagu` package (VIMC-2517)

--- a/R/cleanup.R
+++ b/R/cleanup.R
@@ -48,11 +48,12 @@ orderly_cleanup_data <- function(config) {
   assert_is(config, "orderly_config")
   con <- orderly_db("destination", config, FALSE)
   on.exit(DBI::dbDisconnect(con))
-  data <- DBI::dbGetQuery(con, "SELECT hash_data FROM orderly")[[1]]
+
+  data <- DBI::dbGetQuery(con, "SELECT hash from report_version_data")[[1]]
 
   ## Determine all used data sets in *both* draft and published
   ## reports
-  used_pub <- unique(unlist(lapply(data, jsonlite::fromJSON)))
+  used_pub <- unique(data)
   dr <- orderly_list_drafts(config, FALSE)
   yml <- path_orderly_run_yml(
     file.path(path_draft(config$path), dr$name, dr$id))

--- a/R/cleanup.R
+++ b/R/cleanup.R
@@ -48,7 +48,6 @@ orderly_cleanup_data <- function(config) {
   assert_is(config, "orderly_config")
   con <- orderly_db("destination", config, FALSE)
   on.exit(DBI::dbDisconnect(con))
-
   data <- DBI::dbGetQuery(con, "SELECT hash from report_version_data")[[1]]
 
   ## Determine all used data sets in *both* draft and published

--- a/R/db.R
+++ b/R/db.R
@@ -23,7 +23,7 @@ orderly_db <- function(type, config = NULL, locate = TRUE, validate = TRUE) {
     con <- do.call(DBI::dbConnect, c(list(x$driver()), x$args))
     if (type == "destination") {
       withCallingHandlers(
-        report_db2_init(con, config, validate = validate),
+        report_db_init(con, config, validate = validate),
         error = function(e) DBI::dbDisconnect(con))
     }
     con
@@ -78,9 +78,9 @@ orderly_rebuild <- function(config = NULL, locate = TRUE, verbose = TRUE,
     if_schema_changed <- FALSE
   }
 
-  if (!if_schema_changed || report_db2_needs_rebuild(config)) {
+  if (!if_schema_changed || report_db_needs_rebuild(config)) {
     orderly_log("rebuild", "db")
-    report_db2_rebuild(config, verbose)
+    report_db_rebuild(config, verbose)
     invisible(TRUE)
   } else {
     invisible(FALSE)

--- a/R/db.R
+++ b/R/db.R
@@ -23,7 +23,7 @@ orderly_db <- function(type, config = NULL, locate = TRUE, validate = TRUE) {
     con <- do.call(DBI::dbConnect, c(list(x$driver()), x$args))
     if (type == "destination") {
       withCallingHandlers(
-        report_db_init(con, config, validate = validate),
+        report_db2_init(con, config, validate = validate),
         error = function(e) DBI::dbDisconnect(con))
     }
     con
@@ -53,90 +53,6 @@ orderly_db_args <- function(type, config) {
   list(driver = driver, args = args)
 }
 
-## Reports database needs special initialisation:
-report_db_init <- function(con, config, must_create = FALSE, validate = TRUE) {
-  ## TODO: must_create is never used
-  orderly_table <- "orderly"
-  if (!DBI::dbExistsTable(con, orderly_table)) {
-    ## TODO: we'll need some postgres translation here
-    ## TODO: dumping json columns in as text for now
-    ##
-    ## TODO: the door is open here for the table name to be
-    ## configurable, but defaulting to 'orderly', but I do not know
-    ## that that is good thing, really.
-    cols <- report_db_cols()
-    col_types <- sprintf("  %s %s",
-                         c(names(cols), config$fields$name),
-                         c(unname(cols), config$fields$type_sql))
-
-    sql <- sprintf("CREATE TABLE %s (\n%s\n)",
-                   orderly_table,
-                   paste(col_types, collapse = ",\n"))
-    DBI::dbExecute(con, sql)
-  } else if (must_create) {
-    stop(sprintf("Table '%s' already exists", orderly_table))
-  } else {
-    sql <- sprintf("SELECT * FROM %s LIMIT 0", orderly_table)
-    d <- DBI::dbGetQuery(con, sql)
-    custom_name <- config$fields$name
-    msg <- setdiff(custom_name, names(d))
-    if (length(msg) > 0L) {
-      stop(sprintf("custom fields %s not present in existing database",
-                   paste(squote(msg), collapse = ", ")))
-    }
-    extra <- setdiff(setdiff(names(d), names(report_db_cols())), custom_name)
-    if (length(extra) > 0L) {
-      stop(sprintf("custom fields %s in database not present in config",
-                   paste(squote(extra), collapse = ", ")))
-    }
-  }
-
-  report_db2_init(con, config, must_create, validate)
-  orderly_table
-}
-
-report_db_rebuild <- function(config, verbose = TRUE) {
-  assert_is(config, "orderly_config")
-  root <- config$path
-  con <- orderly_db("destination", config, validate = FALSE)
-  on.exit(DBI::dbDisconnect(con))
-  ## TODO: this assumes name known
-  tbl <- "orderly"
-  DBI::dbExecute(con, "DELETE FROM orderly")
-  reports <- unlist(lapply(list_dirs(path_archive(root)), list_dirs))
-  if (length(reports) > 0L) {
-    dat <- rbind_df(lapply(reports, report_read_data, config))
-    DBI::dbWriteTable(con, tbl, dat, append = TRUE)
-  }
-
-  report_db2_rebuild(config, verbose)
-}
-
-report_db_cols <- function() {
-  c(## INPUTS:
-    id = "TEXT PRIMARY KEY NOT NULL",
-    name = "TEXT",
-    displayname = "TEXT",
-    description = "TEXT",
-    views = "TEXT",          # should be json (dict)
-    data = "TEXT",           # should be json (dict)
-    packages = "TEXT",       # should be json (array)
-    script = "TEXT",
-    artefacts = "TEXT",      # should be json (array)
-    resources = "TEXT",      # should be json (array)
-    hash_script = "TEXT",
-    ## OUTPUTS
-    parameters = "TEXT",     # should be json (dict with values)
-    date = "TIMESTAMP",
-    hash_orderly = "TEXT",
-    hash_input = "TEXT",
-    hash_resources = "TEXT", # should be json (dict)
-    hash_data = "TEXT",      # should be json (dict)
-    hash_artefacts = "TEXT", # should be json (dict)
-    depends = "TEXT",        # should be json (array of dicts)
-    ## PUBLISHING
-    published = "BOOLEAN")
-}
 
 ##' Rebuild the report database
 ##' @title Rebuild the report database
@@ -164,7 +80,7 @@ orderly_rebuild <- function(config = NULL, locate = TRUE, verbose = TRUE,
 
   if (!if_schema_changed || report_db2_needs_rebuild(config)) {
     orderly_log("rebuild", "db")
-    report_db_rebuild(config, verbose)
+    report_db2_rebuild(config, verbose)
     invisible(TRUE)
   } else {
     invisible(FALSE)

--- a/R/publish.R
+++ b/R/publish.R
@@ -35,7 +35,7 @@ orderly_publish <- function(id, value = TRUE, name = NULL,
 
   con <- orderly_db("destination", config, FALSE)
   on.exit(DBI::dbDisconnect(con))
-  report_db2_publish(con, id, name, value)
+  report_db_publish(con, id, name, value)
 
   invisible(NULL)
 }

--- a/R/publish.R
+++ b/R/publish.R
@@ -35,10 +35,6 @@ orderly_publish <- function(id, value = TRUE, name = NULL,
 
   con <- orderly_db("destination", config, FALSE)
   on.exit(DBI::dbDisconnect(con))
-  orderly_table <- "orderly"
-  sql <- sprintf("UPDATE %s SET published = $1 WHERE id = $2", orderly_table)
-  DBI::dbExecute(con, sql, list(value, id))
-
   report_db2_publish(con, id, name, value)
 
   invisible(NULL)

--- a/R/recipe_commit.R
+++ b/R/recipe_commit.R
@@ -47,7 +47,7 @@ recipe_commit <- function(workdir, config) {
   on.exit(DBI::dbDisconnect(con))
 
   ## Ensure that the db is in a reasonable state:
-  report_db2_init(con, config)
+  report_db_init(con, config)
   ## Copy the _files_ over, but we'll roll this back if anything fails
   dest <- copy_report(workdir, dat$name, config)
 

--- a/R/recipe_commit.R
+++ b/R/recipe_commit.R
@@ -47,18 +47,17 @@ recipe_commit <- function(workdir, config) {
   on.exit(DBI::dbDisconnect(con))
 
   ## Ensure that the db is in a reasonable state:
-  tbl <- report_db_init(con, config)
+  report_db2_init(con, config)
   ## Copy the _files_ over, but we'll roll this back if anything fails
-  success <- FALSE
   dest <- copy_report(workdir, dat$name, config)
-  on.exit(if (!success) unlink(dest, recursive = TRUE), add = TRUE)
 
-  report_data_import(con, workdir, config)
-  success <- DBI::dbWriteTable(con, tbl, dat, append = TRUE)
+  withCallingHandlers(
+    report_data_import(con, workdir, config),
+    error = function(e) unlink(dest, recursive = TRUE))
 
-  if (success) {
-    unlink(workdir, recursive = TRUE)
-  }
+  ## After success we can delete the draft directory
+  unlink(workdir, recursive = TRUE)
+
   orderly_log("success", ":)")
   dest
 }

--- a/scripts/schema/create_schema
+++ b/scripts/schema/create_schema
@@ -1,3 +1,2 @@
 #!/usr/bin/env Rscript
 con <- orderly::orderly_db("destination")
-DBI::dbRemoveTable(con, "orderly")

--- a/tests/testthat/helper-orderly.R
+++ b/tests/testthat/helper-orderly.R
@@ -4,12 +4,6 @@ with_wd <- function(path, code) {
   force(code)
 }
 
-read_orderly_db <- function(path) {
-  con <- orderly_db("destination", path)
-  on.exit(DBI::dbDisconnect(con))
-  DBI::dbReadTable(con, "orderly")
-}
-
 skip_if_no_git <- function() {
   if (nzchar(Sys.which("git"))) {
     return()

--- a/tests/testthat/test-db.R
+++ b/tests/testthat/test-db.R
@@ -14,7 +14,6 @@ test_that("custom fields", {
   con <- orderly_db("destination", path)
   on.exit(DBI::dbDisconnect(con))
 
-  expect_true(DBI::dbExistsTable(con, "orderly"))
   expect_true(DBI::dbExistsTable(con, "orderly_schema"))
 
   ## TODO: should the db initialisation here check that the custom
@@ -22,27 +21,17 @@ test_that("custom fields", {
   ## not great either.  But then performance probably does not matter.
 
   config <- orderly_config_get(path)
-  expect_error(report_db_init(con, config, TRUE),
-               "Table 'orderly' already exists")
   expect_error(report_db2_init(con, config, TRUE),
                "Table 'orderly_schema' already exists")
-
-  d <- DBI::dbReadTable(con, "orderly")
-  d <- d[setdiff(names(d), "author")]
-  DBI::dbWriteTable(con, "orderly", d, overwrite = TRUE)
 
   d <- DBI::dbReadTable(con, "report_version")
   d <- d[setdiff(names(d), "author")]
   DBI::dbWriteTable(con, "report_version", d, overwrite = TRUE)
 
-  expect_error(report_db_init(con, config, FALSE),
-               "custom fields 'author' not present in existing database")
   expect_error(report_db2_init(con, config, FALSE),
                "custom fields 'author' not present in existing database")
 
   config$fields <- NULL
-  expect_error(report_db_init(con, config, FALSE),
-               "custom fields 'requester', 'comments' in database")
   expect_error(report_db2_init(con, config, FALSE),
                "custom fields 'requester', 'comments' in database")
 })
@@ -56,7 +45,7 @@ test_that("rebuild empty database", {
 
   con <- orderly_db("destination", path)
   on.exit(DBI::dbDisconnect(con))
-  expect_true(DBI::dbExistsTable(con, "orderly"))
+  expect_true(DBI::dbExistsTable(con, "orderly_schema"))
 })
 
 test_that("rebuild nonempty database", {
@@ -68,7 +57,7 @@ test_that("rebuild nonempty database", {
   orderly_rebuild(path)
   con <- orderly_db("destination", path)
   on.exit(DBI::dbDisconnect(con))
-  expect_equal(nrow(DBI::dbReadTable(con, "orderly")), 1)
+  expect_equal(nrow(DBI::dbReadTable(con, "report_version")), 1)
 })
 
 test_that("no transient db", {

--- a/tests/testthat/test-db.R
+++ b/tests/testthat/test-db.R
@@ -21,18 +21,18 @@ test_that("custom fields", {
   ## not great either.  But then performance probably does not matter.
 
   config <- orderly_config_get(path)
-  expect_error(report_db2_init(con, config, TRUE),
+  expect_error(report_db_init(con, config, TRUE),
                "Table 'orderly_schema' already exists")
 
   d <- DBI::dbReadTable(con, "report_version")
   d <- d[setdiff(names(d), "author")]
   DBI::dbWriteTable(con, "report_version", d, overwrite = TRUE)
 
-  expect_error(report_db2_init(con, config, FALSE),
+  expect_error(report_db_init(con, config, FALSE),
                "custom fields 'author' not present in existing database")
 
   config$fields <- NULL
-  expect_error(report_db2_init(con, config, FALSE),
+  expect_error(report_db_init(con, config, FALSE),
                "custom fields 'requester', 'comments' in database")
 })
 
@@ -109,29 +109,29 @@ test_that("avoid unserialisable parameters", {
                     config = path, echo = FALSE)
   expect_error(orderly_commit(id, config = path),
                "Unsupported parameter type")
-  expect_error(report_db2_parameter_type(t), "Unsupported parameter type")
-  expect_error(report_db2_parameter_serialise(t), "Unsupported parameter type")
+  expect_error(report_db_parameter_type(t), "Unsupported parameter type")
+  expect_error(report_db_parameter_serialise(t), "Unsupported parameter type")
 })
 
 
 test_that("dialects", {
   skip_on_cran() # likely platform dependent
-  s <- report_db2_schema_read(NULL, "sqlite")
-  p <- report_db2_schema_read(NULL, "postgres")
+  s <- report_db_schema_read(NULL, "sqlite")
+  p <- report_db_schema_read(NULL, "postgres")
   expect_false(isTRUE(all.equal(s, p)))
 
   path <- prepare_orderly_example("minimal")
   config <- orderly_config(path)
   con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
   on.exit(DBI::dbDisconnect(con))
-  expect_error(report_db2_init_create(con, config, "postgres"),
+  expect_error(report_db_init_create(con, config, "postgres"),
                "syntax error")
 
-  expect_silent(report_db2_init_create(con, config, "sqlite"))
+  expect_silent(report_db_init_create(con, config, "sqlite"))
 
-  expect_equal(report_db2_dialect(con), "sqlite")
-  expect_equal(report_db2_dialect(structure(TRUE, class = "PqConnection")),
+  expect_equal(report_db_dialect(con), "sqlite")
+  expect_equal(report_db_dialect(structure(TRUE, class = "PqConnection")),
                "postgres")
-  expect_error(report_db2_dialect(structure(TRUE, class = "other")),
+  expect_error(report_db_dialect(structure(TRUE, class = "other")),
                "Can't determine SQL dialect")
 })

--- a/tests/testthat/test-publish.R
+++ b/tests/testthat/test-publish.R
@@ -1,35 +1,42 @@
 context("publish")
 
 test_that("included example", {
+  read_published <- function(path) {
+    con <- orderly_db("destination", config = path)
+    on.exit(DBI::dbDisconnect(con))
+    d <- DBI::dbReadTable(con, "report_version")
+    d$published
+  }
+
   path <- prepare_orderly_example("example")
-  expect_equal(read_orderly_db(path)$published, numeric(0))
+  expect_equal(read_published(path), numeric(0))
 
   id <- orderly_run("example", list(cyl = 4), config = path, echo = FALSE)
   p <- orderly_commit(id, config = path)
 
   yml <- path_orderly_published_yml(p)
   expect_false(file.exists(yml))
-  expect_equal(read_orderly_db(path)$published, 0)
+  expect_equal(read_published(path), 0)
 
   orderly_publish(id, config = path)
-  expect_equal(read_orderly_db(path)$published, 1)
+  expect_equal(read_published(path), 1)
   expect_true(file.exists(yml))
   expect_equal(yaml_read(yml), list(published = TRUE))
 
   expect_message(orderly_publish(id, config = path),
                  "Report is already published")
-  expect_equal(read_orderly_db(path)$published, 1)
+  expect_equal(read_published(path), 1)
   expect_true(file.exists(yml))
   expect_equal(yaml_read(yml), list(published = TRUE))
 
   orderly_publish(id, value = FALSE, config = path)
-  expect_equal(read_orderly_db(path)$published, 0)
+  expect_equal(read_published(path), 0)
   expect_true(file.exists(yml))
   expect_equal(yaml_read(yml), list(published = FALSE))
 
   expect_message(orderly_publish(id, value = FALSE, config = path),
                  "Report is already unpublished")
-  expect_equal(read_orderly_db(path)$published, 0)
+  expect_equal(read_published(path), 0)
   expect_true(file.exists(yml))
   expect_equal(yaml_read(yml), list(published = FALSE))
 })

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -371,6 +371,7 @@ test_that("resources", {
 
 test_that("markdown", {
   skip_if_not_installed("rmarkdown")
+  skip_on_appveyor() # See https://github.com/jgm/pandoc/issues/5037
   path <- prepare_orderly_example("knitr")
 
   id <- orderly_run("example", config = path, echo = FALSE)

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -100,12 +100,7 @@ test_that("run", {
 
   con_destination <- orderly_db("destination", config)
   on.exit(DBI::dbDisconnect(con_destination))
-  expect_true(DBI::dbExistsTable(con_destination, "orderly"))
-  d <- DBI::dbReadTable(con_destination, "orderly")
-  expect_true(all(vlapply(d[names(d) != "published"], is.character)))
-  expect_true(is.numeric(d$published))
-
-  expect_equal(d$id, basename(q))
+  expect_true(DBI::dbExistsTable(con_destination, "report_version"))
 })
 
 ## Same as in read; we generate a report and then break it
@@ -212,7 +207,9 @@ test_that("included example", {
   id <- orderly_run("example", list(cyl = 4), config = path, echo = FALSE)
   p <- orderly_commit(id, config = path)
   expect_true(is_directory(p))
-  dat <- read_orderly_db(path)
+  con <- orderly_db("destination", config = path)
+  on.exit(DBI::dbDisconnect(con))
+  dat <- DBI::dbReadTable(con, "report_version")
   expect_equal(dat$description, NA_character_)
   expect_equal(dat$displayname, NA_character_)
 })
@@ -223,7 +220,9 @@ test_that("included other", {
   p <- orderly_commit(id, config = path)
   info <- recipe_read(file.path(path_src(path), "other"),
                       orderly_config(path))
-  dat <- read_orderly_db(path)
+  con <- orderly_db("destination", config = path)
+  on.exit(DBI::dbDisconnect(con))
+  dat <- DBI::dbReadTable(con, "report_version")
   expect_equal(dat$description, info$description)
   expect_equal(dat$displayname, info$displayname)
 })
@@ -360,10 +359,12 @@ test_that("resources", {
   expect_true(file.exists(file.path(p, "meta/data.csv")))
   p <- orderly_commit(id, config = path)
 
-  d <- read_orderly_db(path)
-  expect_identical(d$resources, '["meta/data.csv"]')
-  expect_identical(d$hash_resources,
-                   '{"meta/data.csv":"0bec5bf6f93c547bc9c6774acaf85e1a"}')
+  con <- orderly_db("destination", config = path)
+  d <- DBI::dbGetQuery(
+    con, "SELECT * FROM file_input WHERE file_purpose = 'resource'")
+
+  expect_identical(d$filename, "meta/data.csv")
+  expect_identical(d$file_hash, "0bec5bf6f93c547bc9c6774acaf85e1a")
   expect_true(file.exists(file.path(p, "meta/data.csv")))
 })
 

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -491,11 +491,15 @@ test_that("show_question", {
 })
 
 test_that("show_question interactive", {
-  ## We can't check that show_question will return true on appveyor since
-  ## R CMD check is non-interactive
-  skip_on_cran()
-  skip_on_travis()
-  skip_on_appveyor()
+  withr::with_options(
+    list(orderly.nolog = NULL),
+    expect_equal(show_question(), interactive()))
 
-  expect_identical(show_question(), TRUE)
+  mockery::stub(show_question, "interactive", TRUE)
+  withr::with_options(
+    list(orderly.nolog = NULL),
+    expect_equal(show_question(), TRUE))
+  withr::with_options(
+    list(orderly.nolog = TRUE),
+    expect_equal(show_question(), FALSE))
 })


### PR DESCRIPTION
Remove the old db schema

Most of the diff here is:

* removing code that used to maintain the old `orderly` table in the db
* renaming lots of functions from `_db2_` to `_db_`
* fixing up tests that checked on the state of the db (I have kept the intent of the tests the same)

There are two opportunistic fixes of other tests, flagged below.

Before merging this we should double check that this works with the reporting api; the `orderly.server` and the `montagu-orderly` containers have been updated now on the `i2769` branch so can be used in integration tests