### PR TITLE
VIMC-2874: Don't use orderly.yml when writing to db

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 0.6.1
+Version: 0.6.2
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/R/db2.R
+++ b/R/db2.R
@@ -283,7 +283,9 @@ report_data_import <- function(con, workdir, config) {
     git_sha = dat_rds$git$sha %||% NA_character_,
     git_branch = dat_rds$git$branch %||% NA_character_,
     git_clean = git_clean)
-  report_version <- cbind(report_version, dat_rds$meta$extra_fields)
+  if (!is.null(dat_rds$meta$extra_fields)) {
+    report_version <- cbind(report_version, dat_rds$meta$extra_fields)
+  }
   DBI::dbWriteTable(con, "report_version", report_version, append = TRUE)
 
   if (!is.null(dat_rds$meta$view)) {

--- a/R/recipe_run.R
+++ b/R/recipe_run.R
@@ -264,15 +264,13 @@ recipe_run <- function(info, parameters, envir, config, echo = TRUE) {
                          "id_requested", "is_latest", "is_pinned")]
   }
 
-  if (!is.null(config$fields)) {
-    extra_fields <- drop_null(set_names(
-      lapply(config$fields$name, function(x) info[[x]]),
-      config$fields$name))
-    if (length(extra_fields) > 0L) {
-      extra_fields <- as_data_frame(extra_fields)
-    } else {
-      extra_filds <- NULL
-    }
+  extra_fields <- drop_null(set_names(
+    lapply(config$fields$name, function(x) info[[x]]),
+    config$fields$name))
+  if (length(extra_fields) > 0L) {
+    extra_fields <- as_data_frame(extra_fields)
+  } else {
+    extra_fields <- NULL
   }
 
   session <- session_info()

--- a/R/recipe_run.R
+++ b/R/recipe_run.R
@@ -241,6 +241,13 @@ recipe_run <- function(info, parameters, envir, config, echo = TRUE) {
     hash_readme <- NULL
   }
 
+  if (is.null(info$sources)) {
+    hash_sources <- NULL
+  } else {
+    hash_sources <- resource_info$hash_resources[info$sources]
+  }
+  hash_orderly_yml <- hash_files("orderly.yml")
+  hash_script <- hash_files(info$script)
   hash_data_csv <- con_csv$mset(prep$data)
   hash_data_rds <- con_rds$mset(prep$data)
   stopifnot(identical(hash_data_csv, hash_data_rds))
@@ -257,6 +264,17 @@ recipe_run <- function(info, parameters, envir, config, echo = TRUE) {
                          "id_requested", "is_latest", "is_pinned")]
   }
 
+  if (!is.null(config$fields)) {
+    extra_fields <- drop_null(set_names(
+      lapply(config$fields$name, function(x) info[[x]]),
+      config$fields$name))
+    if (length(extra_fields) > 0L) {
+      extra_fields <- as_data_frame(extra_fields)
+    } else {
+      extra_filds <- NULL
+    }
+  }
+
   session <- session_info()
   session$git <- info$git
 
@@ -264,17 +282,20 @@ recipe_run <- function(info, parameters, envir, config, echo = TRUE) {
                name = info$name,
                parameters = parameters,
                date = as.character(Sys.time()),
+               displayname = info$displayname %||% NA_character_,
+               description = info$description %||% NA_character_,
+               extra_fields = extra_fields,
                connection = !is.null(info$connection),
-               ## Don't know what of these two are most useful:
+               packages = info$packages,
                hash_orderly = info$hash,
-               hash_input = hash_files("orderly.yml", FALSE),
-               ## Below here all seems sensible enough to track
-               hash_script = hash_files(info$script, FALSE),
+               hash_orderly_yml = as.list(hash_orderly_yml),
+               hash_script = as.list(hash_script),
                hash_readme = as.list(hash_readme),
                hash_resources = as.list(resource_info$hash_resources),
                hash_global = as.list(resource_info$hash_global),
                hash_data = as.list(hash_data_rds),
                hash_artefacts = as.list(hash_artefacts),
+               artefacts = info$artefacts,
                depends = depends,
                elapsed = as.numeric(elapsed, "secs"),
                git = info$git)

--- a/R/util.R
+++ b/R/util.R
@@ -153,17 +153,6 @@ hash_object <- function(object) {
   digest::digest(object)
 }
 
-to_json <- function(x, auto_unbox = TRUE, ...) {
-  jsonlite::toJSON(x, auto_unbox = auto_unbox)
-}
-
-to_json_string <- function(...) {
-  as.character(to_json(...))
-}
-
-to_json_string_charvec <- function(x) {
-  to_json_string(x %||% character(0), auto_unbox = FALSE)
-}
 
 list_dirs <- function(path) {
   files <- dir(path, full.names = TRUE)

--- a/inst/migrate/0.6.2.R
+++ b/inst/migrate/0.6.2.R
@@ -1,0 +1,37 @@
+migrate <- function(data, path, config) {
+  if (!is.null(data$archive_version) && data$archive_version >= "0.6.2") {
+    migration_result(FALSE, data)
+  }
+
+  prev <- data
+
+  filename <- file.path(path, "orderly.yml")
+  dat_yml <- yaml_read(filename)
+
+  data$meta$displayname <- dat_yml$displayname %||% NA_character_
+  data$meta$description <- dat_yml$description %||% NA_character_
+
+  names(data$meta$hash_script) <- dat_yml$script
+  data$meta$hash_orderly_yml <-
+    set_names(hash_files(file.path(path, "orderly.yml")), "orderly.yml")
+
+  extra_fields <- drop_null(set_names(
+    lapply(config$fields$name, function(x) dat_yml[[x]]),
+    config$fields$name))
+  if (length(extra_fields) > 0L) {
+    data$meta$extra_fields <- as_data_frame(extra_fields)
+  }
+
+  data$meta$artefacts <-
+    recipe_read_check_artefacts(dat_yml$artefacts, filename, path)
+
+  if (!is.null(dat_yml$sources)) {
+    data$meta$hash_sources <- data$meta$hash_resources[dat_yml$sources]
+  }
+  if (!is.null(dat_yml$packages)) {
+    data$meta$packages <- dat_yml$packages
+  }
+
+  updated <- !identical(prev, data)
+  migration_result(updated, data)
+}

--- a/tests/testthat/test-migrate.R
+++ b/tests/testthat/test-migrate.R
@@ -305,3 +305,19 @@ test_that("migrate 0.6.0 -> 0.6.1", {
     readRDS(path_orderly_run_rds(p))$meta$hash_readme,
     c("README.md" = "499b37b7fbc174e2fd8559ad96a06178"))
 })
+
+
+test_that("migrate 0.6.1 -> 0.6.2", {
+  path <- unpack_reference("0.6.0")
+
+  reports <- subset(orderly_list_archive(path), name == "use_resource")
+  p <- file.path(path, "archive", "use_resource", reports$id[[1]])
+  expect_null(readRDS(path_orderly_run_rds(p))$meta$hash_orderly_yml)
+
+  orderly_migrate(path, to = "0.6.2")
+  orderly_rebuild(path)
+
+  expect_equal(
+    readRDS(path_orderly_run_rds(p))$meta$hash_orderly_yml,
+    c("orderly.yml" = "23f4542f02ad69ddafc6fab2a4391e6c"))
+})

--- a/tests/testthat/test-migrate.R
+++ b/tests/testthat/test-migrate.R
@@ -148,7 +148,7 @@ test_that("mixed migration", {
   unlink(path_orderly_archive_version(path))
 
   msg <- capture_messages(
-    orderly_migrate(path, to = curr, verbose = TRUE, dry_run = TRUE))
+    orderly_migrate(path, to = curr, verbose = TRUE))
   expect_true(
     any(grepl(sprintf("[ ok         ]  example/%s", id), msg, fixed = TRUE)))
 })

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -66,10 +66,10 @@ test_that("run", {
   expect_identical(run$hash_resources, list())
   expect_identical(run$parameters, parameters)
   expect_is(run$date, "character")
-  ## I feel hash_orderly and hash_input have the wrong names here
   expect_identical(run$hash_orderly, info$hash)
-  expect_identical(run$hash_input,
-                   hash_files(file.path(p, "orderly.yml"), FALSE))
+  expect_identical(
+    run$hash_orderly_yml,
+    set_names(as.list(hash_files(file.path(p, "orderly.yml"))), "orderly.yml"))
 
   expect_is(run$hash_data, "list")
   expect_equal(length(run$hash_data), 1)


### PR DESCRIPTION
This PR removes the use of orderly.yml when writing to the db.  Previously we used a combination of data from the orderly_run.rds and orderly.yml but this causes problems when loading a configuration that is no longer valid, as is the case at the moment on montagu after the db updates introduced in 0.6.0