### PR TITLE
VIMC-2919: rename the `config` in user-visible functions

### DIFF
--- a/R/changelog.R
+++ b/R/changelog.R
@@ -58,7 +58,7 @@ changelog_read_previous <- function(name, config) {
   ## that is going to end up in the configuration.
   prev <- orderly_latest(name, config, locate = FALSE,
                          draft = FALSE, must_work = FALSE)
-  changelog_read_json(file.path(config$path, "archive", name, prev))
+  changelog_read_json(file.path(config$root, "archive", name, prev))
 }
 
 

--- a/R/cleanup.R
+++ b/R/cleanup.R
@@ -16,9 +16,9 @@
 ##'   \code{\link{orderly_test_start}}
 ##' @inheritParams orderly_list
 ##' @export
-orderly_cleanup <- function(name = NULL, config = NULL, locate = TRUE,
+orderly_cleanup <- function(name = NULL, path = NULL, locate = TRUE,
                             draft = TRUE, data = TRUE, failed_only = FALSE) {
-  config <- orderly_config_get(config, locate)
+  config <- orderly_config_get(path, locate)
   if (draft) {
     orderly_cleanup_drafts(config, name, failed_only)
   }

--- a/R/cleanup.R
+++ b/R/cleanup.R
@@ -16,9 +16,9 @@
 ##'   \code{\link{orderly_test_start}}
 ##' @inheritParams orderly_list
 ##' @export
-orderly_cleanup <- function(name = NULL, path = NULL, locate = TRUE,
+orderly_cleanup <- function(name = NULL, root = NULL, locate = TRUE,
                             draft = TRUE, data = TRUE, failed_only = FALSE) {
-  config <- orderly_config_get(path, locate)
+  config <- orderly_config_get(root, locate)
   if (draft) {
     orderly_cleanup_drafts(config, name, failed_only)
   }
@@ -34,7 +34,7 @@ orderly_cleanup_drafts <- function(config, name = NULL, failed_only = FALSE) {
     assert_character(name)
     d <- d[d$name %in% name, , drop = FALSE]
   }
-  p <- file.path(path_draft(config$path), d$name, d$id)
+  p <- file.path(path_draft(config$root), d$name, d$id)
   if (failed_only) {
     p <- p[!file.exists(path_orderly_run_rds(p))]
   }
@@ -55,7 +55,7 @@ orderly_cleanup_data <- function(config) {
   used_pub <- unique(data)
   dr <- orderly_list_drafts(config, FALSE)
   path_rds <- path_orderly_run_rds(
-    file.path(path_draft(config$path), dr$name, dr$id))
+    file.path(path_draft(config$root), dr$name, dr$id))
   used_draft <-
     unlist(lapply(path_rds, function(x)
       readRDS(x)$meta$hash_data), use.names = FALSE)

--- a/R/config.R
+++ b/R/config.R
@@ -1,14 +1,14 @@
-orderly_config <- function(path) {
-  filename <- path_orderly_config_yml(path)
+orderly_config <- function(root) {
+  filename <- path_orderly_config_yml(root)
   if (!file.exists(filename)) {
-    stop("Did not find file 'orderly_config.yml' at path ", path)
+    stop("Did not find file 'orderly_config.yml' at path ", root)
   }
   withr::with_envvar(
-    orderly_envir_read(path),
-    orderly_config_read_yaml(filename, path))
+    orderly_envir_read(root),
+    orderly_config_read_yaml(filename, root))
 }
 
-orderly_config_read_yaml <- function(filename, path) {
+orderly_config_read_yaml <- function(filename, root) {
   info <- yaml_read(filename)
   check_fields(info, filename, character(),
                c("destination", "fields", "minimum_orderly_version",
@@ -73,7 +73,7 @@ orderly_config_read_yaml <- function(filename, path) {
 
   info$remote <- config_check_remote(info$remote, filename)
 
-  info$path <- normalizePath(path, mustWork = TRUE)
+  info$root <- normalizePath(root, mustWork = TRUE)
 
   remote_identity <- Sys.getenv("ORDERLY_API_SERVER_IDENTITY", "")
   if (nzchar(remote_identity)) {
@@ -86,10 +86,10 @@ orderly_config_read_yaml <- function(filename, path) {
 
   if (!is.null(info$global_resources)) {
     assert_is_directory(info$global_resources, name = "global resource",
-                        workdir = path)
+                        workdir = root)
   }
 
-  info$archive_version <- read_orderly_archive_version(path)
+  info$archive_version <- read_orderly_archive_version(root)
 
   class(info) <- "orderly_config"
   info
@@ -204,11 +204,11 @@ sql_type <- function(type, name) {
 }
 
 orderly_locate_config <- function() {
-  path <- find_file_descend("orderly_config.yml")
-  if (is.null(path)) {
+  root <- find_file_descend("orderly_config.yml")
+  if (is.null(root)) {
     stop("Reached root without finding 'orderly_config.yml'")
   }
-  orderly_config(path)
+  orderly_config(root)
 }
 
 

--- a/R/config.R
+++ b/R/config.R
@@ -212,7 +212,7 @@ orderly_locate_config <- function() {
 }
 
 
-orderly_config_get <- function(x, locate) {
+orderly_config_get <- function(x, locate = FALSE) {
   if (inherits(x, "orderly_config")) {
     x
   } else if (is.null(x) && locate) {

--- a/R/db.R
+++ b/R/db.R
@@ -12,12 +12,12 @@
 ##'   = "destination"}).  This is primarily intended for internal use.
 ##'
 ##' @export
-orderly_db <- function(type, path = NULL, locate = TRUE, validate = TRUE) {
-  config <- orderly_config_get(path, locate)
+orderly_db <- function(type, root = NULL, locate = TRUE, validate = TRUE) {
+  config <- orderly_config_get(root, locate)
   if (type == "rds") {
-    con <- file_store_rds(path_rds(config$path))
+    con <- file_store_rds(path_rds(config$root))
   } else if (type == "csv") {
-    con <- file_store_csv(path_csv(config$path))
+    con <- file_store_csv(path_csv(config$root))
   } else if (type == "destination") {
     con <- orderly_db_dbi_connect(config$destination, config)
     withCallingHandlers(
@@ -42,7 +42,7 @@ orderly_db_args <- function(x, config) {
   driver <- getExportedValue(x$driver[[1L]], x$driver[[2L]])
 
   args <- withr::with_envvar(
-    orderly_envir_read(config$path),
+    orderly_envir_read(config$root),
     args <- resolve_driver_config(x$args, config))
 
   if (x$driver[[2]] == "SQLite") {
@@ -51,7 +51,7 @@ orderly_db_args <- function(x, config) {
       stop("Cannot use a transient SQLite database with orderly")
     }
     if (is_relative_path(args$dbname)) {
-      args$dbname <- file.path(config$path, args$dbname)
+      args$dbname <- file.path(config$root, args$dbname)
     }
   }
 
@@ -72,16 +72,16 @@ orderly_db_args <- function(x, config) {
 ##'   fast enough to call regularly.
 ##'
 ##' @export
-orderly_rebuild <- function(path = NULL, locate = TRUE, verbose = TRUE,
+orderly_rebuild <- function(root = NULL, locate = TRUE, verbose = TRUE,
                             if_schema_changed = FALSE) {
   ## We'll skip warnings here - they'll come out as messages rather
   ## than warnings.
   oo <- options(orderly.nowarnings = TRUE)
   on.exit(options(oo))
 
-  config <- orderly_config_get(path, locate)
+  config <- orderly_config_get(root, locate)
 
-  if (length(migrate_plan(config$path, to = NULL)) > 0L) {
+  if (length(migrate_plan(config$root, to = NULL)) > 0L) {
     orderly_log("migrate", "archive")
     orderly_migrate(config, locate = FALSE, verbose = verbose)
     ## This should trigger a rebuild, regardless of what anything else thinks

--- a/R/db.R
+++ b/R/db.R
@@ -12,8 +12,8 @@
 ##'   = "destination"}).  This is primarily intended for internal use.
 ##'
 ##' @export
-orderly_db <- function(type, config = NULL, locate = TRUE, validate = TRUE) {
-  config <- orderly_config_get(config, locate)
+orderly_db <- function(type, path = NULL, locate = TRUE, validate = TRUE) {
+  config <- orderly_config_get(path, locate)
   if (type == "rds") {
     con <- file_store_rds(path_rds(config$path))
   } else if (type == "csv") {
@@ -72,14 +72,14 @@ orderly_db_args <- function(x, config) {
 ##'   fast enough to call regularly.
 ##'
 ##' @export
-orderly_rebuild <- function(config = NULL, locate = TRUE, verbose = TRUE,
+orderly_rebuild <- function(path = NULL, locate = TRUE, verbose = TRUE,
                             if_schema_changed = FALSE) {
   ## We'll skip warnings here - they'll come out as messages rather
   ## than warnings.
   oo <- options(orderly.nowarnings = TRUE)
   on.exit(options(oo))
 
-  config <- orderly_config_get(config, locate)
+  config <- orderly_config_get(path, locate)
 
   if (length(migrate_plan(config$path, to = NULL)) > 0L) {
     orderly_log("migrate", "archive")

--- a/R/db2.R
+++ b/R/db2.R
@@ -198,7 +198,7 @@ report_db_open_existing <- function(con, config) {
 
 report_db_rebuild <- function(config, verbose = TRUE) {
   assert_is(config, "orderly_config")
-  root <- config$path
+  root <- config$root
   con <- orderly_db("destination", config, validate = FALSE)
   on.exit(DBI::dbDisconnect(con))
 

--- a/R/main.R
+++ b/R/main.R
@@ -125,12 +125,12 @@ main_do_run <- function(x) {
   main_run <- function() {
     if (pull) {
       if (is.null(ref)) {
-        git_pull(config$path)
+        git_pull(config$root)
       } else {
         stop("Can't use --pull with --ref; perhaps you meant --fetch ?")
       }
     }
-    dat <- orderly_run(name, parameters, path = config, id_file = id_file,
+    dat <- orderly_run(name, parameters, root = config, id_file = id_file,
                        ref = ref, fetch = fetch, message = message,
                        extended_output = TRUE)
     if (commit) {
@@ -147,7 +147,7 @@ main_do_run <- function(x) {
     log <- tempfile()
     ## we should run this with try() so that we can capture logs there
     dat <- capture_log(main_run(), log)
-    dest <- (if (commit) path_archive else path_draft)(config$path)
+    dest <- (if (commit) path_archive else path_draft)(config$root)
     file_copy(log, file.path(dest, name, dat$id, "orderly.log"))
   }
 
@@ -188,11 +188,11 @@ main_args_cleanup <- function(res) {
 }
 
 main_do_cleanup <- function(x) {
-  path <- x$options$root
+  root <- x$options$root
   draft <- !x$options$no_draft
   data <- !x$options$no_data
   failed_only <- x$options$failed_only
-  orderly_cleanup(path = path, draft = draft, data = data,
+  orderly_cleanup(root = root, draft = draft, data = data,
                   failed_only = failed_only)
 }
 
@@ -206,9 +206,9 @@ main_args_commit <- function(res) {
 }
 
 main_do_commit <- function(x) {
-  path <- x$options$root
+  root <- x$options$root
   id <- x$args
-  orderly_commit(id, path = path, locate = TRUE)
+  orderly_commit(id, root = root, locate = TRUE)
 }
 
 ## 4. publish
@@ -227,10 +227,10 @@ main_args_publish <- function(res) {
 }
 
 main_do_publish <- function(x) {
-  path <- x$options$root
+  root <- x$options$root
   value <- !x$options$unpublish
   id <- x$args
-  orderly_publish(id, value, path = path, locate = TRUE)
+  orderly_publish(id, value, root = root, locate = TRUE)
 }
 
 ## 4. rebuild
@@ -249,9 +249,9 @@ main_args_rebuild <- function(res) {
 }
 
 main_do_rebuild <- function(x) {
-  path <- x$options$root
+  root <- x$options$root
   if_schema_changed <- x$options$if_schema_changed
-  orderly_rebuild(path, if_schema_changed = if_schema_changed)
+  orderly_rebuild(root, if_schema_changed = if_schema_changed)
 }
 
 ## 5. list
@@ -272,11 +272,11 @@ main_args_list <- function(res) {
 }
 
 main_do_list <- function(x) {
-  path <- x$options$root
+  root <- x$options$root
   switch(x$args,
-         names = writeLines(orderly_list(path)),
-         drafts = print(orderly_list_drafts(path)),
-         archive = print(orderly_list_archive(path)),
+         names = writeLines(orderly_list(root)),
+         drafts = print(orderly_list_drafts(root)),
+         archive = print(orderly_list_archive(root)),
          stop("orderly bug"))
   invisible(NULL)
 }
@@ -302,12 +302,12 @@ main_args_latest <- function(res) {
 }
 
 main_do_latest <- function(x) {
-  path <- x$options$root
+  root <- x$options$root
   names <- x$args
   draft <- x$options$draft
   value_if_missing <- x$options$value_if_missing
   must_work <- is.null(value_if_missing)
-  ids <- vcapply(names, orderly_latest, path = path, locate = TRUE,
+  ids <- vcapply(names, orderly_latest, root = root, locate = TRUE,
                  draft = draft, must_work = must_work,
                  USE.NAMES = FALSE)
   ids[is.na(ids)] <- value_if_missing
@@ -337,10 +337,10 @@ main_args_migrate <- function(res) {
 
 
 main_do_migrate <- function(x) {
-  path <- x$options$root
+  root <- x$options$root
   dry_run <- x$options$dry_run
   to <- x$options$to
-  orderly_migrate(path, to = to, dry_run = dry_run)
+  orderly_migrate(root, to = to, dry_run = dry_run)
 }
 
 

--- a/R/main.R
+++ b/R/main.R
@@ -130,7 +130,7 @@ main_do_run <- function(x) {
         stop("Can't use --pull with --ref; perhaps you meant --fetch ?")
       }
     }
-    dat <- orderly_run(name, parameters, config = config, id_file = id_file,
+    dat <- orderly_run(name, parameters, path = config, id_file = id_file,
                        ref = ref, fetch = fetch, message = message,
                        extended_output = TRUE)
     if (commit) {
@@ -188,11 +188,11 @@ main_args_cleanup <- function(res) {
 }
 
 main_do_cleanup <- function(x) {
-  config <- orderly_config_get(x$options$root, TRUE)
+  path <- x$options$root
   draft <- !x$options$no_draft
   data <- !x$options$no_data
   failed_only <- x$options$failed_only
-  orderly_cleanup(config = config, draft = draft, data = data,
+  orderly_cleanup(path = path, draft = draft, data = data,
                   failed_only = failed_only)
 }
 
@@ -206,9 +206,9 @@ main_args_commit <- function(res) {
 }
 
 main_do_commit <- function(x) {
-  config <- orderly_config_get(x$options$root, TRUE)
+  path <- x$options$root
   id <- x$args
-  orderly_commit(id, config = config)
+  orderly_commit(id, path = path, locate = TRUE)
 }
 
 ## 4. publish
@@ -227,10 +227,10 @@ main_args_publish <- function(res) {
 }
 
 main_do_publish <- function(x) {
-  config <- orderly_config_get(x$options$root, TRUE)
+  path <- x$options$root
   value <- !x$options$unpublish
   id <- x$args
-  orderly_publish(id, value, config = config)
+  orderly_publish(id, value, path = path, locate = TRUE)
 }
 
 ## 4. rebuild
@@ -249,8 +249,9 @@ main_args_rebuild <- function(res) {
 }
 
 main_do_rebuild <- function(x) {
-  config <- orderly_config_get(x$options$root, TRUE)
-  orderly_rebuild(config, if_schema_changed = x$options$if_schema_changed)
+  path <- x$options$root
+  if_schema_changed <- x$options$if_schema_changed
+  orderly_rebuild(path, if_schema_changed = if_schema_changed)
 }
 
 ## 5. list
@@ -271,11 +272,11 @@ main_args_list <- function(res) {
 }
 
 main_do_list <- function(x) {
-  config <- orderly_config_get(x$options$root, TRUE)
+  path <- x$options$root
   switch(x$args,
-         names = writeLines(orderly_list(config)),
-         drafts = print(orderly_list_drafts(config)),
-         archive = print(orderly_list_archive(config)),
+         names = writeLines(orderly_list(path)),
+         drafts = print(orderly_list_drafts(path)),
+         archive = print(orderly_list_archive(path)),
          stop("orderly bug"))
   invisible(NULL)
 }
@@ -301,12 +302,12 @@ main_args_latest <- function(res) {
 }
 
 main_do_latest <- function(x) {
-  config <- orderly_config_get(x$options$root, TRUE)
+  path <- x$options$root
   names <- x$args
   draft <- x$options$draft
   value_if_missing <- x$options$value_if_missing
   must_work <- is.null(value_if_missing)
-  ids <- vcapply(names, orderly_latest, config = config,
+  ids <- vcapply(names, orderly_latest, path = path, locate = TRUE,
                  draft = draft, must_work = must_work,
                  USE.NAMES = FALSE)
   ids[is.na(ids)] <- value_if_missing
@@ -336,10 +337,10 @@ main_args_migrate <- function(res) {
 
 
 main_do_migrate <- function(x) {
-  config <- orderly_config_get(x$options$root, TRUE)
+  path <- x$options$root
   dry_run <- x$options$dry_run
   to <- x$options$to
-  orderly_migrate(config, to = to, dry_run = dry_run)
+  orderly_migrate(path, to = to, dry_run = dry_run)
 }
 
 

--- a/R/migrate.R
+++ b/R/migrate.R
@@ -46,7 +46,7 @@
 ##'   migrated this might come in helpful.
 ##'
 ##' @export
-orderly_migrate <- function(config = NULL, locate = TRUE, to = NULL,
+orderly_migrate <- function(path = NULL, locate = TRUE, to = NULL,
                             verbose = FALSE, dry_run = FALSE,
                             skip_failed = FALSE) {
   ## We'll skip warnings here - they'll come out as messages rather
@@ -54,7 +54,7 @@ orderly_migrate <- function(config = NULL, locate = TRUE, to = NULL,
   oo <- options(orderly.nowarnings = TRUE)
   on.exit(options(oo))
 
-  config <- orderly_config_get(config, locate)
+  config <- orderly_config_get(path, locate)
   root <- config$path
 
   migrations <- migrate_plan(root, to)

--- a/R/migrate.R
+++ b/R/migrate.R
@@ -46,7 +46,7 @@
 ##'   migrated this might come in helpful.
 ##'
 ##' @export
-orderly_migrate <- function(path = NULL, locate = TRUE, to = NULL,
+orderly_migrate <- function(root = NULL, locate = TRUE, to = NULL,
                             verbose = FALSE, dry_run = FALSE,
                             skip_failed = FALSE) {
   ## We'll skip warnings here - they'll come out as messages rather
@@ -54,8 +54,8 @@ orderly_migrate <- function(path = NULL, locate = TRUE, to = NULL,
   oo <- options(orderly.nowarnings = TRUE)
   on.exit(options(oo))
 
-  config <- orderly_config_get(path, locate)
-  root <- config$path
+  config <- orderly_config_get(root, locate)
+  root <- config$root
 
   migrations <- migrate_plan(root, to)
 
@@ -111,24 +111,24 @@ migrate_apply <- function(root, version, fun, config, verbose, dry_run,
 }
 
 
-migrate_apply1 <- function(path, version, fun, config, dry_run, skip_failed) {
+migrate_apply1 <- function(root, version, fun, config, dry_run, skip_failed) {
   if (skip_failed) {
     return(tryCatch(
-      migrate_apply1(path, version, fun, config, dry_run, FALSE),
-      error = function(e) migrate_skip(e, path, version, config, dry_run)))
+      migrate_apply1(root, version, fun, config, dry_run, FALSE),
+      error = function(e) migrate_skip(e, root, version, config, dry_run)))
   }
-  file <- path_orderly_run_rds_backup(path, version)
+  file <- path_orderly_run_rds_backup(root, version)
 
   ## This should never happen, and the behaviour if it does is not
   ## well defined.  So let's assert here and if it turns out to matter
   ## we'll find out soon enough.
   stopifnot(!file.exists(file))
 
-  file_orig <- path_orderly_run_rds(path)
+  file_orig <- path_orderly_run_rds(root)
   dat <- readRDS(file_orig)
   version_previous <- get_version(dat$archive_version)
   if (version_previous < version) {
-    res <- fun(dat, path, config)
+    res <- fun(dat, root, config)
     res$data$archive_version <- numeric_version(version)
     if (!dry_run) {
       file_copy(file_orig, file)
@@ -148,17 +148,17 @@ migrate_fail_message <- function(name, id, error) {
 }
 
 
-migrate_skip <- function(error, path, version, config, dry_run) {
-  name <- basename(dirname(path))
-  id <- basename(path)
+migrate_skip <- function(error, root, version, config, dry_run) {
+  name <- basename(dirname(root))
+  id <- basename(root)
   migrate_fail_message(name, id, error)
   dest_rel <- file.path(path_archive_broken(), name, id)
-  dest <- file.path(config$path, dest_rel)
+  dest <- file.path(config$root, dest_rel)
   if (dry_run) {
     action <- "would be"
   } else {
     dir.create(dirname(dest), FALSE, TRUE)
-    file_move(path, dest)
+    file_move(root, dest)
     action <- "has been"
   }
   message(sprintf("...this report %s moved to\n\t'%s'",
@@ -206,9 +206,9 @@ read_orderly_archive_version <- function(root) {
 
 
 write_orderly_archive_version <- function(version, root) {
-  path <- path_orderly_archive_version(root)
-  dir.create(dirname(path), FALSE, TRUE)
-  writeLines(as.character(version), path)
+  root <- path_orderly_archive_version(root)
+  dir.create(dirname(root), FALSE, TRUE)
+  writeLines(as.character(version), root)
 }
 
 
@@ -216,7 +216,7 @@ check_orderly_archive_version <- function(config) {
   used <- numeric_version(config$archive_version)
   curr <- cache$current_archive_version
   if (used == "0.0.0" && nrow(orderly_list_archive(config)) == 0L) {
-    write_orderly_archive_version(curr, config$path)
+    write_orderly_archive_version(curr, config$root)
     used <- curr
   }
   if (used < curr) {

--- a/R/new.R
+++ b/R/new.R
@@ -35,21 +35,21 @@
 ##'
 ##' @inheritParams orderly_list
 ##' @export
-orderly_new <- function(name, path = NULL, locate = TRUE, quiet = FALSE,
+orderly_new <- function(name, root = NULL, locate = TRUE, quiet = FALSE,
                         template = NULL) {
-  config <- orderly_config_get(path, locate)
+  config <- orderly_config_get(root, locate)
   assert_scalar_character(name)
   if (grepl("[[:space:]]", name)) {
     stop("'name' cannot contain spaces")
   }
-  dest <- file.path(path_src(config$path), name)
+  dest <- file.path(path_src(config$root), name)
   if (file.exists(dest)) {
     stop(sprintf("A report already exists called '%s'", name))
   }
 
   if (is.null(template)) {
     template <-
-      if (has_template(config$path, "default")) "default" else "system"
+      if (has_template(config$root, "default")) "default" else "system"
   }
 
   if (template == "system") {
@@ -88,12 +88,12 @@ orderly_new_system <- function(dest, config) {
 
 
 orderly_new_user <- function(dest, config, template) {
-  if (!has_template(config$path, template)) {
+  if (!has_template(config$root, template)) {
     stop(sprintf("Did not find file '%s' within orderly root",
                  file.path("template", template, "orderly.yml")))
   }
   dir.create(dest)
-  path_template <- file.path(config$path, "template", template)
+  path_template <- file.path(config$root, "template", template)
   files <- dir(path_template, all.files = TRUE, no.. = TRUE, full.names = TRUE)
   file_copy(files, dest, recursive = TRUE)
 }

--- a/R/new.R
+++ b/R/new.R
@@ -35,9 +35,9 @@
 ##'
 ##' @inheritParams orderly_list
 ##' @export
-orderly_new <- function(name, config = NULL, locate = TRUE, quiet = FALSE,
+orderly_new <- function(name, path = NULL, locate = TRUE, quiet = FALSE,
                         template = NULL) {
-  config <- orderly_config_get(config, locate)
+  config <- orderly_config_get(path, locate)
   assert_scalar_character(name)
   if (grepl("[[:space:]]", name)) {
     stop("'name' cannot contain spaces")

--- a/R/publish.R
+++ b/R/publish.R
@@ -12,12 +12,12 @@
 ##' @inheritParams orderly_list
 ##' @export
 orderly_publish <- function(id, value = TRUE, name = NULL,
-                            path = NULL, locate = TRUE) {
-  config <- orderly_config_get(path, locate)
+                            root = NULL, locate = TRUE) {
+  config <- orderly_config_get(root, locate)
   if (is.null(name)) {
     name <- orderly_find_name(id, config, draft = FALSE, must_work = TRUE)
   }
-  workdir <- file.path(path_archive(config$path), name, id)
+  workdir <- file.path(path_archive(config$root), name, id)
   yml <- path_orderly_published_yml(workdir)
 
   if (file.exists(yml)) {

--- a/R/publish.R
+++ b/R/publish.R
@@ -12,8 +12,8 @@
 ##' @inheritParams orderly_list
 ##' @export
 orderly_publish <- function(id, value = TRUE, name = NULL,
-                            config = NULL, locate = TRUE) {
-  config <- orderly_config_get(config, locate)
+                            path = NULL, locate = TRUE) {
+  config <- orderly_config_get(path, locate)
   if (is.null(name)) {
     name <- orderly_find_name(id, config, draft = FALSE, must_work = TRUE)
   }

--- a/R/query.R
+++ b/R/query.R
@@ -10,7 +10,7 @@ VERSION_ID_RE <- "^([0-9]{8}-[0-9]{6})-([[:xdigit:]]{4})([[:xdigit:]]{4})$"
 ##'
 ##' @title List orderly reports
 ##'
-##' @param path The path to an orderly root directoy, or \code{NULL}
+##' @param root The path to an orderly root directoy, or \code{NULL}
 ##'   (the default) to search for one from the current working
 ##'   directory if \code{locate} is \code{TRUE}).
 ##'
@@ -20,9 +20,9 @@ VERSION_ID_RE <- "^([0-9]{8}-[0-9]{6})-([[:xdigit:]]{4})([[:xdigit:]]{4})$"
 ##'   parents until it finds an \code{orderly_config.yml} file.
 ##'
 ##' @export
-orderly_list <- function(path = NULL, locate = TRUE) {
-  config <- orderly_config_get(path, locate)
-  basename(list_dirs(path_src(config$path)))
+orderly_list <- function(root = NULL, locate = TRUE) {
+  config <- orderly_config_get(root, locate)
+  basename(list_dirs(path_src(config$root)))
 }
 
 ##' List draft and archived reports.  This returns a data.frame with
@@ -32,14 +32,14 @@ orderly_list <- function(path = NULL, locate = TRUE) {
 ##' @title List draft and archived reports
 ##' @inheritParams orderly_list
 ##' @export
-orderly_list_drafts <- function(path = NULL, locate = TRUE) {
-  orderly_list2(TRUE, path, locate)
+orderly_list_drafts <- function(root = NULL, locate = TRUE) {
+  orderly_list2(TRUE, root, locate)
 }
 
 ##' @export
 ##' @rdname orderly_list_drafts
-orderly_list_archive <- function(path = NULL, locate = TRUE) {
-  orderly_list2(FALSE, path, locate)
+orderly_list_archive <- function(root = NULL, locate = TRUE) {
+  orderly_list2(FALSE, root, locate)
 }
 
 ##' Find most recent version of an orderly report
@@ -55,18 +55,18 @@ orderly_list_archive <- function(path = NULL, locate = TRUE) {
 ##'
 ##' @inheritParams orderly_list
 ##' @export
-orderly_latest <- function(name = NULL, path = NULL, locate = TRUE,
+orderly_latest <- function(name = NULL, root = NULL, locate = TRUE,
                            draft = FALSE, must_work = TRUE) {
-  config <- orderly_config_get(path, locate)
+  config <- orderly_config_get(root, locate)
 
   if (is.null(name)) {
     d <- orderly_list2(draft, config, FALSE)
     ids <- d$id
     path <-
-      file.path((if (draft) path_draft else path_archive)(config$path), d$name)
+      file.path((if (draft) path_draft else path_archive)(config$root), d$name)
   } else {
     path <-
-      file.path((if (draft) path_draft else path_archive)(config$path), name)
+      file.path((if (draft) path_draft else path_archive)(config$root), name)
     ids <- orderly_list_dir(path)
   }
 
@@ -102,19 +102,19 @@ orderly_latest <- function(name = NULL, path = NULL, locate = TRUE,
 ##'
 ##' @export
 ##' @author Rich FitzJohn
-orderly_open <- function(id, name = NULL, path = NULL, locate = TRUE,
+orderly_open <- function(id, name = NULL, root = NULL, locate = TRUE,
                          draft = NULL) {
-  path <- orderly_locate(id, name, path, locate, draft, TRUE)
-  open_directory(path)
+  root <- orderly_locate(id, name, root, locate, draft, TRUE)
+  open_directory(root)
 }
 
 ##' @export
 ##' @rdname orderly_open
-orderly_open_latest <- function(name = NULL, path = NULL, locate = TRUE,
+orderly_open_latest <- function(name = NULL, root = NULL, locate = TRUE,
                                 draft = FALSE) {
-  id <- orderly_latest(name, path, locate, draft, TRUE)
-  path <- orderly_locate(id, name, path, locate, draft, TRUE)
-  open_directory(path)
+  id <- orderly_latest(name, root, locate, draft, TRUE)
+  root <- orderly_locate(id, name, root, locate, draft, TRUE)
+  open_directory(root)
 }
 
 ##' Find the last id that was run
@@ -122,20 +122,20 @@ orderly_open_latest <- function(name = NULL, path = NULL, locate = TRUE,
 ##' @inheritParams orderly_list
 ##' @param draft Find draft reports?
 ##' @export
-orderly_last_id <- function(path = NULL, locate = TRUE, draft = TRUE) {
-  config <- orderly_config_get(path, locate)
+orderly_last_id <- function(root = NULL, locate = TRUE, draft = TRUE) {
+  config <- orderly_config_get(root, locate)
   path <- if (draft) path_draft else path_archive
-  check <- list_dirs(path(config$path))
+  check <- list_dirs(path(config$root))
 
   d <- orderly_list2(draft, config, FALSE)
   latest_id(d$id)
 }
 
 
-orderly_list2 <- function(draft, path = NULL, locate = TRUE) {
-  config <- orderly_config_get(path, locate)
+orderly_list2 <- function(draft, root = NULL, locate = TRUE) {
+  config <- orderly_config_get(root, locate)
   path <- if (draft) path_draft else path_archive
-  check <- list_dirs(path(config$path))
+  check <- list_dirs(path(config$root))
   res <- lapply(check, orderly_list_dir)
   data.frame(name = rep(basename(check), lengths(res)),
              id = as.character(unlist(res)),
@@ -145,7 +145,7 @@ orderly_list2 <- function(draft, path = NULL, locate = TRUE) {
 orderly_find_name <- function(id, config, locate = FALSE, draft = TRUE,
                               must_work = FALSE) {
   config <- orderly_config_get(config, locate)
-  path <- (if (draft) path_draft else path_archive)(config$path)
+  path <- (if (draft) path_draft else path_archive)(config$root)
   ## NOTE: listing draft/archive rather than using orderly_list here
   ## because it allows for the existance of an archived report that we
   ## don't have the source for (VIMC-1013 and a related bug when
@@ -170,7 +170,7 @@ orderly_find_report <- function(id, name, config, locate = FALSE,
   ## TODO: I don't think that the treatment of draft is OK here - we
   ## should allow reports to roll over into archive gracefully.
   path <-
-    file.path((if (draft) path_draft else path_archive)(config$path), name)
+    file.path((if (draft) path_draft else path_archive)(config$root), name)
   if (id == "latest") {
     id <- orderly_latest(name, config, FALSE,
                          draft = draft, must_work = must_work)
@@ -215,9 +215,9 @@ latest_id <- function(ids) {
 ## This is annoyingly similar to orderly_find_report, but allows for
 ## draft and name to be NULL.  It's used only in tests and in the
 ## orderly_open function
-orderly_locate <- function(id, name, path = NULL, locate = TRUE,
+orderly_locate <- function(id, name, root = NULL, locate = TRUE,
                            draft = NULL, must_work = TRUE) {
-  config <- orderly_config_get(path, locate)
+  config <- orderly_config_get(root, locate)
   if (id == "latest") {
     if (is.null(name)) {
       stop("name must be given for id = 'latest'")
@@ -244,7 +244,7 @@ orderly_locate <- function(id, name, path = NULL, locate = TRUE,
   if (is.null(id) || is.null(name)) {
     NULL
   } else {
-    path <- (if (draft) path_draft else path_archive)(config$path)
+    path <- (if (draft) path_draft else path_archive)(config$root)
     file.path(path, name, id)
   }
 }

--- a/R/query.R
+++ b/R/query.R
@@ -10,8 +10,9 @@ VERSION_ID_RE <- "^([0-9]{8}-[0-9]{6})-([[:xdigit:]]{4})([[:xdigit:]]{4})$"
 ##'
 ##' @title List orderly reports
 ##'
-##' @param config An orderly configuration, or the path to one (or
-##'   \code{NULL} to locate one if \code{locate} is \code{TRUE}).
+##' @param path The path to an orderly root directoy, or \code{NULL}
+##'   (the default) to search for one from the current working
+##'   directory if \code{locate} is \code{TRUE}).
 ##'
 ##' @param locate Logical, indicating if the configuration should be
 ##'   searched for.  If \code{TRUE} and \code{config} is not given,
@@ -19,8 +20,8 @@ VERSION_ID_RE <- "^([0-9]{8}-[0-9]{6})-([[:xdigit:]]{4})([[:xdigit:]]{4})$"
 ##'   parents until it finds an \code{orderly_config.yml} file.
 ##'
 ##' @export
-orderly_list <- function(config = NULL, locate = TRUE) {
-  config <- orderly_config_get(config, locate)
+orderly_list <- function(path = NULL, locate = TRUE) {
+  config <- orderly_config_get(path, locate)
   basename(list_dirs(path_src(config$path)))
 }
 
@@ -31,14 +32,14 @@ orderly_list <- function(config = NULL, locate = TRUE) {
 ##' @title List draft and archived reports
 ##' @inheritParams orderly_list
 ##' @export
-orderly_list_drafts <- function(config = NULL, locate = TRUE) {
-  orderly_list2(TRUE, config, locate)
+orderly_list_drafts <- function(path = NULL, locate = TRUE) {
+  orderly_list2(TRUE, path, locate)
 }
 
 ##' @export
 ##' @rdname orderly_list_drafts
-orderly_list_archive <- function(config = NULL, locate = TRUE) {
-  orderly_list2(FALSE, config, locate)
+orderly_list_archive <- function(path = NULL, locate = TRUE) {
+  orderly_list2(FALSE, path, locate)
 }
 
 ##' Find most recent version of an orderly report
@@ -54,9 +55,9 @@ orderly_list_archive <- function(config = NULL, locate = TRUE) {
 ##'
 ##' @inheritParams orderly_list
 ##' @export
-orderly_latest <- function(name = NULL, config = NULL, locate = TRUE,
+orderly_latest <- function(name = NULL, path = NULL, locate = TRUE,
                            draft = FALSE, must_work = TRUE) {
-  config <- orderly_config_get(config, locate)
+  config <- orderly_config_get(path, locate)
 
   if (is.null(name)) {
     d <- orderly_list2(draft, config, FALSE)
@@ -101,18 +102,18 @@ orderly_latest <- function(name = NULL, config = NULL, locate = TRUE,
 ##'
 ##' @export
 ##' @author Rich FitzJohn
-orderly_open <- function(id, name = NULL, config = NULL, locate = TRUE,
+orderly_open <- function(id, name = NULL, path = NULL, locate = TRUE,
                          draft = NULL) {
-  path <- orderly_locate(id, name, config, locate, draft, TRUE)
+  path <- orderly_locate(id, name, path, locate, draft, TRUE)
   open_directory(path)
 }
 
 ##' @export
 ##' @rdname orderly_open
-orderly_open_latest <- function(name = NULL, config = NULL, locate = TRUE,
+orderly_open_latest <- function(name = NULL, path = NULL, locate = TRUE,
                                 draft = FALSE) {
-  id <- orderly_latest(name, config, locate, draft, TRUE)
-  path <- orderly_locate(id, name, config, locate, draft, TRUE)
+  id <- orderly_latest(name, path, locate, draft, TRUE)
+  path <- orderly_locate(id, name, path, locate, draft, TRUE)
   open_directory(path)
 }
 
@@ -121,8 +122,8 @@ orderly_open_latest <- function(name = NULL, config = NULL, locate = TRUE,
 ##' @inheritParams orderly_list
 ##' @param draft Find draft reports?
 ##' @export
-orderly_last_id <- function(config = NULL, locate = TRUE, draft = TRUE) {
-  config <- orderly_config_get(config, locate)
+orderly_last_id <- function(path = NULL, locate = TRUE, draft = TRUE) {
+  config <- orderly_config_get(path, locate)
   path <- if (draft) path_draft else path_archive
   check <- list_dirs(path(config$path))
 
@@ -130,8 +131,9 @@ orderly_last_id <- function(config = NULL, locate = TRUE, draft = TRUE) {
   latest_id(d$id)
 }
 
-orderly_list2 <- function(draft, config = NULL, locate = TRUE) {
-  config <- orderly_config_get(config, locate)
+
+orderly_list2 <- function(draft, path = NULL, locate = TRUE) {
+  config <- orderly_config_get(path, locate)
   path <- if (draft) path_draft else path_archive
   check <- list_dirs(path(config$path))
   res <- lapply(check, orderly_list_dir)
@@ -213,9 +215,9 @@ latest_id <- function(ids) {
 ## This is annoyingly similar to orderly_find_report, but allows for
 ## draft and name to be NULL.  It's used only in tests and in the
 ## orderly_open function
-orderly_locate <- function(id, name, config = NULL, locate = TRUE,
+orderly_locate <- function(id, name, path = NULL, locate = TRUE,
                            draft = NULL, must_work = TRUE) {
-  config <- orderly_config_get(config, locate)
+  config <- orderly_config_get(path, locate)
   if (id == "latest") {
     if (is.null(name)) {
       stop("name must be given for id = 'latest'")

--- a/R/recipe_commit.R
+++ b/R/recipe_commit.R
@@ -8,8 +8,8 @@
 ##'
 ##' @inheritParams orderly_list
 ##' @export
-orderly_commit <- function(id, name = NULL, config = NULL, locate = TRUE) {
-  config <- orderly_config_get(config, locate)
+orderly_commit <- function(id, name = NULL, path = NULL, locate = TRUE) {
+  config <- orderly_config_get(path, locate)
   check_orderly_archive_version(config)
   if (is.null(name)) {
     name <- orderly_find_name(id, config, draft = TRUE, must_work = TRUE)

--- a/R/recipe_commit.R
+++ b/R/recipe_commit.R
@@ -8,18 +8,18 @@
 ##'
 ##' @inheritParams orderly_list
 ##' @export
-orderly_commit <- function(id, name = NULL, path = NULL, locate = TRUE) {
-  config <- orderly_config_get(path, locate)
+orderly_commit <- function(id, name = NULL, root = NULL, locate = TRUE) {
+  config <- orderly_config_get(root, locate)
   check_orderly_archive_version(config)
   if (is.null(name)) {
     name <- orderly_find_name(id, config, draft = TRUE, must_work = TRUE)
   } else {
-    if (!file.exists(file.path(path_draft(config$path), name, id))) {
+    if (!file.exists(file.path(path_draft(config$root), name, id))) {
       stop(sprintf("Did not find draft report %s/%s", name, id))
     }
   }
-  workdir <- file.path(path_draft(config$path), name, id)
-  recipe_commit(workdir, config$path)
+  workdir <- file.path(path_draft(config$root), name, id)
+  recipe_commit(workdir, config$root)
 }
 
 recipe_commit <- function(workdir, config) {
@@ -69,7 +69,7 @@ recipe_commit <- function(workdir, config) {
 copy_report <- function(workdir, name, config) {
   assert_is(config, "orderly_config")
   id <- basename(workdir)
-  parent <- path_archive(config$path, name)
+  parent <- path_archive(config$root, name)
   dest <- file.path(parent, id)
   if (file.exists(dest)) {
     ## This situation probably needs help to resolve but I don't know

--- a/R/recipe_run.R
+++ b/R/recipe_run.R
@@ -41,12 +41,12 @@
 ##' @param id_file Write the identifier into a file
 ##' @export
 orderly_run <- function(name, parameters = NULL, envir = NULL,
-                        config = NULL, locate = TRUE, echo = TRUE,
+                        path = NULL, locate = TRUE, echo = TRUE,
                         id_file = NULL, fetch = FALSE, ref = NULL,
                         open = FALSE, message = NULL, extended_output = FALSE) {
   assert_scalar_logical(open)
   envir <- orderly_environment(envir)
-  config <- orderly_config_get(config, locate)
+  config <- orderly_config_get(path, locate)
   check_orderly_archive_version(config)
 
   info <- recipe_prepare(config, name, id_file, ref, fetch, message)
@@ -68,8 +68,8 @@ orderly_run <- function(name, parameters = NULL, envir = NULL,
 ##' @export
 ##' @rdname orderly_run
 orderly_data <- function(name, parameters = NULL, envir = NULL,
-                         config = NULL, locate = TRUE) {
-  config <- orderly_config_get(config, locate)
+                         path = NULL, locate = TRUE) {
+  config <- orderly_config_get(path, locate)
   info <- recipe_read(file.path(path_src(config$path), name), config)
   envir <- orderly_environment(envir)
   recipe_data(config, info, parameters, envir)
@@ -92,12 +92,12 @@ orderly_data <- function(name, parameters = NULL, envir = NULL,
 ##' @inheritParams orderly_run
 ##' @export
 orderly_test_start <- function(name, parameters = NULL, envir = .GlobalEnv,
-                               config = NULL, locate = TRUE) {
+                               path = NULL, locate = TRUE) {
   if (!is.null(cache$test)) {
     stop("Already running in test mode")
   }
 
-  config <- orderly_config_get(config, locate)
+  config <- orderly_config_get(path, locate)
   ## TODO: support ref here
   info <- recipe_prepare(config, name, id_file = NULL, ref = NULL,
                          fetch = FALSE, message = NULL)
@@ -151,7 +151,7 @@ orderly_test_restart <- function(cleanup = TRUE) {
   parameters <- cache$test$parameters
   config <- cache$test$config
   orderly_test_end(cleanup)
-  orderly_test_start(name, parameters, config = config)
+  orderly_test_start(name, parameters, path = config)
 }
 
 ##' @export

--- a/R/remote.R
+++ b/R/remote.R
@@ -24,11 +24,11 @@
 ##'
 ##' @inheritParams orderly_list
 ##' @export
-pull_dependencies <- function(name, path = NULL, locate = TRUE, remote = NULL) {
-  config <- orderly_config_get(path, locate)
+pull_dependencies <- function(name, root = NULL, locate = TRUE, remote = NULL) {
+  config <- orderly_config_get(root, locate)
   remote <- get_remote(remote, config)
 
-  path <- file.path(path_src(config$path), name)
+  path <- file.path(path_src(config$root), name)
   depends <- recipe_read(path, config, FALSE)$depends
 
   for (i in seq_len(nrow(depends))) {
@@ -44,9 +44,9 @@ pull_dependencies <- function(name, path = NULL, locate = TRUE, remote = NULL) {
 ##'
 ##' @param id The identifier (for \code{pull_archive}.  The default is
 ##'   to use the latest report.
-pull_archive <- function(name, id = "latest", path = NULL, locate = TRUE,
+pull_archive <- function(name, id = "latest", root = NULL, locate = TRUE,
                          remote = NULL) {
-  config <- orderly_config_get(path, locate)
+  config <- orderly_config_get(root, locate)
   remote <- get_remote(remote, config)
 
   v <- remote_report_versions(name, config, FALSE, remote)
@@ -67,12 +67,12 @@ pull_archive <- function(name, id = "latest", path = NULL, locate = TRUE,
       call. = FALSE)
   }
 
-  dest <- file.path(path_archive(config$path), name, id)
+  dest <- file.path(path_archive(config$root), name, id)
   if (file.exists(dest)) {
     orderly_log("pull", sprintf("%s:%s already exists, skipping", name, id))
   } else {
     orderly_log("pull", sprintf("%s:%s", name, id))
-    remote$pull(name, id, config$path)
+    remote$pull(name, id, config$root)
   }
 }
 
@@ -87,9 +87,9 @@ pull_archive <- function(name, id = "latest", path = NULL, locate = TRUE,
 ##' @title Push an archive report to a remote location
 ##' @inheritParams pull_dependencies
 ##' @export
-push_archive <- function(name, id = "latest", path = NULL, locate = TRUE,
+push_archive <- function(name, id = "latest", root = NULL, locate = TRUE,
                          remote = NULL) {
-  config <- orderly_config_get(path, locate)
+  config <- orderly_config_get(root, locate)
   remote <- get_remote(remote, config)
 
   if (id == "latest") {
@@ -101,7 +101,7 @@ push_archive <- function(name, id = "latest", path = NULL, locate = TRUE,
     orderly_log("push", sprintf("%s:%s already exists, skipping", name, id))
   } else {
     orderly_log("push", sprintf("%s:%s", name, id))
-    remote$push(name, id, config$path)
+    remote$push(name, id, config$root)
   }
 }
 
@@ -152,8 +152,8 @@ orderly_run_remote <- function(name, parameters = NULL, ref = NULL,
                                open = TRUE, stop_on_error = TRUE,
                                stop_on_timeout = TRUE,
                                progress = TRUE,
-                               path = NULL, locate = TRUE, remote = NULL) {
-  remote <- get_remote(remote, orderly_config_get(path, locate))
+                               root = NULL, locate = TRUE, remote = NULL) {
+  remote <- get_remote(remote, orderly_config_get(root, locate))
   remote$run(name, parameters = parameters, ref = ref,
              timeout = timeout, wait = wait, poll = poll, progress = progress,
              stop_on_error = stop_on_error, stop_on_timeout = stop_on_timeout,
@@ -175,13 +175,13 @@ orderly_run_remote <- function(name, parameters = NULL, ref = NULL,
 ##' @inheritParams orderly_run_remote
 ##' @export
 orderly_publish_remote <- function(name, id, value = TRUE,
-                                   path = NULL, locate = TRUE,
+                                   root = NULL, locate = TRUE,
                                    remote = NULL) {
   assert_scalar_character(name)
   assert_scalar_character(id)
   assert_scalar_logical(value)
 
-  config <- orderly_config_get(path, locate)
+  config <- orderly_config_get(root, locate)
   remote <- get_remote(remote, config)
   remote$publish(name, id, value)
 }
@@ -194,8 +194,8 @@ orderly_publish_remote <- function(name, id, value = TRUE,
 ##' @inheritParams orderly_list
 ##' @export
 ##' @rdname default_remote
-set_default_remote <- function(value, path = NULL, locate = TRUE) {
-  config <- orderly_config_get(path, locate)
+set_default_remote <- function(value, root = NULL, locate = TRUE) {
+  config <- orderly_config_get(root, locate)
 
   if (is.null(value)) {
     remote <- NULL
@@ -204,16 +204,16 @@ set_default_remote <- function(value, path = NULL, locate = TRUE) {
     remote <- get_remote(value, config)
   }
 
-  cache$default_remote[[config$path]] <- remote
+  cache$default_remote[[config$root]] <- remote
   invisible(remote)
 }
 
 
 ##' @rdname default_remote
-get_default_remote <- function(path = NULL, locate = TRUE) {
-  config <- orderly_config_get(path, locate)
-  if (!is.null(cache$default_remote[[config$path]])) {
-    return(cache$default_remote[[config$path]])
+get_default_remote <- function(root = NULL, locate = TRUE) {
+  config <- orderly_config_get(root, locate)
+  if (!is.null(cache$default_remote[[config$root]])) {
+    return(cache$default_remote[[config$root]])
   }
   if (length(config$remote) > 0L) {
     return(get_remote(names(config$remote)[[1L]], config))
@@ -259,8 +259,8 @@ load_remote <- function(name, config) {
 
 
 ## Most of these functions can really shrink now?
-remote_report_names <- function(path = NULL, locate = TRUE, remote = NULL) {
-  remote <- get_remote(remote, orderly_config_get(path, locate))
+remote_report_names <- function(root = NULL, locate = TRUE, remote = NULL) {
+  remote <- get_remote(remote, orderly_config_get(root, locate))
   remote$list_reports()
 }
 

--- a/R/remote.R
+++ b/R/remote.R
@@ -24,8 +24,8 @@
 ##'
 ##' @inheritParams orderly_list
 ##' @export
-pull_dependencies <- function(name, config = NULL, locate = TRUE, remote = NULL) {
-  config <- orderly_config_get(config, locate)
+pull_dependencies <- function(name, path = NULL, locate = TRUE, remote = NULL) {
+  config <- orderly_config_get(path, locate)
   remote <- get_remote(remote, config)
 
   path <- file.path(path_src(config$path), name)
@@ -44,9 +44,9 @@ pull_dependencies <- function(name, config = NULL, locate = TRUE, remote = NULL)
 ##'
 ##' @param id The identifier (for \code{pull_archive}.  The default is
 ##'   to use the latest report.
-pull_archive <- function(name, id = "latest", config = NULL, locate = TRUE,
+pull_archive <- function(name, id = "latest", path = NULL, locate = TRUE,
                          remote = NULL) {
-  config <- orderly_config_get(config, locate)
+  config <- orderly_config_get(path, locate)
   remote <- get_remote(remote, config)
 
   v <- remote_report_versions(name, config, FALSE, remote)
@@ -87,9 +87,9 @@ pull_archive <- function(name, id = "latest", config = NULL, locate = TRUE,
 ##' @title Push an archive report to a remote location
 ##' @inheritParams pull_dependencies
 ##' @export
-push_archive <- function(name, id = "latest", config = NULL, locate = TRUE,
+push_archive <- function(name, id = "latest", path = NULL, locate = TRUE,
                          remote = NULL) {
-  config <- orderly_config_get(config, locate)
+  config <- orderly_config_get(path, locate)
   remote <- get_remote(remote, config)
 
   if (id == "latest") {
@@ -152,8 +152,8 @@ orderly_run_remote <- function(name, parameters = NULL, ref = NULL,
                                open = TRUE, stop_on_error = TRUE,
                                stop_on_timeout = TRUE,
                                progress = TRUE,
-                               config = NULL, locate = TRUE, remote = NULL) {
-  remote <- get_remote(remote, orderly_config_get(config, locate))
+                               path = NULL, locate = TRUE, remote = NULL) {
+  remote <- get_remote(remote, orderly_config_get(path, locate))
   remote$run(name, parameters = parameters, ref = ref,
              timeout = timeout, wait = wait, poll = poll, progress = progress,
              stop_on_error = stop_on_error, stop_on_timeout = stop_on_timeout,
@@ -175,13 +175,13 @@ orderly_run_remote <- function(name, parameters = NULL, ref = NULL,
 ##' @inheritParams orderly_run_remote
 ##' @export
 orderly_publish_remote <- function(name, id, value = TRUE,
-                                   config = NULL, locate = TRUE,
+                                   path = NULL, locate = TRUE,
                                    remote = NULL) {
   assert_scalar_character(name)
   assert_scalar_character(id)
   assert_scalar_logical(value)
 
-  config <- orderly_config_get(config, locate)
+  config <- orderly_config_get(path, locate)
   remote <- get_remote(remote, config)
   remote$publish(name, id, value)
 }
@@ -194,8 +194,8 @@ orderly_publish_remote <- function(name, id, value = TRUE,
 ##' @inheritParams orderly_list
 ##' @export
 ##' @rdname default_remote
-set_default_remote <- function(value, config = NULL, locate = TRUE) {
-  config <- orderly_config_get(config, locate)
+set_default_remote <- function(value, path = NULL, locate = TRUE) {
+  config <- orderly_config_get(path, locate)
 
   if (is.null(value)) {
     remote <- NULL
@@ -210,8 +210,8 @@ set_default_remote <- function(value, config = NULL, locate = TRUE) {
 
 
 ##' @rdname default_remote
-get_default_remote <- function(config = NULL, locate = TRUE) {
-  config <- orderly_config_get(config, locate)
+get_default_remote <- function(path = NULL, locate = TRUE) {
+  config <- orderly_config_get(path, locate)
   if (!is.null(cache$default_remote[[config$path]])) {
     return(cache$default_remote[[config$path]])
   }
@@ -259,8 +259,8 @@ load_remote <- function(name, config) {
 
 
 ## Most of these functions can really shrink now?
-remote_report_names <- function(config = NULL, locate = TRUE, remote = NULL) {
-  remote <- get_remote(remote, orderly_config_get(config, locate))
+remote_report_names <- function(path = NULL, locate = TRUE, remote = NULL) {
+  remote <- get_remote(remote, orderly_config_get(path, locate))
   remote$list_reports()
 }
 

--- a/R/remote_path.R
+++ b/R/remote_path.R
@@ -21,7 +21,7 @@ R6_orderly_remote_path <- R6::R6Class(
         stop("Does not look like an orderly repository: ", squote(path))
       }
       self$config <- orderly_config(path)
-      self$name <- name %||% self$config$path
+      self$name <- name %||% self$config$root
       lockBinding(quote(config), self)
       lockBinding(quote(name), self)
     },
@@ -36,19 +36,19 @@ R6_orderly_remote_path <- R6::R6Class(
     },
 
     pull = function(name, id, root) {
-      src <- file.path(path_archive(self$config$path), name, id)
+      src <- file.path(path_archive(self$config$root), name, id)
       dest <- file.path(path_archive(root), name, id)
       copy_directory(src, dest, TRUE)
     },
 
     push = function(name, id, root) {
       src <- file.path(path_archive(root), name, id)
-      dest <- file.path(path_archive(self$config$path), name, id)
+      dest <- file.path(path_archive(self$config$root), name, id)
       copy_directory(src, dest, rollback_on_error = TRUE)
     },
 
     publish = function(name, id, value = TRUE) {
-      orderly_publish(id, value = value, name = name, path = self$config)
+      orderly_publish(id, value = value, name = name, root = self$config)
     },
 
     run = function(...) {

--- a/R/remote_path.R
+++ b/R/remote_path.R
@@ -48,7 +48,7 @@ R6_orderly_remote_path <- R6::R6Class(
     },
 
     publish = function(name, id, value = TRUE) {
-      orderly_publish(id, value = value, name = name, config = self$config)
+      orderly_publish(id, value = value, name = name, path = self$config)
     },
 
     run = function(...) {

--- a/R/runner.R
+++ b/R/runner.R
@@ -146,7 +146,7 @@ R6_orderly_runner <- R6::R6Class(
     ## doesn't take too much to do (write one file and write to the
     ## SQL database)
     publish = function(name, id, value = TRUE) {
-      orderly_publish(id, value, name, path = self$config)
+      orderly_publish(id, value, name, root = self$config)
       value
     },
 
@@ -190,7 +190,7 @@ R6_orderly_runner <- R6::R6Class(
 
     cleanup = function(name = NULL, draft = TRUE, data = TRUE,
                        failed_only = FALSE) {
-      orderly_cleanup(name = name, path = self$config, draft = draft,
+      orderly_cleanup(name = name, root = self$config, draft = draft,
                       data = data, failed_only = failed_only)
     },
 
@@ -400,7 +400,7 @@ runner_allow_ref <- function(allow_ref, config) {
     allow_ref <- !(config$server_options$master_only %||% FALSE)
   }
   if (allow_ref) {
-    res <- git_run(c("rev-parse", "HEAD"), root = config$path, check = FALSE)
+    res <- git_run(c("rev-parse", "HEAD"), root = config$root, check = FALSE)
     allow_ref <- res$success
   }
   allow_ref

--- a/R/runner.R
+++ b/R/runner.R
@@ -146,7 +146,7 @@ R6_orderly_runner <- R6::R6Class(
     ## doesn't take too much to do (write one file and write to the
     ## SQL database)
     publish = function(name, id, value = TRUE) {
-      orderly_publish(id, value, name, config = self$config)
+      orderly_publish(id, value, name, path = self$config)
       value
     },
 
@@ -190,7 +190,7 @@ R6_orderly_runner <- R6::R6Class(
 
     cleanup = function(name = NULL, draft = TRUE, data = TRUE,
                        failed_only = FALSE) {
-      orderly_cleanup(name = name, config = self$config, draft = draft,
+      orderly_cleanup(name = name, path = self$config, draft = draft,
                       data = data, failed_only = failed_only)
     },
 

--- a/R/testing.R
+++ b/R/testing.R
@@ -21,10 +21,10 @@ run_orderly_demo <- function(path) {
     if (!is.null(x$before)) {
       withr::with_dir(path, x$before())
     }
-    id <- orderly_run(x$name, x$parameters, echo = FALSE, path = path)
+    id <- orderly_run(x$name, x$parameters, echo = FALSE, root = path)
     id_new <- demo_change_time(id, x$time, path)
     if (isTRUE(x$publish)) {
-      orderly_publish(id_new, path = path)
+      orderly_publish(id_new, root = path)
     }
   }
 
@@ -65,7 +65,7 @@ prepare_orderly_example <- function(name, path = tempfile()) {
   } else {
     generator <- fake_db
   }
-  con <- orderly_db("source", path = path)
+  con <- orderly_db("source", root = path)
   on.exit(lapply(con, DBI::dbDisconnect))
   if (length(con) > 0L) {
     generator(con)
@@ -125,7 +125,7 @@ demo_change_time <- function(id, time, path) {
     changelog_save_json(changelog, p)
   }
 
-  orderly_commit(id_new, name, path = path)
+  orderly_commit(id_new, name, root = path)
 
   id_new
 }
@@ -197,8 +197,8 @@ prepare_orderly_git_example <- function(path = tempfile(), run_report = FALSE) {
   git_run(c("commit", "-m", "orderly"), path_upstream)
 
   if (run_report) {
-    id <- orderly_run("minimal", path = path)
-    orderly_commit(id, path = path)
+    id <- orderly_run("minimal", root = path)
+    orderly_commit(id, root = path)
   }
 
   c(origin = path_upstream, local = path)

--- a/R/testing.R
+++ b/R/testing.R
@@ -21,10 +21,10 @@ run_orderly_demo <- function(path) {
     if (!is.null(x$before)) {
       withr::with_dir(path, x$before())
     }
-    id <- orderly_run(x$name, x$parameters, echo = FALSE, config = path)
+    id <- orderly_run(x$name, x$parameters, echo = FALSE, path = path)
     id_new <- demo_change_time(id, x$time, path)
     if (isTRUE(x$publish)) {
-      orderly_publish(id_new, config = path)
+      orderly_publish(id_new, path = path)
     }
   }
 
@@ -65,7 +65,7 @@ prepare_orderly_example <- function(name, path = tempfile()) {
   } else {
     generator <- fake_db
   }
-  con <- orderly_db("source", config = path)
+  con <- orderly_db("source", path = path)
   on.exit(lapply(con, DBI::dbDisconnect))
   if (length(con) > 0L) {
     generator(con)
@@ -125,7 +125,7 @@ demo_change_time <- function(id, time, path) {
     changelog_save_json(changelog, p)
   }
 
-  orderly_commit(id_new, name, config = path)
+  orderly_commit(id_new, name, path = path)
 
   id_new
 }
@@ -197,8 +197,8 @@ prepare_orderly_git_example <- function(path = tempfile(), run_report = FALSE) {
   git_run(c("commit", "-m", "orderly"), path_upstream)
 
   if (run_report) {
-    id <- orderly_run("minimal", config = path)
-    orderly_commit(id, config = path)
+    id <- orderly_run("minimal", path = path)
+    orderly_commit(id, path = path)
   }
 
   c(origin = path_upstream, local = path)

--- a/R/vault.R
+++ b/R/vault.R
@@ -10,7 +10,7 @@ resolve_secrets <- function(x, config) {
     if (any(i)) {
       loadNamespace("vaultr")
       vault <- withr::with_envvar(
-        orderly_envir_read(config$path),
+        orderly_envir_read(config$root),
         vaultr::vault_client(login = TRUE, addr = config$vault_server))
       key <- unname(sub(re, "\\1", x[i]))
       field <- unname(sub(re, "\\2", x[i]))

--- a/inst/migrate/0.5.0.R
+++ b/inst/migrate/0.5.0.R
@@ -25,7 +25,7 @@ migrate <- function(data, path, config) {
   is_pinned <- id_requested != "latest"
 
   if (any(is_pinned)) {
-    archive <- get_order(config$path)
+    archive <- get_order(config$root)
     tmp <- archive[archive$id < data$meta$id &
                    archive$name %in% data$meta$depends$name, ]
     is_latest <- id_requested %in% tapply(tmp$id, tmp$name, max)
@@ -50,7 +50,7 @@ migrate <- function(data, path, config) {
   ## link.
   d <- data$meta$depends
 
-  p <- unique(file.path(path_archive(config$path), d$name, d$id))
+  p <- unique(file.path(path_archive(config$root), d$name, d$id))
   valid <- lapply(path_orderly_run_rds(p), function(x)
     names(readRDS(x)$meta$hash_artefacts))
   names(valid) <- basename(p)

--- a/man/default_remote.Rd
+++ b/man/default_remote.Rd
@@ -5,14 +5,14 @@
 \alias{get_default_remote}
 \title{Set default remote location}
 \usage{
-set_default_remote(value, path = NULL, locate = TRUE)
+set_default_remote(value, root = NULL, locate = TRUE)
 
-get_default_remote(path = NULL, locate = TRUE)
+get_default_remote(root = NULL, locate = TRUE)
 }
 \arguments{
 \item{value}{A string describing a remote, or \code{NULL} to clear}
 
-\item{path}{The path to an orderly root directoy, or \code{NULL}
+\item{root}{The path to an orderly root directoy, or \code{NULL}
 (the default) to search for one from the current working
 directory if \code{locate} is \code{TRUE}).}
 

--- a/man/default_remote.Rd
+++ b/man/default_remote.Rd
@@ -5,15 +5,16 @@
 \alias{get_default_remote}
 \title{Set default remote location}
 \usage{
-set_default_remote(value, config = NULL, locate = TRUE)
+set_default_remote(value, path = NULL, locate = TRUE)
 
-get_default_remote(config = NULL, locate = TRUE)
+get_default_remote(path = NULL, locate = TRUE)
 }
 \arguments{
 \item{value}{A string describing a remote, or \code{NULL} to clear}
 
-\item{config}{An orderly configuration, or the path to one (or
-\code{NULL} to locate one if \code{locate} is \code{TRUE}).}
+\item{path}{The path to an orderly root directoy, or \code{NULL}
+(the default) to search for one from the current working
+directory if \code{locate} is \code{TRUE}).}
 
 \item{locate}{Logical, indicating if the configuration should be
 searched for.  If \code{TRUE} and \code{config} is not given,

--- a/man/orderly_cleanup.Rd
+++ b/man/orderly_cleanup.Rd
@@ -4,14 +4,15 @@
 \alias{orderly_cleanup}
 \title{Orderly cleanup}
 \usage{
-orderly_cleanup(name = NULL, config = NULL, locate = TRUE,
+orderly_cleanup(name = NULL, path = NULL, locate = TRUE,
   draft = TRUE, data = TRUE, failed_only = FALSE)
 }
 \arguments{
 \item{name}{Optional name; in this case only clean up drafts with this name}
 
-\item{config}{An orderly configuration, or the path to one (or
-\code{NULL} to locate one if \code{locate} is \code{TRUE}).}
+\item{path}{The path to an orderly root directoy, or \code{NULL}
+(the default) to search for one from the current working
+directory if \code{locate} is \code{TRUE}).}
 
 \item{locate}{Logical, indicating if the configuration should be
 searched for.  If \code{TRUE} and \code{config} is not given,

--- a/man/orderly_cleanup.Rd
+++ b/man/orderly_cleanup.Rd
@@ -4,13 +4,13 @@
 \alias{orderly_cleanup}
 \title{Orderly cleanup}
 \usage{
-orderly_cleanup(name = NULL, path = NULL, locate = TRUE,
+orderly_cleanup(name = NULL, root = NULL, locate = TRUE,
   draft = TRUE, data = TRUE, failed_only = FALSE)
 }
 \arguments{
 \item{name}{Optional name; in this case only clean up drafts with this name}
 
-\item{path}{The path to an orderly root directoy, or \code{NULL}
+\item{root}{The path to an orderly root directoy, or \code{NULL}
 (the default) to search for one from the current working
 directory if \code{locate} is \code{TRUE}).}
 

--- a/man/orderly_commit.Rd
+++ b/man/orderly_commit.Rd
@@ -4,7 +4,7 @@
 \alias{orderly_commit}
 \title{Commit a generated report}
 \usage{
-orderly_commit(id, name = NULL, path = NULL, locate = TRUE)
+orderly_commit(id, name = NULL, root = NULL, locate = TRUE)
 }
 \arguments{
 \item{id}{The identifier of the report}
@@ -12,7 +12,7 @@ orderly_commit(id, name = NULL, path = NULL, locate = TRUE)
 \item{name}{The name of the report - this can be omitted and the
 name will be determined from the \code{id}.}
 
-\item{path}{The path to an orderly root directoy, or \code{NULL}
+\item{root}{The path to an orderly root directoy, or \code{NULL}
 (the default) to search for one from the current working
 directory if \code{locate} is \code{TRUE}).}
 

--- a/man/orderly_commit.Rd
+++ b/man/orderly_commit.Rd
@@ -4,7 +4,7 @@
 \alias{orderly_commit}
 \title{Commit a generated report}
 \usage{
-orderly_commit(id, name = NULL, config = NULL, locate = TRUE)
+orderly_commit(id, name = NULL, path = NULL, locate = TRUE)
 }
 \arguments{
 \item{id}{The identifier of the report}
@@ -12,8 +12,9 @@ orderly_commit(id, name = NULL, config = NULL, locate = TRUE)
 \item{name}{The name of the report - this can be omitted and the
 name will be determined from the \code{id}.}
 
-\item{config}{An orderly configuration, or the path to one (or
-\code{NULL} to locate one if \code{locate} is \code{TRUE}).}
+\item{path}{The path to an orderly root directoy, or \code{NULL}
+(the default) to search for one from the current working
+directory if \code{locate} is \code{TRUE}).}
 
 \item{locate}{Logical, indicating if the configuration should be
 searched for.  If \code{TRUE} and \code{config} is not given,

--- a/man/orderly_db.Rd
+++ b/man/orderly_db.Rd
@@ -4,14 +4,15 @@
 \alias{orderly_db}
 \title{Connect to orderly databases}
 \usage{
-orderly_db(type, config = NULL, locate = TRUE, validate = TRUE)
+orderly_db(type, path = NULL, locate = TRUE, validate = TRUE)
 }
 \arguments{
 \item{type}{The type of connection to make (\code{source},
 \code{destination}, \code{csv} or \code{rds}).}
 
-\item{config}{An orderly configuration, or the path to one (or
-\code{NULL} to locate one if \code{locate} is \code{TRUE}).}
+\item{path}{The path to an orderly root directoy, or \code{NULL}
+(the default) to search for one from the current working
+directory if \code{locate} is \code{TRUE}).}
 
 \item{locate}{Logical, indicating if the configuration should be
 searched for.  If \code{TRUE} and \code{config} is not given,

--- a/man/orderly_db.Rd
+++ b/man/orderly_db.Rd
@@ -4,13 +4,13 @@
 \alias{orderly_db}
 \title{Connect to orderly databases}
 \usage{
-orderly_db(type, path = NULL, locate = TRUE, validate = TRUE)
+orderly_db(type, root = NULL, locate = TRUE, validate = TRUE)
 }
 \arguments{
 \item{type}{The type of connection to make (\code{source},
 \code{destination}, \code{csv} or \code{rds}).}
 
-\item{path}{The path to an orderly root directoy, or \code{NULL}
+\item{root}{The path to an orderly root directoy, or \code{NULL}
 (the default) to search for one from the current working
 directory if \code{locate} is \code{TRUE}).}
 

--- a/man/orderly_last_id.Rd
+++ b/man/orderly_last_id.Rd
@@ -4,11 +4,12 @@
 \alias{orderly_last_id}
 \title{Get id of last run report}
 \usage{
-orderly_last_id(config = NULL, locate = TRUE, draft = TRUE)
+orderly_last_id(path = NULL, locate = TRUE, draft = TRUE)
 }
 \arguments{
-\item{config}{An orderly configuration, or the path to one (or
-\code{NULL} to locate one if \code{locate} is \code{TRUE}).}
+\item{path}{The path to an orderly root directoy, or \code{NULL}
+(the default) to search for one from the current working
+directory if \code{locate} is \code{TRUE}).}
 
 \item{locate}{Logical, indicating if the configuration should be
 searched for.  If \code{TRUE} and \code{config} is not given,

--- a/man/orderly_last_id.Rd
+++ b/man/orderly_last_id.Rd
@@ -4,10 +4,10 @@
 \alias{orderly_last_id}
 \title{Get id of last run report}
 \usage{
-orderly_last_id(path = NULL, locate = TRUE, draft = TRUE)
+orderly_last_id(root = NULL, locate = TRUE, draft = TRUE)
 }
 \arguments{
-\item{path}{The path to an orderly root directoy, or \code{NULL}
+\item{root}{The path to an orderly root directoy, or \code{NULL}
 (the default) to search for one from the current working
 directory if \code{locate} is \code{TRUE}).}
 

--- a/man/orderly_latest.Rd
+++ b/man/orderly_latest.Rd
@@ -4,14 +4,14 @@
 \alias{orderly_latest}
 \title{Find most recent report}
 \usage{
-orderly_latest(name = NULL, path = NULL, locate = TRUE,
+orderly_latest(name = NULL, root = NULL, locate = TRUE,
   draft = FALSE, must_work = TRUE)
 }
 \arguments{
 \item{name}{Name of the report to find; if \code{NULL} returns the
 most recent report across all names}
 
-\item{path}{The path to an orderly root directoy, or \code{NULL}
+\item{root}{The path to an orderly root directoy, or \code{NULL}
 (the default) to search for one from the current working
 directory if \code{locate} is \code{TRUE}).}
 

--- a/man/orderly_latest.Rd
+++ b/man/orderly_latest.Rd
@@ -4,15 +4,16 @@
 \alias{orderly_latest}
 \title{Find most recent report}
 \usage{
-orderly_latest(name = NULL, config = NULL, locate = TRUE,
+orderly_latest(name = NULL, path = NULL, locate = TRUE,
   draft = FALSE, must_work = TRUE)
 }
 \arguments{
 \item{name}{Name of the report to find; if \code{NULL} returns the
 most recent report across all names}
 
-\item{config}{An orderly configuration, or the path to one (or
-\code{NULL} to locate one if \code{locate} is \code{TRUE}).}
+\item{path}{The path to an orderly root directoy, or \code{NULL}
+(the default) to search for one from the current working
+directory if \code{locate} is \code{TRUE}).}
 
 \item{locate}{Logical, indicating if the configuration should be
 searched for.  If \code{TRUE} and \code{config} is not given,

--- a/man/orderly_list.Rd
+++ b/man/orderly_list.Rd
@@ -4,10 +4,10 @@
 \alias{orderly_list}
 \title{List orderly reports}
 \usage{
-orderly_list(path = NULL, locate = TRUE)
+orderly_list(root = NULL, locate = TRUE)
 }
 \arguments{
-\item{path}{The path to an orderly root directoy, or \code{NULL}
+\item{root}{The path to an orderly root directoy, or \code{NULL}
 (the default) to search for one from the current working
 directory if \code{locate} is \code{TRUE}).}
 

--- a/man/orderly_list.Rd
+++ b/man/orderly_list.Rd
@@ -4,11 +4,12 @@
 \alias{orderly_list}
 \title{List orderly reports}
 \usage{
-orderly_list(config = NULL, locate = TRUE)
+orderly_list(path = NULL, locate = TRUE)
 }
 \arguments{
-\item{config}{An orderly configuration, or the path to one (or
-\code{NULL} to locate one if \code{locate} is \code{TRUE}).}
+\item{path}{The path to an orderly root directoy, or \code{NULL}
+(the default) to search for one from the current working
+directory if \code{locate} is \code{TRUE}).}
 
 \item{locate}{Logical, indicating if the configuration should be
 searched for.  If \code{TRUE} and \code{config} is not given,

--- a/man/orderly_list_drafts.Rd
+++ b/man/orderly_list_drafts.Rd
@@ -5,12 +5,12 @@
 \alias{orderly_list_archive}
 \title{List draft and archived reports}
 \usage{
-orderly_list_drafts(path = NULL, locate = TRUE)
+orderly_list_drafts(root = NULL, locate = TRUE)
 
-orderly_list_archive(path = NULL, locate = TRUE)
+orderly_list_archive(root = NULL, locate = TRUE)
 }
 \arguments{
-\item{path}{The path to an orderly root directoy, or \code{NULL}
+\item{root}{The path to an orderly root directoy, or \code{NULL}
 (the default) to search for one from the current working
 directory if \code{locate} is \code{TRUE}).}
 

--- a/man/orderly_list_drafts.Rd
+++ b/man/orderly_list_drafts.Rd
@@ -5,13 +5,14 @@
 \alias{orderly_list_archive}
 \title{List draft and archived reports}
 \usage{
-orderly_list_drafts(config = NULL, locate = TRUE)
+orderly_list_drafts(path = NULL, locate = TRUE)
 
-orderly_list_archive(config = NULL, locate = TRUE)
+orderly_list_archive(path = NULL, locate = TRUE)
 }
 \arguments{
-\item{config}{An orderly configuration, or the path to one (or
-\code{NULL} to locate one if \code{locate} is \code{TRUE}).}
+\item{path}{The path to an orderly root directoy, or \code{NULL}
+(the default) to search for one from the current working
+directory if \code{locate} is \code{TRUE}).}
 
 \item{locate}{Logical, indicating if the configuration should be
 searched for.  If \code{TRUE} and \code{config} is not given,

--- a/man/orderly_migrate.Rd
+++ b/man/orderly_migrate.Rd
@@ -4,12 +4,13 @@
 \alias{orderly_migrate}
 \title{Migrate an orderly archive}
 \usage{
-orderly_migrate(config = NULL, locate = TRUE, to = NULL,
+orderly_migrate(path = NULL, locate = TRUE, to = NULL,
   verbose = FALSE, dry_run = FALSE, skip_failed = FALSE)
 }
 \arguments{
-\item{config}{An orderly configuration, or the path to one (or
-\code{NULL} to locate one if \code{locate} is \code{TRUE}).}
+\item{path}{The path to an orderly root directoy, or \code{NULL}
+(the default) to search for one from the current working
+directory if \code{locate} is \code{TRUE}).}
 
 \item{locate}{Logical, indicating if the configuration should be
 searched for.  If \code{TRUE} and \code{config} is not given,

--- a/man/orderly_migrate.Rd
+++ b/man/orderly_migrate.Rd
@@ -4,11 +4,11 @@
 \alias{orderly_migrate}
 \title{Migrate an orderly archive}
 \usage{
-orderly_migrate(path = NULL, locate = TRUE, to = NULL,
+orderly_migrate(root = NULL, locate = TRUE, to = NULL,
   verbose = FALSE, dry_run = FALSE, skip_failed = FALSE)
 }
 \arguments{
-\item{path}{The path to an orderly root directoy, or \code{NULL}
+\item{root}{The path to an orderly root directoy, or \code{NULL}
 (the default) to search for one from the current working
 directory if \code{locate} is \code{TRUE}).}
 

--- a/man/orderly_new.Rd
+++ b/man/orderly_new.Rd
@@ -4,13 +4,13 @@
 \alias{orderly_new}
 \title{Create new report}
 \usage{
-orderly_new(name, path = NULL, locate = TRUE, quiet = FALSE,
+orderly_new(name, root = NULL, locate = TRUE, quiet = FALSE,
   template = NULL)
 }
 \arguments{
 \item{name}{Name of the new report (will be a directory name).}
 
-\item{path}{The path to an orderly root directoy, or \code{NULL}
+\item{root}{The path to an orderly root directoy, or \code{NULL}
 (the default) to search for one from the current working
 directory if \code{locate} is \code{TRUE}).}
 

--- a/man/orderly_new.Rd
+++ b/man/orderly_new.Rd
@@ -4,14 +4,15 @@
 \alias{orderly_new}
 \title{Create new report}
 \usage{
-orderly_new(name, config = NULL, locate = TRUE, quiet = FALSE,
+orderly_new(name, path = NULL, locate = TRUE, quiet = FALSE,
   template = NULL)
 }
 \arguments{
 \item{name}{Name of the new report (will be a directory name).}
 
-\item{config}{An orderly configuration, or the path to one (or
-\code{NULL} to locate one if \code{locate} is \code{TRUE}).}
+\item{path}{The path to an orderly root directoy, or \code{NULL}
+(the default) to search for one from the current working
+directory if \code{locate} is \code{TRUE}).}
 
 \item{locate}{Logical, indicating if the configuration should be
 searched for.  If \code{TRUE} and \code{config} is not given,

--- a/man/orderly_open.Rd
+++ b/man/orderly_open.Rd
@@ -5,10 +5,10 @@
 \alias{orderly_open_latest}
 \title{Open directory of completed report}
 \usage{
-orderly_open(id, name = NULL, path = NULL, locate = TRUE,
+orderly_open(id, name = NULL, root = NULL, locate = TRUE,
   draft = NULL)
 
-orderly_open_latest(name = NULL, path = NULL, locate = TRUE,
+orderly_open_latest(name = NULL, root = NULL, locate = TRUE,
   draft = FALSE)
 }
 \arguments{
@@ -18,7 +18,7 @@ which case \code{name} and \code{draft} must be specified}
 \item{name}{The name of the report.  Can be omitted if \code{id}
 is not \code{latest}}
 
-\item{path}{The path to an orderly root directoy, or \code{NULL}
+\item{root}{The path to an orderly root directoy, or \code{NULL}
 (the default) to search for one from the current working
 directory if \code{locate} is \code{TRUE}).}
 

--- a/man/orderly_open.Rd
+++ b/man/orderly_open.Rd
@@ -5,10 +5,10 @@
 \alias{orderly_open_latest}
 \title{Open directory of completed report}
 \usage{
-orderly_open(id, name = NULL, config = NULL, locate = TRUE,
+orderly_open(id, name = NULL, path = NULL, locate = TRUE,
   draft = NULL)
 
-orderly_open_latest(name = NULL, config = NULL, locate = TRUE,
+orderly_open_latest(name = NULL, path = NULL, locate = TRUE,
   draft = FALSE)
 }
 \arguments{
@@ -18,8 +18,9 @@ which case \code{name} and \code{draft} must be specified}
 \item{name}{The name of the report.  Can be omitted if \code{id}
 is not \code{latest}}
 
-\item{config}{An orderly configuration, or the path to one (or
-\code{NULL} to locate one if \code{locate} is \code{TRUE}).}
+\item{path}{The path to an orderly root directoy, or \code{NULL}
+(the default) to search for one from the current working
+directory if \code{locate} is \code{TRUE}).}
 
 \item{locate}{Logical, indicating if the configuration should be
 searched for.  If \code{TRUE} and \code{config} is not given,

--- a/man/orderly_publish.Rd
+++ b/man/orderly_publish.Rd
@@ -4,7 +4,7 @@
 \alias{orderly_publish}
 \title{Publish a report}
 \usage{
-orderly_publish(id, value = TRUE, name = NULL, path = NULL,
+orderly_publish(id, value = TRUE, name = NULL, root = NULL,
   locate = TRUE)
 }
 \arguments{
@@ -16,7 +16,7 @@ or \code{FALSE}.}
 \item{name}{Optional report name.  If not given, then the name
 will be determined from the \code{id}}
 
-\item{path}{The path to an orderly root directoy, or \code{NULL}
+\item{root}{The path to an orderly root directoy, or \code{NULL}
 (the default) to search for one from the current working
 directory if \code{locate} is \code{TRUE}).}
 

--- a/man/orderly_publish.Rd
+++ b/man/orderly_publish.Rd
@@ -4,7 +4,7 @@
 \alias{orderly_publish}
 \title{Publish a report}
 \usage{
-orderly_publish(id, value = TRUE, name = NULL, config = NULL,
+orderly_publish(id, value = TRUE, name = NULL, path = NULL,
   locate = TRUE)
 }
 \arguments{
@@ -16,8 +16,9 @@ or \code{FALSE}.}
 \item{name}{Optional report name.  If not given, then the name
 will be determined from the \code{id}}
 
-\item{config}{An orderly configuration, or the path to one (or
-\code{NULL} to locate one if \code{locate} is \code{TRUE}).}
+\item{path}{The path to an orderly root directoy, or \code{NULL}
+(the default) to search for one from the current working
+directory if \code{locate} is \code{TRUE}).}
 
 \item{locate}{Logical, indicating if the configuration should be
 searched for.  If \code{TRUE} and \code{config} is not given,

--- a/man/orderly_publish_remote.Rd
+++ b/man/orderly_publish_remote.Rd
@@ -4,7 +4,7 @@
 \alias{orderly_publish_remote}
 \title{Publish orderly report on remote server}
 \usage{
-orderly_publish_remote(name, id, value = TRUE, path = NULL,
+orderly_publish_remote(name, id, value = TRUE, root = NULL,
   locate = TRUE, remote = NULL)
 }
 \arguments{
@@ -16,7 +16,7 @@ orderly_publish_remote(name, id, value = TRUE, path = NULL,
 \item{value}{As \code{\link{orderly_publish}}, \code{TRUE} or
 \code{FALSE} to publish or unpublish a report (respectively)}
 
-\item{path}{The path to an orderly root directoy, or \code{NULL}
+\item{root}{The path to an orderly root directoy, or \code{NULL}
 (the default) to search for one from the current working
 directory if \code{locate} is \code{TRUE}).}
 

--- a/man/orderly_publish_remote.Rd
+++ b/man/orderly_publish_remote.Rd
@@ -4,7 +4,7 @@
 \alias{orderly_publish_remote}
 \title{Publish orderly report on remote server}
 \usage{
-orderly_publish_remote(name, id, value = TRUE, config = NULL,
+orderly_publish_remote(name, id, value = TRUE, path = NULL,
   locate = TRUE, remote = NULL)
 }
 \arguments{
@@ -16,8 +16,9 @@ orderly_publish_remote(name, id, value = TRUE, config = NULL,
 \item{value}{As \code{\link{orderly_publish}}, \code{TRUE} or
 \code{FALSE} to publish or unpublish a report (respectively)}
 
-\item{config}{An orderly configuration, or the path to one (or
-\code{NULL} to locate one if \code{locate} is \code{TRUE}).}
+\item{path}{The path to an orderly root directoy, or \code{NULL}
+(the default) to search for one from the current working
+directory if \code{locate} is \code{TRUE}).}
 
 \item{locate}{Logical, indicating if the configuration should be
 searched for.  If \code{TRUE} and \code{config} is not given,

--- a/man/orderly_rebuild.Rd
+++ b/man/orderly_rebuild.Rd
@@ -4,12 +4,13 @@
 \alias{orderly_rebuild}
 \title{Rebuild the report database}
 \usage{
-orderly_rebuild(config = NULL, locate = TRUE, verbose = TRUE,
+orderly_rebuild(path = NULL, locate = TRUE, verbose = TRUE,
   if_schema_changed = FALSE)
 }
 \arguments{
-\item{config}{An orderly configuration, or the path to one (or
-\code{NULL} to locate one if \code{locate} is \code{TRUE}).}
+\item{path}{The path to an orderly root directoy, or \code{NULL}
+(the default) to search for one from the current working
+directory if \code{locate} is \code{TRUE}).}
 
 \item{locate}{Logical, indicating if the configuration should be
 searched for.  If \code{TRUE} and \code{config} is not given,

--- a/man/orderly_rebuild.Rd
+++ b/man/orderly_rebuild.Rd
@@ -4,11 +4,11 @@
 \alias{orderly_rebuild}
 \title{Rebuild the report database}
 \usage{
-orderly_rebuild(path = NULL, locate = TRUE, verbose = TRUE,
+orderly_rebuild(root = NULL, locate = TRUE, verbose = TRUE,
   if_schema_changed = FALSE)
 }
 \arguments{
-\item{path}{The path to an orderly root directoy, or \code{NULL}
+\item{root}{The path to an orderly root directoy, or \code{NULL}
 (the default) to search for one from the current working
 directory if \code{locate} is \code{TRUE}).}
 

--- a/man/orderly_run.Rd
+++ b/man/orderly_run.Rd
@@ -5,12 +5,12 @@
 \alias{orderly_data}
 \title{Run a report}
 \usage{
-orderly_run(name, parameters = NULL, envir = NULL, path = NULL,
+orderly_run(name, parameters = NULL, envir = NULL, root = NULL,
   locate = TRUE, echo = TRUE, id_file = NULL, fetch = FALSE,
   ref = NULL, open = FALSE, message = NULL,
   extended_output = FALSE)
 
-orderly_data(name, parameters = NULL, envir = NULL, path = NULL,
+orderly_data(name, parameters = NULL, envir = NULL, root = NULL,
   locate = TRUE)
 }
 \arguments{
@@ -24,7 +24,7 @@ parameters declared in the orderly.yml.}
 by default a new environment will be made with the global
 environment as the parent.}
 
-\item{path}{The path to an orderly root directoy, or \code{NULL}
+\item{root}{The path to an orderly root directoy, or \code{NULL}
 (the default) to search for one from the current working
 directory if \code{locate} is \code{TRUE}).}
 

--- a/man/orderly_run.Rd
+++ b/man/orderly_run.Rd
@@ -5,12 +5,12 @@
 \alias{orderly_data}
 \title{Run a report}
 \usage{
-orderly_run(name, parameters = NULL, envir = NULL, config = NULL,
+orderly_run(name, parameters = NULL, envir = NULL, path = NULL,
   locate = TRUE, echo = TRUE, id_file = NULL, fetch = FALSE,
   ref = NULL, open = FALSE, message = NULL,
   extended_output = FALSE)
 
-orderly_data(name, parameters = NULL, envir = NULL, config = NULL,
+orderly_data(name, parameters = NULL, envir = NULL, path = NULL,
   locate = TRUE)
 }
 \arguments{
@@ -24,8 +24,9 @@ parameters declared in the orderly.yml.}
 by default a new environment will be made with the global
 environment as the parent.}
 
-\item{config}{An orderly configuration, or the path to one (or
-\code{NULL} to locate one if \code{locate} is \code{TRUE}).}
+\item{path}{The path to an orderly root directoy, or \code{NULL}
+(the default) to search for one from the current working
+directory if \code{locate} is \code{TRUE}).}
 
 \item{locate}{Logical, indicating if the configuration should be
 searched for.  If \code{TRUE} and \code{config} is not given,

--- a/man/orderly_run_remote.Rd
+++ b/man/orderly_run_remote.Rd
@@ -7,7 +7,7 @@
 orderly_run_remote(name, parameters = NULL, ref = NULL,
   timeout = NULL, wait = 3600, poll = 1, open = TRUE,
   stop_on_error = TRUE, stop_on_timeout = TRUE, progress = TRUE,
-  config = NULL, locate = TRUE, remote = NULL)
+  path = NULL, locate = TRUE, remote = NULL)
 }
 \arguments{
 \item{name}{Name of the report}
@@ -44,8 +44,9 @@ complete.}
 \item{progress}{Logical, indicating if a progress spinner should
 be included.}
 
-\item{config}{An orderly configuration, or the path to one (or
-\code{NULL} to locate one if \code{locate} is \code{TRUE}).}
+\item{path}{The path to an orderly root directoy, or \code{NULL}
+(the default) to search for one from the current working
+directory if \code{locate} is \code{TRUE}).}
 
 \item{locate}{Logical, indicating if the configuration should be
 searched for.  If \code{TRUE} and \code{config} is not given,

--- a/man/orderly_run_remote.Rd
+++ b/man/orderly_run_remote.Rd
@@ -7,7 +7,7 @@
 orderly_run_remote(name, parameters = NULL, ref = NULL,
   timeout = NULL, wait = 3600, poll = 1, open = TRUE,
   stop_on_error = TRUE, stop_on_timeout = TRUE, progress = TRUE,
-  path = NULL, locate = TRUE, remote = NULL)
+  root = NULL, locate = TRUE, remote = NULL)
 }
 \arguments{
 \item{name}{Name of the report}
@@ -44,7 +44,7 @@ complete.}
 \item{progress}{Logical, indicating if a progress spinner should
 be included.}
 
-\item{path}{The path to an orderly root directoy, or \code{NULL}
+\item{root}{The path to an orderly root directoy, or \code{NULL}
 (the default) to search for one from the current working
 directory if \code{locate} is \code{TRUE}).}
 

--- a/man/orderly_test_start.Rd
+++ b/man/orderly_test_start.Rd
@@ -8,7 +8,7 @@
 \title{Prepare a directory for orderly to use}
 \usage{
 orderly_test_start(name, parameters = NULL, envir = .GlobalEnv,
-  path = NULL, locate = TRUE)
+  root = NULL, locate = TRUE)
 
 orderly_test_end(cleanup = FALSE)
 
@@ -27,7 +27,7 @@ parameters declared in the orderly.yml.}
 by default a new environment will be made with the global
 environment as the parent.}
 
-\item{path}{The path to an orderly root directoy, or \code{NULL}
+\item{root}{The path to an orderly root directoy, or \code{NULL}
 (the default) to search for one from the current working
 directory if \code{locate} is \code{TRUE}).}
 

--- a/man/orderly_test_start.Rd
+++ b/man/orderly_test_start.Rd
@@ -8,7 +8,7 @@
 \title{Prepare a directory for orderly to use}
 \usage{
 orderly_test_start(name, parameters = NULL, envir = .GlobalEnv,
-  config = NULL, locate = TRUE)
+  path = NULL, locate = TRUE)
 
 orderly_test_end(cleanup = FALSE)
 
@@ -27,8 +27,9 @@ parameters declared in the orderly.yml.}
 by default a new environment will be made with the global
 environment as the parent.}
 
-\item{config}{An orderly configuration, or the path to one (or
-\code{NULL} to locate one if \code{locate} is \code{TRUE}).}
+\item{path}{The path to an orderly root directoy, or \code{NULL}
+(the default) to search for one from the current working
+directory if \code{locate} is \code{TRUE}).}
 
 \item{locate}{Logical, indicating if the configuration should be
 searched for.  If \code{TRUE} and \code{config} is not given,

--- a/man/pull_dependencies.Rd
+++ b/man/pull_dependencies.Rd
@@ -5,15 +5,15 @@
 \alias{pull_archive}
 \title{Download dependent reports}
 \usage{
-pull_dependencies(name, path = NULL, locate = TRUE, remote = NULL)
+pull_dependencies(name, root = NULL, locate = TRUE, remote = NULL)
 
-pull_archive(name, id = "latest", path = NULL, locate = TRUE,
+pull_archive(name, id = "latest", root = NULL, locate = TRUE,
   remote = NULL)
 }
 \arguments{
 \item{name}{Name of the report to download dependencies for}
 
-\item{path}{The path to an orderly root directoy, or \code{NULL}
+\item{root}{The path to an orderly root directoy, or \code{NULL}
 (the default) to search for one from the current working
 directory if \code{locate} is \code{TRUE}).}
 

--- a/man/pull_dependencies.Rd
+++ b/man/pull_dependencies.Rd
@@ -5,16 +5,17 @@
 \alias{pull_archive}
 \title{Download dependent reports}
 \usage{
-pull_dependencies(name, config = NULL, locate = TRUE, remote = NULL)
+pull_dependencies(name, path = NULL, locate = TRUE, remote = NULL)
 
-pull_archive(name, id = "latest", config = NULL, locate = TRUE,
+pull_archive(name, id = "latest", path = NULL, locate = TRUE,
   remote = NULL)
 }
 \arguments{
 \item{name}{Name of the report to download dependencies for}
 
-\item{config}{An orderly configuration, or the path to one (or
-\code{NULL} to locate one if \code{locate} is \code{TRUE}).}
+\item{path}{The path to an orderly root directoy, or \code{NULL}
+(the default) to search for one from the current working
+directory if \code{locate} is \code{TRUE}).}
 
 \item{locate}{Logical, indicating if the configuration should be
 searched for.  If \code{TRUE} and \code{config} is not given,

--- a/man/push_archive.Rd
+++ b/man/push_archive.Rd
@@ -4,7 +4,7 @@
 \alias{push_archive}
 \title{Push an archive report to a remote location}
 \usage{
-push_archive(name, id = "latest", config = NULL, locate = TRUE,
+push_archive(name, id = "latest", path = NULL, locate = TRUE,
   remote = NULL)
 }
 \arguments{
@@ -13,8 +13,9 @@ push_archive(name, id = "latest", config = NULL, locate = TRUE,
 \item{id}{The identifier (for \code{pull_archive}.  The default is
 to use the latest report.}
 
-\item{config}{An orderly configuration, or the path to one (or
-\code{NULL} to locate one if \code{locate} is \code{TRUE}).}
+\item{path}{The path to an orderly root directoy, or \code{NULL}
+(the default) to search for one from the current working
+directory if \code{locate} is \code{TRUE}).}
 
 \item{locate}{Logical, indicating if the configuration should be
 searched for.  If \code{TRUE} and \code{config} is not given,

--- a/man/push_archive.Rd
+++ b/man/push_archive.Rd
@@ -4,7 +4,7 @@
 \alias{push_archive}
 \title{Push an archive report to a remote location}
 \usage{
-push_archive(name, id = "latest", path = NULL, locate = TRUE,
+push_archive(name, id = "latest", root = NULL, locate = TRUE,
   remote = NULL)
 }
 \arguments{
@@ -13,7 +13,7 @@ push_archive(name, id = "latest", path = NULL, locate = TRUE,
 \item{id}{The identifier (for \code{pull_archive}.  The default is
 to use the latest report.}
 
-\item{path}{The path to an orderly root directoy, or \code{NULL}
+\item{root}{The path to an orderly root directoy, or \code{NULL}
 (the default) to search for one from the current working
 directory if \code{locate} is \code{TRUE}).}
 

--- a/tests/testthat/helper-orderly.R
+++ b/tests/testthat/helper-orderly.R
@@ -52,10 +52,10 @@ prepare_orderly_remote_example <- function(path = tempfile()) {
 
   prepare_orderly_example("depends", path_remote)
 
-  id1 <- orderly_run("example", path = path_remote, echo = FALSE)
-  id2 <- orderly_run("example", path = path_remote, echo = FALSE)
-  orderly_commit(id1, path = path_remote)
-  orderly_commit(id2, path = path_remote)
+  id1 <- orderly_run("example", root = path_remote, echo = FALSE)
+  id2 <- orderly_run("example", root = path_remote, echo = FALSE)
+  orderly_commit(id1, root = path_remote)
+  orderly_commit(id2, root = path_remote)
   remote_path <- orderly_remote_path(path_remote)
 
   path_local <- prepare_orderly_example("depends")

--- a/tests/testthat/helper-orderly.R
+++ b/tests/testthat/helper-orderly.R
@@ -52,10 +52,10 @@ prepare_orderly_remote_example <- function(path = tempfile()) {
 
   prepare_orderly_example("depends", path_remote)
 
-  id1 <- orderly_run("example", config = path_remote, echo = FALSE)
-  id2 <- orderly_run("example", config = path_remote, echo = FALSE)
-  orderly_commit(id1, config = path_remote)
-  orderly_commit(id2, config = path_remote)
+  id1 <- orderly_run("example", path = path_remote, echo = FALSE)
+  id2 <- orderly_run("example", path = path_remote, echo = FALSE)
+  orderly_commit(id1, path = path_remote)
+  orderly_commit(id2, path = path_remote)
   remote_path <- orderly_remote_path(path_remote)
 
   path_local <- prepare_orderly_example("depends")

--- a/tests/testthat/test-changelog.R
+++ b/tests/testthat/test-changelog.R
@@ -155,8 +155,8 @@ test_that("append changelog", {
 
   writeLines(c("[label1]", "value1"), path_cl)
 
-  id1 <- orderly_run("example", config = path, echo = FALSE)
-  p1 <- orderly_commit(id1, config = path)
+  id1 <- orderly_run("example", path = path, echo = FALSE)
+  p1 <- orderly_commit(id1, path = path)
 
   l1 <- changelog_read_json(p1)
   expect_equal(l1,
@@ -165,7 +165,7 @@ test_that("append changelog", {
                           from_file = TRUE,
                           report_version = id1))
 
-  con <- orderly_db("destination", config = path)
+  con <- orderly_db("destination", path = path)
   on.exit(DBI::dbDisconnect(con))
   d <- DBI::dbReadTable(con, "changelog")
   d$from_file <- as.logical(d$from_file)
@@ -175,8 +175,8 @@ test_that("append changelog", {
   txt <- c("[label2]", "value2", readLines(path_cl))
   writeLines(txt, path_cl)
 
-  id2 <- orderly_run("example", config = path, echo = FALSE)
-  p2 <- orderly_commit(id2, config = path)
+  id2 <- orderly_run("example", path = path, echo = FALSE)
+  p2 <- orderly_commit(id2, path = path)
 
   l2 <- changelog_read_json(p2)
   expect_equal(changelog_read_json(p2),
@@ -185,8 +185,8 @@ test_that("append changelog", {
                           from_file = TRUE,
                           report_version = c(id2, id1)))
 
-  id3 <- orderly_run("example", config = path, echo = FALSE)
-  p3 <- orderly_commit(id3, config = path)
+  id3 <- orderly_run("example", path = path, echo = FALSE)
+  p3 <- orderly_commit(id3, path = path)
   expect_equal(changelog_read_json(p3),
                changelog_read_json(p2))
 })
@@ -200,21 +200,21 @@ test_that("label change requires rebuild", {
   path_cl <- path_changelog_txt(path_example)
 
   writeLines(c("[label1]", "value1"), path_cl)
-  id1 <- orderly_run("example", config = path, echo = FALSE)
-  p1 <- orderly_commit(id1, config = path)
+  id1 <- orderly_run("example", path = path, echo = FALSE)
+  p1 <- orderly_commit(id1, path = path)
 
   d <- yaml_read(file.path(path, "orderly_config.yml"))
   d$changelog <- d$changelog[1]
   yaml_write(d, file.path(path, "orderly_config.yml"))
 
   writeLines(c("[label1]", "value2", "[label1]", "value1"), path_cl)
-  id2 <- orderly_run("example", config = path, echo = FALSE)
+  id2 <- orderly_run("example", path = path, echo = FALSE)
   expect_error(
-    orderly_commit(id2, config = path),
+    orderly_commit(id2, path = path),
     "changelog labels have changed: rebuild with orderly::orderly_rebuild")
 
-  orderly_rebuild(config = path)
-  p2 <- orderly_commit(id2, config = path)
+  orderly_rebuild(path = path)
+  p2 <- orderly_commit(id2, path = path)
 })
 
 
@@ -227,7 +227,7 @@ test_that("label values are checked", {
 
   writeLines(c("[label]", "value1"), path_cl)
   expect_error(
-    orderly_run("example", config = path, echo = FALSE),
+    orderly_run("example", path = path, echo = FALSE),
     "Unknown changelog label: 'label'. Use one of 'label1', 'label2'")
 })
 
@@ -239,7 +239,7 @@ test_that("reports can't use changelogs if not enabled", {
   path_cl <- path_changelog_txt(path_example)
   writeLines(c("[label1]", "value1"), path_cl)
   expect_error(
-    orderly_run("example", config = path, echo = FALSE),
+    orderly_run("example", path = path, echo = FALSE),
     "report 'example' uses changelog, but this is not enabled",
     fixed = TRUE)
 })
@@ -251,37 +251,37 @@ test_that("public changelog", {
   name <- "example"
   ids <- character(10)
   for (i in seq_along(ids)) {
-    ids[[i]] <- orderly_run(name, config = path, echo = FALSE,
+    ids[[i]] <- orderly_run(name, path = path, echo = FALSE,
                             message = sprintf("[label1] %d", i))
-    orderly_commit(ids[[i]], config = path)
+    orderly_commit(ids[[i]], path = path)
   }
 
-  con <- orderly_db("destination", config = path)
+  con <- orderly_db("destination", path = path)
   on.exit(DBI::dbDisconnect(con))
 
-  orderly_publish(ids[[2]], config = path)
+  orderly_publish(ids[[2]], path = path)
   expect_equal(
     DBI::dbReadTable(con, "changelog")$report_version_public,
     rep(c(ids[[2]], NA_character_), c(2, length(ids) - 2)))
 
-  orderly_publish(ids[[6]], config = path)
+  orderly_publish(ids[[6]], path = path)
   expect_equal(
     DBI::dbReadTable(con, "changelog")$report_version_public,
     rep(c(ids[[2]], ids[[6]], NA_character_), c(2, 4, 4)))
 
-  orderly_publish(ids[[5]], config = path)
+  orderly_publish(ids[[5]], path = path)
   expect_equal(
     DBI::dbReadTable(con, "changelog")$report_version_public,
     rep(c(ids[[2]], ids[[5]], ids[[6]], NA_character_), c(2, 3, 1, 4)))
 
-  orderly_publish(ids[[2]], FALSE, config = path)
+  orderly_publish(ids[[2]], FALSE, path = path)
   expect_equal(
     DBI::dbReadTable(con, "changelog")$report_version_public,
     rep(c(ids[[5]], ids[[6]], NA_character_), c(5, 1, 4)))
 
   ## This should all survive a rebuild
   prev <- DBI::dbReadTable(con, "changelog")
-  orderly_rebuild(config = path)
+  orderly_rebuild(path = path)
   expect_equal(DBI::dbReadTable(con, "changelog"), prev)
 })
 
@@ -292,35 +292,35 @@ test_that("public changelog with multiple entries", {
   name <- "example"
   ids <- character(3)
 
-  ids[[1]] <- orderly_run(name, config = path, echo = FALSE,
+  ids[[1]] <- orderly_run(name, path = path, echo = FALSE,
                           message = paste("[label1]", c("a", "b", "c")))
-  ids[[2]] <- orderly_run(name, config = path, echo = FALSE,
+  ids[[2]] <- orderly_run(name, path = path, echo = FALSE,
                           message = paste("[label1]", c("d")))
-  ids[[3]] <- orderly_run(name, config = path, echo = FALSE,
+  ids[[3]] <- orderly_run(name, path = path, echo = FALSE,
                           message = paste("[label1]", c("e", "f")))
   for (i in ids) {
-    orderly_commit(i, config = path)
+    orderly_commit(i, path = path)
   }
 
-  con <- orderly_db("destination", config = path)
+  con <- orderly_db("destination", path = path)
   on.exit(DBI::dbDisconnect(con))
 
-  orderly_publish(ids[[2]], config = path)
+  orderly_publish(ids[[2]], path = path)
   expect_equal(
     DBI::dbReadTable(con, "changelog")$report_version_public,
     rep(c(ids[[2]], NA_character_), c(4, 2)))
 
-  orderly_publish(ids[[1]], config = path)
+  orderly_publish(ids[[1]], path = path)
   expect_equal(
     DBI::dbReadTable(con, "changelog")$report_version_public,
     rep(c(ids[[1]], ids[[2]], NA_character_), c(3, 1, 2)))
 
-  orderly_publish(ids[[3]], config = path)
+  orderly_publish(ids[[3]], path = path)
   expect_equal(
     DBI::dbReadTable(con, "changelog")$report_version_public,
     rep(c(ids[[1]], ids[[2]], ids[[3]]), c(3, 1, 2)))
 
-  orderly_publish(ids[[2]], FALSE, config = path)
+  orderly_publish(ids[[2]], FALSE, path = path)
   expect_equal(
     DBI::dbReadTable(con, "changelog")$report_version_public,
     rep(c(ids[[1]], ids[[3]]), c(3, 3)))
@@ -334,14 +334,14 @@ test_that("public version has no changelog", {
   ids <- character(4)
   for (i in seq_along(ids)) {
     msg <- if (i != 3) sprintf("[label1] %d", i)
-    ids[[i]] <- orderly_run(name, config = path, echo = FALSE, message = msg)
-    orderly_commit(ids[[i]], config = path)
+    ids[[i]] <- orderly_run(name, path = path, echo = FALSE, message = msg)
+    orderly_commit(ids[[i]], path = path)
   }
 
-  con <- orderly_db("destination", config = path)
+  con <- orderly_db("destination", path = path)
   DBI::dbReadTable(con, "changelog")
 
-  orderly_publish(ids[[3]], config = path)
+  orderly_publish(ids[[3]], path = path)
   expect_equal(
     DBI::dbReadTable(con, "changelog")$report_version_public,
     rep(c(ids[[3]], NA_character_), c(2, 1)))

--- a/tests/testthat/test-cleanup.R
+++ b/tests/testthat/test-cleanup.R
@@ -2,68 +2,68 @@ context("cleanup")
 
 test_that("cleanup nothing", {
   path <- prepare_orderly_example("minimal")
-  expect_null(orderly_cleanup(config = path))
-  expect_equal(orderly_list(config = path), "example")
+  expect_null(orderly_cleanup(path = path))
+  expect_equal(orderly_list(path = path), "example")
 })
 
 test_that("cleanup draft", {
   path <- prepare_orderly_example("minimal")
-  id <- orderly_run("example", config = path, echo = FALSE)
-  expect_equal(nrow(orderly_list_drafts(config = path)), 1)
+  id <- orderly_run("example", path = path, echo = FALSE)
+  expect_equal(nrow(orderly_list_drafts(path = path)), 1)
   expect_equal(length(orderly_db("csv", path)$list()), 1)
-  orderly_cleanup(config = path)
-  expect_equal(nrow(orderly_list_drafts(config = path)), 0)
+  orderly_cleanup(path = path)
+  expect_equal(nrow(orderly_list_drafts(path = path)), 0)
   expect_equal(length(orderly_db("csv", path)$list()), 0)
 })
 
 test_that("cleanup keeps draft data", {
   path <- prepare_orderly_example("minimal")
-  id <- orderly_run("example", config = path, echo = FALSE)
-  rds <- orderly_db("rds", config = path)
+  id <- orderly_run("example", path = path, echo = FALSE)
+  rds <- orderly_db("rds", path = path)
   h <- rds$list()
-  orderly_cleanup(config = path, draft = FALSE)
+  orderly_cleanup(path = path, draft = FALSE)
   expect_identical(rds$list(), h)
 })
 
 test_that("cleanup with archive", {
   path <- prepare_orderly_example("minimal")
-  id1 <- orderly_run("example", config = path, echo = FALSE)
-  id2 <- orderly_run("example", config = path, echo = FALSE)
+  id1 <- orderly_run("example", path = path, echo = FALSE)
+  id2 <- orderly_run("example", path = path, echo = FALSE)
 
-  expect_equal(nrow(orderly_list_drafts(config = path)), 2)
+  expect_equal(nrow(orderly_list_drafts(path = path)), 2)
   expect_equal(length(orderly_db("csv", path)$list()), 1)
 
-  orderly_commit(id2, config = path)
+  orderly_commit(id2, path = path)
 
-  orderly_cleanup(config = path)
-  expect_equal(nrow(orderly_list_drafts(config = path)), 0)
-  expect_equal(nrow(orderly_list_archive(config = path)), 1)
+  orderly_cleanup(path = path)
+  expect_equal(nrow(orderly_list_drafts(path = path)), 0)
+  expect_equal(nrow(orderly_list_archive(path = path)), 1)
   expect_equal(length(orderly_db("csv", path)$list()), 1)
 })
 
 test_that("cleanup failed", {
   path <- prepare_orderly_example("minimal")
-  id1 <- orderly_run("example", config = path, echo = FALSE)
-  id2 <- orderly_run("example", config = path, echo = FALSE)
+  id1 <- orderly_run("example", path = path, echo = FALSE)
+  id2 <- orderly_run("example", path = path, echo = FALSE)
 
   append_text(file.path(path, "src", "example", "script.R"),
               "stop('this is an error')")
-  id3 <- tryCatch(orderly_run("example", config = path, echo = FALSE),
+  id3 <- tryCatch(orderly_run("example", path = path, echo = FALSE),
                   error = function(e) NULL)
   expect_null(id3)
-  d <- orderly_list_drafts("example", config = path)
+  d <- orderly_list_drafts("example", path = path)
   expect_equal(nrow(d), 3)
 
-  orderly_cleanup(config = path, failed_only = TRUE)
-  d <- orderly_list_drafts("example", config = path)
+  orderly_cleanup(path = path, failed_only = TRUE)
+  d <- orderly_list_drafts("example", path = path)
   expect_equal(nrow(d), 2)
   expect_true(all(c(id1, id2) %in% d$id))
 })
 
 test_that("cleanup by name", {
   path <- prepare_orderly_example("demo")
-  id1 <- orderly_run("minimal", config = path, echo = FALSE)
-  id2 <- orderly_run("other", list(nmin = 0), config = path, echo = FALSE)
+  id1 <- orderly_run("minimal", path = path, echo = FALSE)
+  id2 <- orderly_run("other", list(nmin = 0), path = path, echo = FALSE)
   orderly_cleanup("minimal", path)
   expect_equal(orderly_list_drafts(path),
                data.frame(name = "other", id = id2, stringsAsFactors = FALSE))

--- a/tests/testthat/test-cleanup.R
+++ b/tests/testthat/test-cleanup.R
@@ -2,68 +2,68 @@ context("cleanup")
 
 test_that("cleanup nothing", {
   path <- prepare_orderly_example("minimal")
-  expect_null(orderly_cleanup(path = path))
-  expect_equal(orderly_list(path = path), "example")
+  expect_null(orderly_cleanup(root = path))
+  expect_equal(orderly_list(root = path), "example")
 })
 
 test_that("cleanup draft", {
   path <- prepare_orderly_example("minimal")
-  id <- orderly_run("example", path = path, echo = FALSE)
-  expect_equal(nrow(orderly_list_drafts(path = path)), 1)
+  id <- orderly_run("example", root = path, echo = FALSE)
+  expect_equal(nrow(orderly_list_drafts(root = path)), 1)
   expect_equal(length(orderly_db("csv", path)$list()), 1)
-  orderly_cleanup(path = path)
-  expect_equal(nrow(orderly_list_drafts(path = path)), 0)
+  orderly_cleanup(root = path)
+  expect_equal(nrow(orderly_list_drafts(root = path)), 0)
   expect_equal(length(orderly_db("csv", path)$list()), 0)
 })
 
 test_that("cleanup keeps draft data", {
   path <- prepare_orderly_example("minimal")
-  id <- orderly_run("example", path = path, echo = FALSE)
-  rds <- orderly_db("rds", path = path)
+  id <- orderly_run("example", root = path, echo = FALSE)
+  rds <- orderly_db("rds", root = path)
   h <- rds$list()
-  orderly_cleanup(path = path, draft = FALSE)
+  orderly_cleanup(root = path, draft = FALSE)
   expect_identical(rds$list(), h)
 })
 
 test_that("cleanup with archive", {
   path <- prepare_orderly_example("minimal")
-  id1 <- orderly_run("example", path = path, echo = FALSE)
-  id2 <- orderly_run("example", path = path, echo = FALSE)
+  id1 <- orderly_run("example", root = path, echo = FALSE)
+  id2 <- orderly_run("example", root = path, echo = FALSE)
 
-  expect_equal(nrow(orderly_list_drafts(path = path)), 2)
+  expect_equal(nrow(orderly_list_drafts(root = path)), 2)
   expect_equal(length(orderly_db("csv", path)$list()), 1)
 
-  orderly_commit(id2, path = path)
+  orderly_commit(id2, root = path)
 
-  orderly_cleanup(path = path)
-  expect_equal(nrow(orderly_list_drafts(path = path)), 0)
-  expect_equal(nrow(orderly_list_archive(path = path)), 1)
+  orderly_cleanup(root = path)
+  expect_equal(nrow(orderly_list_drafts(root = path)), 0)
+  expect_equal(nrow(orderly_list_archive(root = path)), 1)
   expect_equal(length(orderly_db("csv", path)$list()), 1)
 })
 
 test_that("cleanup failed", {
   path <- prepare_orderly_example("minimal")
-  id1 <- orderly_run("example", path = path, echo = FALSE)
-  id2 <- orderly_run("example", path = path, echo = FALSE)
+  id1 <- orderly_run("example", root = path, echo = FALSE)
+  id2 <- orderly_run("example", root = path, echo = FALSE)
 
   append_text(file.path(path, "src", "example", "script.R"),
               "stop('this is an error')")
-  id3 <- tryCatch(orderly_run("example", path = path, echo = FALSE),
+  id3 <- tryCatch(orderly_run("example", root = path, echo = FALSE),
                   error = function(e) NULL)
   expect_null(id3)
-  d <- orderly_list_drafts("example", path = path)
+  d <- orderly_list_drafts("example", root = path)
   expect_equal(nrow(d), 3)
 
-  orderly_cleanup(path = path, failed_only = TRUE)
-  d <- orderly_list_drafts("example", path = path)
+  orderly_cleanup(root = path, failed_only = TRUE)
+  d <- orderly_list_drafts("example", root = path)
   expect_equal(nrow(d), 2)
   expect_true(all(c(id1, id2) %in% d$id))
 })
 
 test_that("cleanup by name", {
   path <- prepare_orderly_example("demo")
-  id1 <- orderly_run("minimal", path = path, echo = FALSE)
-  id2 <- orderly_run("other", list(nmin = 0), path = path, echo = FALSE)
+  id1 <- orderly_run("minimal", root = path, echo = FALSE)
+  id2 <- orderly_run("other", list(nmin = 0), root = path, echo = FALSE)
   orderly_cleanup("minimal", path)
   expect_equal(orderly_list_drafts(path),
                data.frame(name = "other", id = id2, stringsAsFactors = FALSE))

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -226,7 +226,7 @@ test_that("can read a configuration with two databases", {
   expect_equal(config$database$source1$args, list(dbname = "source1.sqlite"))
   expect_equal(config$database$source2$args, list(dbname = "source2.sqlite"))
 
-  con <- orderly_db("source", config = path)
+  con <- orderly_db("source", path = path)
   DBI::dbListTables(con$source1)
   DBI::dbListTables(con$source2)
 })

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -10,7 +10,7 @@ test_that("read", {
 
   dat <- orderly_db_args(cfg$destination, cfg)
   expect_identical(dat$driver, RSQLite::SQLite)
-  expect_identical(dat$args$dbname, file.path(cfg$path, "orderly.sqlite"))
+  expect_identical(dat$args$dbname, file.path(cfg$root, "orderly.sqlite"))
 })
 
 test_that("environment variables", {
@@ -88,16 +88,16 @@ test_that("support declaring api server", {
                   driver = "orderly::orderly_remote_path",
                   primary = TRUE,
                   master_only = TRUE,
-                  args = list(path = path)),
+                  args = list(root = path)),
                 other = list(
                   driver = "orderly::orderly_remote_path",
-                  args = list(path = path))))
+                  args = list(root = path))))
   writeLines(yaml::as.yaml(dat), path_orderly_config_yml(path))
   cfg <- orderly_config(path)
 
   expect_is(cfg$remote, "list")
   expect_equal(cfg$remote$main$args,
-               list(path = path, name = "main"))
+               list(root = path, name = "main"))
 
   cfg <- withr::with_envvar(
     c("ORDERLY_API_SERVER_IDENTITY" = "main"),
@@ -134,11 +134,11 @@ test_that("api server has only one primary", {
                 main = list(
                   driver = "orderly::orderly_remote_path",
                   primary = TRUE,
-                  args = list(path = path)),
+                  args = list(root = path)),
                 other = list(
                   driver = "orderly::orderly_remote_path",
                   primary = TRUE,
-                  args = list(path = path))))
+                  args = list(root = path))))
 
   writeLines(yaml::as.yaml(dat), path_orderly_config_yml(path))
   expect_error(
@@ -158,7 +158,7 @@ test_that("remote parse check", {
                 myhost = list(
                   driver = "orderly::orderly_remote_path",
                   primary = TRUE,
-                  args = list(path = path),
+                  args = list(root = path),
                   master_only = "yeah")))
   writeLines(yaml::as.yaml(dat), path_orderly_config_yml(path))
   expect_error(orderly_config(path),
@@ -174,7 +174,7 @@ test_that("no global folder", {
   writeLines(yaml::as.yaml(dat), path_config)
 
   expect_error(
-    orderly_config(path = path),
+    orderly_config(root = path),
     "global resource does not exist: 'invalid_directory'",
     fixed = TRUE
   )
@@ -186,14 +186,14 @@ test_that("vault configuration", {
   path_config <- file.path(path, "orderly_config.yml")
   text <- readLines(path_config)
 
-  expect_null(orderly_config(path = path)$vault_server)
+  expect_null(orderly_config(root = path)$vault_server)
 
   url <- "https://vault.example.com"
   writeLines(c(text, sprintf("vault_server: %s", url)), path_config)
-  expect_equal(orderly_config(path = path)$vault_server, url)
+  expect_equal(orderly_config(root = path)$vault_server, url)
 
   writeLines(c(text, sprintf("vault_server: %s", TRUE)), path_config)
-  expect_error(orderly_config(path = path),
+  expect_error(orderly_config(root = path),
                "orderly_config.yml:vault_server' must be character",
                fixed = TRUE)
 })
@@ -226,7 +226,7 @@ test_that("can read a configuration with two databases", {
   expect_equal(config$database$source1$args, list(dbname = "source1.sqlite"))
   expect_equal(config$database$source2$args, list(dbname = "source2.sqlite"))
 
-  con <- orderly_db("source", path = path)
+  con <- orderly_db("source", root = path)
   DBI::dbListTables(con$source1)
   DBI::dbListTables(con$source2)
 })

--- a/tests/testthat/test-db.R
+++ b/tests/testthat/test-db.R
@@ -50,8 +50,8 @@ test_that("rebuild empty database", {
 
 test_that("rebuild nonempty database", {
   path <- prepare_orderly_example("minimal")
-  id <- orderly_run("example", path = path, echo = FALSE)
-  orderly_commit(id, path = path)
+  id <- orderly_run("example", root = path, echo = FALSE)
+  orderly_commit(id, root = path)
   file.remove(file.path(path, "orderly.sqlite"))
   orderly_rebuild(path)
   orderly_rebuild(path)
@@ -64,7 +64,7 @@ test_that("no transient db", {
   config <- list(destination = list(
                    driver = c("RSQLite", "SQLite"),
                    args = list(dbname = ":memory:")),
-                 path = ".")
+                 root = ".")
   expect_error(orderly_db_args(config$destination, config = config),
                "Cannot use a transient SQLite database with orderly")
 })
@@ -72,10 +72,10 @@ test_that("no transient db", {
 
 test_that("db includes parameters", {
   path <- prepare_orderly_example("example")
-  id <- orderly_run("example", parameters = list(cyl = 4), path = path,
+  id <- orderly_run("example", parameters = list(cyl = 4), root = path,
                     echo = FALSE)
-  orderly_commit(id, path = path)
-  con <- orderly_db("destination", path = path)
+  orderly_commit(id, root = path)
+  con <- orderly_db("destination", root = path)
   d <- DBI::dbReadTable(con, "parameters")
   DBI::dbDisconnect(con)
   expect_equal(d, data_frame(id = 1,
@@ -89,9 +89,9 @@ test_that("db includes parameters", {
 test_that("different parameter types are stored correctly", {
   path <- prepare_orderly_example("parameters")
   id <- orderly_run("example", parameters = list(a = 1, b = TRUE, c = "one"),
-                    path = path, echo = FALSE)
-  orderly_commit(id, path = path)
-  con <- orderly_db("destination", path = path)
+                    root = path, echo = FALSE)
+  orderly_commit(id, root = path)
+  con <- orderly_db("destination", root = path)
   d <- DBI::dbReadTable(con, "parameters")
   DBI::dbDisconnect(con)
   expect_equal(d, data_frame(id = 1:3,
@@ -106,8 +106,8 @@ test_that("avoid unserialisable parameters", {
   path <- prepare_orderly_example("parameters")
   t <- Sys.Date()
   id <- orderly_run("example", parameters = list(a = t, b = TRUE, c = "one"),
-                    path = path, echo = FALSE)
-  expect_error(orderly_commit(id, path = path),
+                    root = path, echo = FALSE)
+  expect_error(orderly_commit(id, root = path),
                "Unsupported parameter type")
   expect_error(report_db_parameter_type(t), "Unsupported parameter type")
   expect_error(report_db_parameter_serialise(t), "Unsupported parameter type")
@@ -139,11 +139,11 @@ test_that("dialects", {
 
 test_that("sources are listed in db", {
   path <- prepare_orderly_example("demo")
-  id <- orderly_run("other", path = path, parameters = list(nmin = 0),
+  id <- orderly_run("other", root = path, parameters = list(nmin = 0),
                     echo = FALSE)
-  orderly_commit(id, path = path)
+  orderly_commit(id, root = path)
 
-  con <- orderly_db("destination", path = path)
+  con <- orderly_db("destination", root = path)
   on.exit(DBI::dbDisconnect(con))
 
   p <- path_orderly_run_rds(file.path(path, "archive", "other", id))

--- a/tests/testthat/test-db.R
+++ b/tests/testthat/test-db.R
@@ -50,8 +50,8 @@ test_that("rebuild empty database", {
 
 test_that("rebuild nonempty database", {
   path <- prepare_orderly_example("minimal")
-  id <- orderly_run("example", config = path, echo = FALSE)
-  orderly_commit(id, config = path)
+  id <- orderly_run("example", path = path, echo = FALSE)
+  orderly_commit(id, path = path)
   file.remove(file.path(path, "orderly.sqlite"))
   orderly_rebuild(path)
   orderly_rebuild(path)
@@ -72,10 +72,10 @@ test_that("no transient db", {
 
 test_that("db includes parameters", {
   path <- prepare_orderly_example("example")
-  id <- orderly_run("example", parameters = list(cyl = 4), config = path,
+  id <- orderly_run("example", parameters = list(cyl = 4), path = path,
                     echo = FALSE)
-  orderly_commit(id, config = path)
-  con <- orderly_db("destination", config = path)
+  orderly_commit(id, path = path)
+  con <- orderly_db("destination", path = path)
   d <- DBI::dbReadTable(con, "parameters")
   DBI::dbDisconnect(con)
   expect_equal(d, data_frame(id = 1,
@@ -89,9 +89,9 @@ test_that("db includes parameters", {
 test_that("different parameter types are stored correctly", {
   path <- prepare_orderly_example("parameters")
   id <- orderly_run("example", parameters = list(a = 1, b = TRUE, c = "one"),
-                    config = path, echo = FALSE)
-  orderly_commit(id, config = path)
-  con <- orderly_db("destination", config = path)
+                    path = path, echo = FALSE)
+  orderly_commit(id, path = path)
+  con <- orderly_db("destination", path = path)
   d <- DBI::dbReadTable(con, "parameters")
   DBI::dbDisconnect(con)
   expect_equal(d, data_frame(id = 1:3,
@@ -106,8 +106,8 @@ test_that("avoid unserialisable parameters", {
   path <- prepare_orderly_example("parameters")
   t <- Sys.Date()
   id <- orderly_run("example", parameters = list(a = t, b = TRUE, c = "one"),
-                    config = path, echo = FALSE)
-  expect_error(orderly_commit(id, config = path),
+                    path = path, echo = FALSE)
+  expect_error(orderly_commit(id, path = path),
                "Unsupported parameter type")
   expect_error(report_db_parameter_type(t), "Unsupported parameter type")
   expect_error(report_db_parameter_serialise(t), "Unsupported parameter type")
@@ -139,11 +139,11 @@ test_that("dialects", {
 
 test_that("sources are listed in db", {
   path <- prepare_orderly_example("demo")
-  id <- orderly_run("other", config = path, parameters = list(nmin = 0),
+  id <- orderly_run("other", path = path, parameters = list(nmin = 0),
                     echo = FALSE)
-  orderly_commit(id, config = path)
+  orderly_commit(id, path = path)
 
-  con <- orderly_db("destination", config = path)
+  con <- orderly_db("destination", path = path)
   on.exit(DBI::dbDisconnect(con))
 
   p <- path_orderly_run_rds(file.path(path, "archive", "other", id))

--- a/tests/testthat/test-file-store.R
+++ b/tests/testthat/test-file-store.R
@@ -36,7 +36,8 @@ test_that("get missing hash", {
   path <- tempfile()
   st <- file_store_rds(path)
   expect_error(st$get(ids::random_id()),
-               "hash '[[:xdigit:]]{32}' not found")
+               "hash '[[:xdigit:]]{32}' not found",
+               class = "HashError")
 })
 
 test_that("mget", {

--- a/tests/testthat/test-git.R
+++ b/tests/testthat/test-git.R
@@ -125,7 +125,7 @@ test_that("detect missing ref", {
 
 test_that("run in detached head", {
   path <- unzip_git_demo()
-  orderly_run("other", list(nmin = 0), config = path, ref = "other",
+  orderly_run("other", list(nmin = 0), path = path, ref = "other",
               echo = FALSE)
 
   expect_equal(orderly_list(path), "minimal")
@@ -178,12 +178,12 @@ test_that("fetch before run", {
   sha1 <- git_ref_to_sha("HEAD", path1)
   sha2 <- git_ref_to_sha("HEAD", path2)
 
-  id1 <- orderly_run("minimal", config = path2, echo = FALSE,
+  id1 <- orderly_run("minimal", path = path2, echo = FALSE,
                      ref = "origin/master")
   expect_equal(git_ref_to_sha("HEAD", path2), sha2)
   expect_equal(git_ref_to_sha("origin/master", path2), sha2)
 
-  id2 <- orderly_run("minimal", config = path2, echo = FALSE,
+  id2 <- orderly_run("minimal", path = path2, echo = FALSE,
                      ref = "origin/master", fetch = TRUE)
 
   expect_equal(git_ref_to_sha("HEAD", path2), sha2)
@@ -209,10 +209,10 @@ test_that("handle failure", {
 
 test_that("git into db", {
   path <- unzip_git_demo()
-  id <- orderly_run("minimal", config = path, echo = FALSE)
-  orderly_commit(id, config = path)
+  id <- orderly_run("minimal", path = path, echo = FALSE)
+  orderly_commit(id, path = path)
 
-  con <- orderly_db("destination", config = path)
+  con <- orderly_db("destination", path = path)
   on.exit(DBI::dbDisconnect(con))
   d <- DBI::dbReadTable(con, "report_version")
 

--- a/tests/testthat/test-git.R
+++ b/tests/testthat/test-git.R
@@ -125,7 +125,7 @@ test_that("detect missing ref", {
 
 test_that("run in detached head", {
   path <- unzip_git_demo()
-  orderly_run("other", list(nmin = 0), path = path, ref = "other",
+  orderly_run("other", list(nmin = 0), root = path, ref = "other",
               echo = FALSE)
 
   expect_equal(orderly_list(path), "minimal")
@@ -178,12 +178,12 @@ test_that("fetch before run", {
   sha1 <- git_ref_to_sha("HEAD", path1)
   sha2 <- git_ref_to_sha("HEAD", path2)
 
-  id1 <- orderly_run("minimal", path = path2, echo = FALSE,
+  id1 <- orderly_run("minimal", root = path2, echo = FALSE,
                      ref = "origin/master")
   expect_equal(git_ref_to_sha("HEAD", path2), sha2)
   expect_equal(git_ref_to_sha("origin/master", path2), sha2)
 
-  id2 <- orderly_run("minimal", path = path2, echo = FALSE,
+  id2 <- orderly_run("minimal", root = path2, echo = FALSE,
                      ref = "origin/master", fetch = TRUE)
 
   expect_equal(git_ref_to_sha("HEAD", path2), sha2)
@@ -209,10 +209,10 @@ test_that("handle failure", {
 
 test_that("git into db", {
   path <- unzip_git_demo()
-  id <- orderly_run("minimal", path = path, echo = FALSE)
-  orderly_commit(id, path = path)
+  id <- orderly_run("minimal", root = path, echo = FALSE)
+  orderly_commit(id, root = path)
 
-  con <- orderly_db("destination", path = path)
+  con <- orderly_db("destination", root = path)
   on.exit(DBI::dbDisconnect(con))
   d <- DBI::dbReadTable(con, "report_version")
 

--- a/tests/testthat/test-global.R
+++ b/tests/testthat/test-global.R
@@ -4,7 +4,7 @@ test_that("global", {
   path <- prepare_orderly_example("global")
   tmp <- tempfile()
   expect_error(
-    orderly_run("example", path = path, id_file = tmp, echo = FALSE),
+    orderly_run("example", root = path, id_file = tmp, echo = FALSE),
     NA # expect no errors
   )
 })
@@ -23,7 +23,7 @@ test_that("missing global file", {
 
   tmp <- tempfile()
   expect_error(
-    orderly_run("example", path = path, id_file = tmp, echo = FALSE),
+    orderly_run("example", root = path, id_file = tmp, echo = FALSE),
                 expected_error)
 })
 
@@ -31,9 +31,9 @@ test_that("missing global file", {
 test_that("global resources end up in db", {
   path <- prepare_orderly_example("global")
   tmp <- tempfile()
-  id <- orderly_run("example", path = path, id_file = tmp, echo = FALSE)
-  orderly_commit(id, path = path)
-  con <- orderly_db("destination", path = path)
+  id <- orderly_run("example", root = path, id_file = tmp, echo = FALSE)
+  orderly_commit(id, root = path)
+  con <- orderly_db("destination", root = path)
   d <- DBI::dbReadTable(con, "file_input")
   DBI::dbDisconnect(con)
   i <- d$file_purpose == "global"

--- a/tests/testthat/test-global.R
+++ b/tests/testthat/test-global.R
@@ -4,7 +4,7 @@ test_that("global", {
   path <- prepare_orderly_example("global")
   tmp <- tempfile()
   expect_error(
-    orderly_run("example", config = path, id_file = tmp, echo = FALSE),
+    orderly_run("example", path = path, id_file = tmp, echo = FALSE),
     NA # expect no errors
   )
 })
@@ -23,7 +23,7 @@ test_that("missing global file", {
 
   tmp <- tempfile()
   expect_error(
-    orderly_run("example", config = path, id_file = tmp, echo = FALSE),
+    orderly_run("example", path = path, id_file = tmp, echo = FALSE),
                 expected_error)
 })
 
@@ -31,9 +31,9 @@ test_that("missing global file", {
 test_that("global resources end up in db", {
   path <- prepare_orderly_example("global")
   tmp <- tempfile()
-  id <- orderly_run("example", config = path, id_file = tmp, echo = FALSE)
-  orderly_commit(id, config = path)
-  con <- orderly_db("destination", config = path)
+  id <- orderly_run("example", path = path, id_file = tmp, echo = FALSE)
+  orderly_commit(id, path = path)
+  con <- orderly_db("destination", path = path)
   d <- DBI::dbReadTable(con, "file_input")
   DBI::dbDisconnect(con)
   i <- d$file_purpose == "global"

--- a/tests/testthat/test-main.R
+++ b/tests/testthat/test-main.R
@@ -73,7 +73,7 @@ test_that("run: fetch", {
 
   res$target(res)
 
-  id <- orderly_latest("minimal", path = path_local)
+  id <- orderly_latest("minimal", root = path_local)
   d <- readRDS(path_orderly_run_rds(
     file.path(path_local, "archive", "minimal", id)))
   expect_equal(d$git$sha, sha_origin)
@@ -105,7 +105,7 @@ test_that("run: pull before run", {
   expect_null(res$options$ref)
   res$target(res)
 
-  id <- orderly_latest("minimal", path = path_local)
+  id <- orderly_latest("minimal", root = path_local)
   d <- readRDS(path_orderly_run_rds(
     file.path(path_local, "archive", "minimal", id)))
   expect_equal(d$git$sha, sha_origin)
@@ -115,7 +115,7 @@ test_that("run: pull before run", {
 
 test_that("commit", {
   path <- prepare_orderly_example("minimal")
-  id <- orderly_run("example", path = path, echo = FALSE)
+  id <- orderly_run("example", root = path, echo = FALSE)
   args <- c("--root", path, "commit", id)
   res <- main_args(args)
   expect_equal(res$command, "commit")
@@ -128,8 +128,8 @@ test_that("commit", {
 
 test_that("publish", {
   path <- prepare_orderly_example("minimal")
-  id <- orderly_run("example", path = path, echo = FALSE)
-  p <- orderly_commit(id, path = path)
+  id <- orderly_run("example", root = path, echo = FALSE)
+  p <- orderly_commit(id, root = path)
 
   args <- c("--root", path, "publish", id)
   res <- main_args(args)
@@ -146,9 +146,9 @@ test_that("publish", {
 
 test_that("latest", {
   path <- prepare_orderly_example("minimal")
-  id1 <- orderly_run("example", path = path, echo = FALSE)
+  id1 <- orderly_run("example", root = path, echo = FALSE)
   Sys.sleep(0.1)
-  id2 <- orderly_run("example", path = path, echo = FALSE)
+  id2 <- orderly_run("example", root = path, echo = FALSE)
 
   args <- c("--root", path, "latest", "--draft", "example")
   res <- main_args(args)
@@ -271,7 +271,7 @@ test_that("rebuild", {
 
 test_that("cleanup", {
   path <- prepare_orderly_example("minimal")
-  id <- orderly_run("example", path = path, echo = FALSE)
+  id <- orderly_run("example", root = path, echo = FALSE)
 
   res <- main_args(c("--root", path, "cleanup"))
   expect_equal(res$command, "cleanup")
@@ -280,18 +280,18 @@ test_that("cleanup", {
   expect_false(res$options$failed_only)
   expect_identical(res$target, main_do_cleanup)
 
-  expect_equal(nrow(orderly_list2(path = path, draft = TRUE)), 1)
+  expect_equal(nrow(orderly_list2(root = path, draft = TRUE)), 1)
   expect_true(main_do_cleanup(res))
-  expect_equal(nrow(orderly_list2(path = path, draft = TRUE)), 0)
+  expect_equal(nrow(orderly_list2(root = path, draft = TRUE)), 0)
   expect_null(main_do_cleanup(res))
 })
 
 
 test_that("list", {
   path <- prepare_orderly_example("minimal")
-  id1 <- orderly_run("example", path = path, echo = FALSE)
-  id2 <- orderly_run("example", path = path, echo = FALSE)
-  orderly_commit(id2, path = path)
+  id1 <- orderly_run("example", root = path, echo = FALSE)
+  id2 <- orderly_run("example", root = path, echo = FALSE)
+  orderly_commit(id2, root = path)
 
   res <- main_args(c("--root", path, "list", "names"))
   expect_equal(capture.output(res$target(res)), "example")
@@ -331,7 +331,7 @@ test_that("run: message", {
 
   capture.output(res$target(res))
 
-  con <- orderly_db("destination", path = path)
+  con <- orderly_db("destination", root = path)
   on.exit(DBI::dbDisconnect(con))
   d <- DBI::dbReadTable(con, "changelog")
 

--- a/tests/testthat/test-main.R
+++ b/tests/testthat/test-main.R
@@ -73,7 +73,7 @@ test_that("run: fetch", {
 
   res$target(res)
 
-  id <- orderly_latest("minimal", config = path_local)
+  id <- orderly_latest("minimal", path = path_local)
   d <- readRDS(path_orderly_run_rds(
     file.path(path_local, "archive", "minimal", id)))
   expect_equal(d$git$sha, sha_origin)
@@ -105,7 +105,7 @@ test_that("run: pull before run", {
   expect_null(res$options$ref)
   res$target(res)
 
-  id <- orderly_latest("minimal", config = path_local)
+  id <- orderly_latest("minimal", path = path_local)
   d <- readRDS(path_orderly_run_rds(
     file.path(path_local, "archive", "minimal", id)))
   expect_equal(d$git$sha, sha_origin)
@@ -115,7 +115,7 @@ test_that("run: pull before run", {
 
 test_that("commit", {
   path <- prepare_orderly_example("minimal")
-  id <- orderly_run("example", config = path, echo = FALSE)
+  id <- orderly_run("example", path = path, echo = FALSE)
   args <- c("--root", path, "commit", id)
   res <- main_args(args)
   expect_equal(res$command, "commit")
@@ -128,8 +128,8 @@ test_that("commit", {
 
 test_that("publish", {
   path <- prepare_orderly_example("minimal")
-  id <- orderly_run("example", config = path, echo = FALSE)
-  p <- orderly_commit(id, config = path)
+  id <- orderly_run("example", path = path, echo = FALSE)
+  p <- orderly_commit(id, path = path)
 
   args <- c("--root", path, "publish", id)
   res <- main_args(args)
@@ -146,9 +146,9 @@ test_that("publish", {
 
 test_that("latest", {
   path <- prepare_orderly_example("minimal")
-  id1 <- orderly_run("example", config = path, echo = FALSE)
+  id1 <- orderly_run("example", path = path, echo = FALSE)
   Sys.sleep(0.1)
-  id2 <- orderly_run("example", config = path, echo = FALSE)
+  id2 <- orderly_run("example", path = path, echo = FALSE)
 
   args <- c("--root", path, "latest", "--draft", "example")
   res <- main_args(args)
@@ -271,7 +271,7 @@ test_that("rebuild", {
 
 test_that("cleanup", {
   path <- prepare_orderly_example("minimal")
-  id <- orderly_run("example", config = path, echo = FALSE)
+  id <- orderly_run("example", path = path, echo = FALSE)
 
   res <- main_args(c("--root", path, "cleanup"))
   expect_equal(res$command, "cleanup")
@@ -280,18 +280,18 @@ test_that("cleanup", {
   expect_false(res$options$failed_only)
   expect_identical(res$target, main_do_cleanup)
 
-  expect_equal(nrow(orderly_list2(config = path, draft = TRUE)), 1)
+  expect_equal(nrow(orderly_list2(path = path, draft = TRUE)), 1)
   expect_true(main_do_cleanup(res))
-  expect_equal(nrow(orderly_list2(config = path, draft = TRUE)), 0)
+  expect_equal(nrow(orderly_list2(path = path, draft = TRUE)), 0)
   expect_null(main_do_cleanup(res))
 })
 
 
 test_that("list", {
   path <- prepare_orderly_example("minimal")
-  id1 <- orderly_run("example", config = path, echo = FALSE)
-  id2 <- orderly_run("example", config = path, echo = FALSE)
-  orderly_commit(id2, config = path)
+  id1 <- orderly_run("example", path = path, echo = FALSE)
+  id2 <- orderly_run("example", path = path, echo = FALSE)
+  orderly_commit(id2, path = path)
 
   res <- main_args(c("--root", path, "list", "names"))
   expect_equal(capture.output(res$target(res)), "example")
@@ -331,7 +331,7 @@ test_that("run: message", {
 
   capture.output(res$target(res))
 
-  con <- orderly_db("destination", config = path)
+  con <- orderly_db("destination", path = path)
   on.exit(DBI::dbDisconnect(con))
   d <- DBI::dbReadTable(con, "changelog")
 

--- a/tests/testthat/test-migrate.R
+++ b/tests/testthat/test-migrate.R
@@ -142,8 +142,8 @@ test_that("mixed migration", {
 
   ## Need to work around an intentional assertion
   writeLines(curr, path_orderly_archive_version(path))
-  id <- orderly_run("example", path = path, echo = FALSE)
-  orderly_commit(id, path = path)
+  id <- orderly_run("example", root = path, echo = FALSE)
+  orderly_commit(id, root = path)
 
   unlink(path_orderly_archive_version(path))
 
@@ -159,12 +159,12 @@ test_that("require migration", {
   on.exit(options(oo))
 
   path <- unpack_reference("0.3.2")
-  expect_error(orderly_run("example", path = path, echo = FALSE),
+  expect_error(orderly_run("example", root = path, echo = FALSE),
                "orderly archive needs migrating from 0.0.0 =>", fixed = TRUE)
-  expect_error(orderly_run("example", path = path, echo = FALSE),
+  expect_error(orderly_run("example", root = path, echo = FALSE),
                "Run orderly::orderly_migrate() to fix", fixed = TRUE)
   orderly_migrate(path)
-  expect_error(orderly_run("example", path = path, echo = FALSE), NA)
+  expect_error(orderly_run("example", root = path, echo = FALSE), NA)
 })
 
 
@@ -179,7 +179,7 @@ test_that("can't commit old version", {
   orderly_migrate(path)
   orderly_rebuild(path)
   expect_error(
-    orderly_commit(id, path = path),
+    orderly_commit(id, root = path),
     "This report was built with an old version of orderly; please rebuild",
     fixed = TRUE)
 })
@@ -207,11 +207,11 @@ test_that("database migrations", {
   DBI::dbDisconnect(con)
   expect_false("published" %in% names(dat))
 
-  orderly_migrate(path = path)
+  orderly_migrate(root = path)
 
-  id <- orderly_run("minimal", path = path, echo = FALSE)
+  id <- orderly_run("minimal", root = path, echo = FALSE)
   expect_error(
-    orderly_commit(id, path = path),
+    orderly_commit(id, root = path),
     "orderly db needs rebuilding with orderly::orderly_rebuild()")
 
   orderly_rebuild(path)
@@ -220,7 +220,7 @@ test_that("database migrations", {
   dat <- DBI::dbReadTable(con, "report_version")
   DBI::dbDisconnect(con)
 
-  expect_error(orderly_commit(id, path = path), NA)
+  expect_error(orderly_commit(id, root = path), NA)
 })
 
 
@@ -232,9 +232,9 @@ test_that("automatic migrations", {
   DBI::dbDisconnect(con)
   expect_false("published" %in% names(dat))
 
-  expect_true(orderly_rebuild(path = path, if_schema_changed = TRUE))
-  expect_false(orderly_rebuild(path = path, if_schema_changed = TRUE))
-  expect_true(orderly_rebuild(path = path, if_schema_changed = FALSE))
+  expect_true(orderly_rebuild(root = path, if_schema_changed = TRUE))
+  expect_false(orderly_rebuild(root = path, if_schema_changed = TRUE))
+  expect_true(orderly_rebuild(root = path, if_schema_changed = FALSE))
 })
 
 

--- a/tests/testthat/test-migrate.R
+++ b/tests/testthat/test-migrate.R
@@ -142,8 +142,8 @@ test_that("mixed migration", {
 
   ## Need to work around an intentional assertion
   writeLines(curr, path_orderly_archive_version(path))
-  id <- orderly_run("example", config = path, echo = FALSE)
-  orderly_commit(id, config = path)
+  id <- orderly_run("example", path = path, echo = FALSE)
+  orderly_commit(id, path = path)
 
   unlink(path_orderly_archive_version(path))
 
@@ -159,12 +159,12 @@ test_that("require migration", {
   on.exit(options(oo))
 
   path <- unpack_reference("0.3.2")
-  expect_error(orderly_run("example", config = path, echo = FALSE),
+  expect_error(orderly_run("example", path = path, echo = FALSE),
                "orderly archive needs migrating from 0.0.0 =>", fixed = TRUE)
-  expect_error(orderly_run("example", config = path, echo = FALSE),
+  expect_error(orderly_run("example", path = path, echo = FALSE),
                "Run orderly::orderly_migrate() to fix", fixed = TRUE)
   orderly_migrate(path)
-  expect_error(orderly_run("example", config = path, echo = FALSE), NA)
+  expect_error(orderly_run("example", path = path, echo = FALSE), NA)
 })
 
 
@@ -179,7 +179,7 @@ test_that("can't commit old version", {
   orderly_migrate(path)
   orderly_rebuild(path)
   expect_error(
-    orderly_commit(id, config = path),
+    orderly_commit(id, path = path),
     "This report was built with an old version of orderly; please rebuild",
     fixed = TRUE)
 })
@@ -207,11 +207,11 @@ test_that("database migrations", {
   DBI::dbDisconnect(con)
   expect_false("published" %in% names(dat))
 
-  orderly_migrate(config = path)
+  orderly_migrate(path = path)
 
-  id <- orderly_run("minimal", config = path, echo = FALSE)
+  id <- orderly_run("minimal", path = path, echo = FALSE)
   expect_error(
-    orderly_commit(id, config = path),
+    orderly_commit(id, path = path),
     "orderly db needs rebuilding with orderly::orderly_rebuild()")
 
   orderly_rebuild(path)
@@ -220,7 +220,7 @@ test_that("database migrations", {
   dat <- DBI::dbReadTable(con, "report_version")
   DBI::dbDisconnect(con)
 
-  expect_error(orderly_commit(id, config = path), NA)
+  expect_error(orderly_commit(id, path = path), NA)
 })
 
 
@@ -232,9 +232,9 @@ test_that("automatic migrations", {
   DBI::dbDisconnect(con)
   expect_false("published" %in% names(dat))
 
-  expect_true(orderly_rebuild(config = path, if_schema_changed = TRUE))
-  expect_false(orderly_rebuild(config = path, if_schema_changed = TRUE))
-  expect_true(orderly_rebuild(config = path, if_schema_changed = FALSE))
+  expect_true(orderly_rebuild(path = path, if_schema_changed = TRUE))
+  expect_false(orderly_rebuild(path = path, if_schema_changed = TRUE))
+  expect_true(orderly_rebuild(path = path, if_schema_changed = FALSE))
 })
 
 

--- a/tests/testthat/test-new.R
+++ b/tests/testthat/test-new.R
@@ -111,7 +111,7 @@ test_that("custom template copies all files", {
 test_that("missing templates are an error", {
   path <- prepare_orderly_example("minimal")
   expect_error(
-    orderly_new("testing", config = path, template = "foo"),
+    orderly_new("testing", path = path, template = "foo"),
     "Did not find file 'template/foo/orderly.yml' within orderly root")
   expect_false(file.exists(file.path(path, "src", "testing")))
 })

--- a/tests/testthat/test-new.R
+++ b/tests/testthat/test-new.R
@@ -111,7 +111,7 @@ test_that("custom template copies all files", {
 test_that("missing templates are an error", {
   path <- prepare_orderly_example("minimal")
   expect_error(
-    orderly_new("testing", path = path, template = "foo"),
+    orderly_new("testing", root = path, template = "foo"),
     "Did not find file 'template/foo/orderly.yml' within orderly root")
   expect_false(file.exists(file.path(path, "src", "testing")))
 })

--- a/tests/testthat/test-orderly.R
+++ b/tests/testthat/test-orderly.R
@@ -53,8 +53,8 @@ test_that("init - no doc", {
 
 test_that("orderly_run_info reports on artefacts", {
   path <- prepare_orderly_example("depends")
-  id1 <- orderly_run("example", config = path, echo = FALSE)
-  id2 <- orderly_run("depend", config = path, echo = FALSE)
+  id1 <- orderly_run("example", path = path, echo = FALSE)
+  id2 <- orderly_run("depend", path = path, echo = FALSE)
 
   d <- readRDS(file.path(path, "draft", "depend", id2, "output.rds"))
   expect_equal(d$depends$id, id1)
@@ -69,8 +69,8 @@ test_that("orderly_run_info errors when not running", {
 
 test_that("orderly_run_info is usable from test_start", {
   path <- prepare_orderly_example("depends")
-  id1 <- orderly_run("example", config = path, echo = FALSE)
-  id2 <- orderly_test_start("depend", config = path)
+  id1 <- orderly_run("example", path = path, echo = FALSE)
+  id2 <- orderly_test_start("depend", path = path)
   on.exit(orderly_test_end())
   info <- orderly_run_info()
   expect_equal(info$depends$id, id1)
@@ -85,11 +85,11 @@ test_that("orderly_run_info is usable from test_start", {
 
 test_that("orderly_run_info: is_latest detects latest version", {
   path <- prepare_orderly_example("depends")
-  id1 <- orderly_run("example", config = path, echo = FALSE)
-  id2 <- orderly_run("example", config = path, echo = FALSE)
+  id1 <- orderly_run("example", path = path, echo = FALSE)
+  id2 <- orderly_run("example", path = path, echo = FALSE)
 
   f <- function() {
-    orderly_test_start("depend", config = path)
+    orderly_test_start("depend", path = path)
     on.exit(orderly_test_end())
     info <- orderly_run_info()
     info
@@ -120,7 +120,7 @@ test_that("orderly_test_start failure resets working directory", {
   txt <- c(readLines(p), "packages: nonexistantpackage")
   writeLines(txt, p)
   wd <- getwd()
-  expect_error(orderly_test_start("example", config = path),
+  expect_error(orderly_test_start("example", path = path),
                "nonexistantpackage")
   expect_equal(getwd(), wd)
 })
@@ -128,7 +128,7 @@ test_that("orderly_test_start failure resets working directory", {
 
 test_that("can't depend on non artefacts", {
   path <- prepare_orderly_example("depends")
-  id <- orderly_run("example", config = path, echo = FALSE)
+  id <- orderly_run("example", path = path, echo = FALSE)
 
   path_yml <- file.path(path, "src", "depend", "orderly.yml")
   d <- yaml_read(path_yml)
@@ -137,15 +137,15 @@ test_that("can't depend on non artefacts", {
   yaml_write(d, path_yml)
 
   expect_error(
-    orderly_run("depend", config = path, echo = FALSE),
+    orderly_run("depend", path = path, echo = FALSE),
     "Dependency file not an artefact of example/.*:\n- 'script.R'")
 })
 
 
 test_that("dependency dir can be used", {
   path <- prepare_orderly_example("demo")
-  id <- orderly_run("use_resource_dir", config = path, echo = FALSE)
-  p <- orderly_commit(id, config = path)
+  id <- orderly_run("use_resource_dir", path = path, echo = FALSE)
+  p <- orderly_commit(id, path = path)
   con <- orderly_db("destination", path)
   on.exit(DBI::dbDisconnect(con))
 
@@ -161,25 +161,25 @@ test_that("dependency dir can be used", {
 test_that("can't commit out of order", {
   path <- prepare_orderly_example("minimal")
 
-  id1 <- orderly_run("example", config = path, echo = FALSE)
-  id2 <- orderly_run("example", config = path, echo = FALSE)
+  id1 <- orderly_run("example", path = path, echo = FALSE)
+  id2 <- orderly_run("example", path = path, echo = FALSE)
 
-  orderly_commit(id2, config = path)
-  expect_error(orderly_commit(id1, config = path),
+  orderly_commit(id2, path = path)
+  expect_error(orderly_commit(id1, path = path),
                "Report id '.+?' is behind existing id '.+?'")
 
   expect_equal(dir(file.path(path, "archive", "example")), id2)
   expect_equal(dir(file.path(path, "draft", "example")), id1)
 
-  id3 <- orderly_run("example", config = path, echo = FALSE)
-  expect_error(orderly_commit(id3, config = path), NA)
+  id3 <- orderly_run("example", path = path, echo = FALSE)
+  expect_error(orderly_commit(id3, path = path), NA)
 })
 
 
 test_that("archive directory is created when needed", {
   path <- prepare_orderly_example("minimal")
   unlink(file.path(path, "archive"), recursive = TRUE)
-  orderly_run("example", config = path, echo = FALSE)
+  orderly_run("example", path = path, echo = FALSE)
   expect_true(file.exists(path_orderly_archive_version(path)))
 })
 

--- a/tests/testthat/test-orderly.R
+++ b/tests/testthat/test-orderly.R
@@ -53,8 +53,8 @@ test_that("init - no doc", {
 
 test_that("orderly_run_info reports on artefacts", {
   path <- prepare_orderly_example("depends")
-  id1 <- orderly_run("example", path = path, echo = FALSE)
-  id2 <- orderly_run("depend", path = path, echo = FALSE)
+  id1 <- orderly_run("example", root = path, echo = FALSE)
+  id2 <- orderly_run("depend", root = path, echo = FALSE)
 
   d <- readRDS(file.path(path, "draft", "depend", id2, "output.rds"))
   expect_equal(d$depends$id, id1)
@@ -69,8 +69,8 @@ test_that("orderly_run_info errors when not running", {
 
 test_that("orderly_run_info is usable from test_start", {
   path <- prepare_orderly_example("depends")
-  id1 <- orderly_run("example", path = path, echo = FALSE)
-  id2 <- orderly_test_start("depend", path = path)
+  id1 <- orderly_run("example", root = path, echo = FALSE)
+  id2 <- orderly_test_start("depend", root = path)
   on.exit(orderly_test_end())
   info <- orderly_run_info()
   expect_equal(info$depends$id, id1)
@@ -85,11 +85,11 @@ test_that("orderly_run_info is usable from test_start", {
 
 test_that("orderly_run_info: is_latest detects latest version", {
   path <- prepare_orderly_example("depends")
-  id1 <- orderly_run("example", path = path, echo = FALSE)
-  id2 <- orderly_run("example", path = path, echo = FALSE)
+  id1 <- orderly_run("example", root = path, echo = FALSE)
+  id2 <- orderly_run("example", root = path, echo = FALSE)
 
   f <- function() {
-    orderly_test_start("depend", path = path)
+    orderly_test_start("depend", root = path)
     on.exit(orderly_test_end())
     info <- orderly_run_info()
     info
@@ -120,7 +120,7 @@ test_that("orderly_test_start failure resets working directory", {
   txt <- c(readLines(p), "packages: nonexistantpackage")
   writeLines(txt, p)
   wd <- getwd()
-  expect_error(orderly_test_start("example", path = path),
+  expect_error(orderly_test_start("example", root = path),
                "nonexistantpackage")
   expect_equal(getwd(), wd)
 })
@@ -128,7 +128,7 @@ test_that("orderly_test_start failure resets working directory", {
 
 test_that("can't depend on non artefacts", {
   path <- prepare_orderly_example("depends")
-  id <- orderly_run("example", path = path, echo = FALSE)
+  id <- orderly_run("example", root = path, echo = FALSE)
 
   path_yml <- file.path(path, "src", "depend", "orderly.yml")
   d <- yaml_read(path_yml)
@@ -137,15 +137,15 @@ test_that("can't depend on non artefacts", {
   yaml_write(d, path_yml)
 
   expect_error(
-    orderly_run("depend", path = path, echo = FALSE),
+    orderly_run("depend", root = path, echo = FALSE),
     "Dependency file not an artefact of example/.*:\n- 'script.R'")
 })
 
 
 test_that("dependency dir can be used", {
   path <- prepare_orderly_example("demo")
-  id <- orderly_run("use_resource_dir", path = path, echo = FALSE)
-  p <- orderly_commit(id, path = path)
+  id <- orderly_run("use_resource_dir", root = path, echo = FALSE)
+  p <- orderly_commit(id, root = path)
   con <- orderly_db("destination", path)
   on.exit(DBI::dbDisconnect(con))
 
@@ -161,25 +161,25 @@ test_that("dependency dir can be used", {
 test_that("can't commit out of order", {
   path <- prepare_orderly_example("minimal")
 
-  id1 <- orderly_run("example", path = path, echo = FALSE)
-  id2 <- orderly_run("example", path = path, echo = FALSE)
+  id1 <- orderly_run("example", root = path, echo = FALSE)
+  id2 <- orderly_run("example", root = path, echo = FALSE)
 
-  orderly_commit(id2, path = path)
-  expect_error(orderly_commit(id1, path = path),
+  orderly_commit(id2, root = path)
+  expect_error(orderly_commit(id1, root = path),
                "Report id '.+?' is behind existing id '.+?'")
 
   expect_equal(dir(file.path(path, "archive", "example")), id2)
   expect_equal(dir(file.path(path, "draft", "example")), id1)
 
-  id3 <- orderly_run("example", path = path, echo = FALSE)
-  expect_error(orderly_commit(id3, path = path), NA)
+  id3 <- orderly_run("example", root = path, echo = FALSE)
+  expect_error(orderly_commit(id3, root = path), NA)
 })
 
 
 test_that("archive directory is created when needed", {
   path <- prepare_orderly_example("minimal")
   unlink(file.path(path, "archive"), recursive = TRUE)
-  orderly_run("example", path = path, echo = FALSE)
+  orderly_run("example", root = path, echo = FALSE)
   expect_true(file.exists(path_orderly_archive_version(path)))
 })
 

--- a/tests/testthat/test-publish.R
+++ b/tests/testthat/test-publish.R
@@ -2,7 +2,7 @@ context("publish")
 
 test_that("included example", {
   read_published <- function(path) {
-    con <- orderly_db("destination", path = path)
+    con <- orderly_db("destination", root = path)
     on.exit(DBI::dbDisconnect(con))
     d <- DBI::dbReadTable(con, "report_version")
     d$published
@@ -11,30 +11,30 @@ test_that("included example", {
   path <- prepare_orderly_example("example")
   expect_equal(read_published(path), numeric(0))
 
-  id <- orderly_run("example", list(cyl = 4), path = path, echo = FALSE)
-  p <- orderly_commit(id, path = path)
+  id <- orderly_run("example", list(cyl = 4), root = path, echo = FALSE)
+  p <- orderly_commit(id, root = path)
 
   yml <- path_orderly_published_yml(p)
   expect_false(file.exists(yml))
   expect_equal(read_published(path), 0)
 
-  orderly_publish(id, path = path)
+  orderly_publish(id, root = path)
   expect_equal(read_published(path), 1)
   expect_true(file.exists(yml))
   expect_equal(yaml_read(yml), list(published = TRUE))
 
-  expect_message(orderly_publish(id, path = path),
+  expect_message(orderly_publish(id, root = path),
                  "Report is already published")
   expect_equal(read_published(path), 1)
   expect_true(file.exists(yml))
   expect_equal(yaml_read(yml), list(published = TRUE))
 
-  orderly_publish(id, value = FALSE, path = path)
+  orderly_publish(id, value = FALSE, root = path)
   expect_equal(read_published(path), 0)
   expect_true(file.exists(yml))
   expect_equal(yaml_read(yml), list(published = FALSE))
 
-  expect_message(orderly_publish(id, value = FALSE, path = path),
+  expect_message(orderly_publish(id, value = FALSE, root = path),
                  "Report is already unpublished")
   expect_equal(read_published(path), 0)
   expect_true(file.exists(yml))

--- a/tests/testthat/test-publish.R
+++ b/tests/testthat/test-publish.R
@@ -2,7 +2,7 @@ context("publish")
 
 test_that("included example", {
   read_published <- function(path) {
-    con <- orderly_db("destination", config = path)
+    con <- orderly_db("destination", path = path)
     on.exit(DBI::dbDisconnect(con))
     d <- DBI::dbReadTable(con, "report_version")
     d$published
@@ -11,30 +11,30 @@ test_that("included example", {
   path <- prepare_orderly_example("example")
   expect_equal(read_published(path), numeric(0))
 
-  id <- orderly_run("example", list(cyl = 4), config = path, echo = FALSE)
-  p <- orderly_commit(id, config = path)
+  id <- orderly_run("example", list(cyl = 4), path = path, echo = FALSE)
+  p <- orderly_commit(id, path = path)
 
   yml <- path_orderly_published_yml(p)
   expect_false(file.exists(yml))
   expect_equal(read_published(path), 0)
 
-  orderly_publish(id, config = path)
+  orderly_publish(id, path = path)
   expect_equal(read_published(path), 1)
   expect_true(file.exists(yml))
   expect_equal(yaml_read(yml), list(published = TRUE))
 
-  expect_message(orderly_publish(id, config = path),
+  expect_message(orderly_publish(id, path = path),
                  "Report is already published")
   expect_equal(read_published(path), 1)
   expect_true(file.exists(yml))
   expect_equal(yaml_read(yml), list(published = TRUE))
 
-  orderly_publish(id, value = FALSE, config = path)
+  orderly_publish(id, value = FALSE, path = path)
   expect_equal(read_published(path), 0)
   expect_true(file.exists(yml))
   expect_equal(yaml_read(yml), list(published = FALSE))
 
-  expect_message(orderly_publish(id, value = FALSE, config = path),
+  expect_message(orderly_publish(id, value = FALSE, path = path),
                  "Report is already unpublished")
   expect_equal(read_published(path), 0)
   expect_true(file.exists(yml))

--- a/tests/testthat/test-query.R
+++ b/tests/testthat/test-query.R
@@ -20,16 +20,16 @@ test_that("non-empty", {
 
 test_that("query through lifecycle", {
   path <- prepare_orderly_example("minimal")
-  expect_equal(orderly_list(config = path), "example")
+  expect_equal(orderly_list(path = path), "example")
 
   empty <- data.frame(name = character(0), id = character(0),
                       stringsAsFactors = FALSE)
   expect_equal(orderly_list_drafts(path), empty)
   expect_equal(orderly_list_archive(path), empty)
 
-  id <- orderly_run("example", config = path, echo = FALSE)
+  id <- orderly_run("example", path = path, echo = FALSE)
 
-  p <- orderly_locate(id, config = path)
+  p <- orderly_locate(id, path = path)
   expect_true(file.exists(p))
   expect_equal(basename(dirname(p)), "example")
   expect_equal(basename(dirname(dirname(p))), "draft")
@@ -51,9 +51,9 @@ test_that("query through lifecycle", {
                "Did not find draft report")
   expect_null(orderly_find_name("id", path, FALSE, TRUE, FALSE))
 
-  orderly_commit(id, config = path)
+  orderly_commit(id, path = path)
 
-  p <- orderly_locate(id, config = path)
+  p <- orderly_locate(id, path = path)
   expect_true(file.exists(p))
   expect_equal(basename(dirname(p)), "example")
   expect_equal(basename(dirname(dirname(p))), "archive")
@@ -103,71 +103,71 @@ test_that("latest_ids", {
 test_that("latest", {
   path <- prepare_orderly_example("minimal")
 
-  expect_equal(orderly_latest("example", config = path, must_work = FALSE),
+  expect_equal(orderly_latest("example", path = path, must_work = FALSE),
                NA_character_)
-  expect_equal(orderly_latest("example", config = path, must_work = FALSE,
+  expect_equal(orderly_latest("example", path = path, must_work = FALSE,
                               draft = TRUE),
                NA_character_)
-  expect_error(orderly_latest("example", config = path),
+  expect_error(orderly_latest("example", path = path),
                "Did not find any archive reports for example")
-  expect_error(orderly_latest("example", config = path, draft = TRUE),
+  expect_error(orderly_latest("example", path = path, draft = TRUE),
                "Did not find any draft reports for example")
 
-  expect_equal(orderly_latest(NULL, config = path, must_work = FALSE),
+  expect_equal(orderly_latest(NULL, path = path, must_work = FALSE),
                NA_character_)
 
-  id1 <- orderly_run("example", config = path, echo = FALSE)
-  expect_equal(orderly_latest(NULL, config = path, draft = TRUE),
+  id1 <- orderly_run("example", path = path, echo = FALSE)
+  expect_equal(orderly_latest(NULL, path = path, draft = TRUE),
                id1)
-  expect_equal(orderly_latest(NULL, config = path, draft = FALSE,
+  expect_equal(orderly_latest(NULL, path = path, draft = FALSE,
                               must_work = FALSE), NA_character_)
   Sys.sleep(0.1)
-  id2 <- orderly_run("example", config = path, echo = FALSE)
-  expect_equal(orderly_latest("example", config = path, draft = TRUE), id2)
-  expect_equal(orderly_latest(NULL, config = path, draft = TRUE),
+  id2 <- orderly_run("example", path = path, echo = FALSE)
+  expect_equal(orderly_latest("example", path = path, draft = TRUE), id2)
+  expect_equal(orderly_latest(NULL, path = path, draft = TRUE),
                id2)
-  expect_equal(orderly_latest(NULL, config = path, draft = FALSE,
+  expect_equal(orderly_latest(NULL, path = path, draft = FALSE,
                               must_work = FALSE), NA_character_)
 
-  orderly_commit(id2, config = path)
-  expect_equal(orderly_latest("example", config = path, draft = TRUE), id1)
-  expect_equal(orderly_latest("example", config = path), id2)
+  orderly_commit(id2, path = path)
+  expect_equal(orderly_latest("example", path = path, draft = TRUE), id1)
+  expect_equal(orderly_latest("example", path = path), id2)
 })
 
 
 test_that("Behaviour with rogue files", {
   path <- prepare_orderly_example("minimal")
-  id1 <- orderly_run("example", config = path, echo = FALSE)
-  id2 <- orderly_run("example", config = path, echo = FALSE)
-  p1 <- orderly_commit(id1, config = path)
-  p2 <- orderly_commit(id2, config = path)
-  expect_equal(orderly_latest("example", config = path), id2)
+  id1 <- orderly_run("example", path = path, echo = FALSE)
+  id2 <- orderly_run("example", path = path, echo = FALSE)
+  p1 <- orderly_commit(id1, path = path)
+  p2 <- orderly_commit(id2, path = path)
+  expect_equal(orderly_latest("example", path = path), id2)
 
   zip_dir(file.path(path, "archive", "example", id2))
 
   expect_error(
-    orderly_latest("example", config = path),
+    orderly_latest("example", path = path),
     "Unexpected files within orderly directory '.*archive/example': '.*\\.zip'")
 })
 
 
 test_that("orderly_last_id", {
   path <- prepare_orderly_example("minimal")
-  id1 <- orderly_run("example", config = path, echo = FALSE)
-  id2 <- orderly_run("example", config = path, echo = FALSE)
-  expect_equal(orderly_last_id(config = path), id2)
-  expect_identical(orderly_last_id(config = path, draft = FALSE),
+  id1 <- orderly_run("example", path = path, echo = FALSE)
+  id2 <- orderly_run("example", path = path, echo = FALSE)
+  expect_equal(orderly_last_id(path = path), id2)
+  expect_identical(orderly_last_id(path = path, draft = FALSE),
                    NA_character_)
-  orderly_commit(id2, config = path)
-  expect_equal(orderly_last_id(config = path), id1)
-  expect_equal(orderly_last_id(config = path, draft = FALSE), id2)
+  orderly_commit(id2, path = path)
+  expect_equal(orderly_last_id(path = path), id1)
+  expect_equal(orderly_last_id(path = path, draft = FALSE), id2)
 })
 
 
 test_that("orderly_find_report", {
   path <- prepare_orderly_example("minimal")
-  id1 <- orderly_run("example", config = path, echo = FALSE)
-  id2 <- orderly_run("example", config = path, echo = FALSE)
+  id1 <- orderly_run("example", path = path, echo = FALSE)
+  id2 <- orderly_run("example", path = path, echo = FALSE)
 
   p <- orderly_find_report("latest", "example", config = path)
   expect_equal(normalizePath(p),
@@ -191,8 +191,8 @@ test_that("orderly_find_report", {
 
 test_that("orderly_locate", {
   path <- prepare_orderly_example("minimal")
-  id1 <- orderly_run("example", config = path, echo = FALSE)
-  id2 <- orderly_run("example", config = path, echo = FALSE)
+  id1 <- orderly_run("example", path = path, echo = FALSE)
+  id2 <- orderly_run("example", path = path, echo = FALSE)
 
   expect_equal(
     normalizePath(orderly_locate("latest", "example", path, draft = TRUE)),
@@ -229,8 +229,8 @@ test_that("orderly_open", {
   mockery::stub(orderly_open, "open_directory", identity)
 
   path <- prepare_orderly_example("minimal")
-  id <- orderly_run("example", config = path, echo = FALSE)
-  res <- orderly_open(id, config = path)
+  id <- orderly_run("example", path = path, echo = FALSE)
+  res <- orderly_open(id, path = path)
   expect_equal(normalizePath(res),
                normalizePath(file.path(path, "draft", "example", id)))
 })
@@ -240,8 +240,8 @@ test_that("orderly_open_latest", {
   mockery::stub(orderly_open_latest, "open_directory", identity)
 
   path <- prepare_orderly_example("minimal")
-  id <- orderly_run("example", config = path, echo = FALSE)
-  res <- orderly_open_latest(config = path, draft = TRUE)
+  id <- orderly_run("example", path = path, echo = FALSE)
+  res <- orderly_open_latest(path = path, draft = TRUE)
   expect_equal(normalizePath(res),
                normalizePath(file.path(path, "draft", "example", id)))
 })

--- a/tests/testthat/test-query.R
+++ b/tests/testthat/test-query.R
@@ -20,16 +20,16 @@ test_that("non-empty", {
 
 test_that("query through lifecycle", {
   path <- prepare_orderly_example("minimal")
-  expect_equal(orderly_list(path = path), "example")
+  expect_equal(orderly_list(root = path), "example")
 
   empty <- data.frame(name = character(0), id = character(0),
                       stringsAsFactors = FALSE)
   expect_equal(orderly_list_drafts(path), empty)
   expect_equal(orderly_list_archive(path), empty)
 
-  id <- orderly_run("example", path = path, echo = FALSE)
+  id <- orderly_run("example", root = path, echo = FALSE)
 
-  p <- orderly_locate(id, path = path)
+  p <- orderly_locate(id, root = path)
   expect_true(file.exists(p))
   expect_equal(basename(dirname(p)), "example")
   expect_equal(basename(dirname(dirname(p))), "draft")
@@ -51,9 +51,9 @@ test_that("query through lifecycle", {
                "Did not find draft report")
   expect_null(orderly_find_name("id", path, FALSE, TRUE, FALSE))
 
-  orderly_commit(id, path = path)
+  orderly_commit(id, root = path)
 
-  p <- orderly_locate(id, path = path)
+  p <- orderly_locate(id, root = path)
   expect_true(file.exists(p))
   expect_equal(basename(dirname(p)), "example")
   expect_equal(basename(dirname(dirname(p))), "archive")
@@ -103,71 +103,71 @@ test_that("latest_ids", {
 test_that("latest", {
   path <- prepare_orderly_example("minimal")
 
-  expect_equal(orderly_latest("example", path = path, must_work = FALSE),
+  expect_equal(orderly_latest("example", root = path, must_work = FALSE),
                NA_character_)
-  expect_equal(orderly_latest("example", path = path, must_work = FALSE,
+  expect_equal(orderly_latest("example", root = path, must_work = FALSE,
                               draft = TRUE),
                NA_character_)
-  expect_error(orderly_latest("example", path = path),
+  expect_error(orderly_latest("example", root = path),
                "Did not find any archive reports for example")
-  expect_error(orderly_latest("example", path = path, draft = TRUE),
+  expect_error(orderly_latest("example", root = path, draft = TRUE),
                "Did not find any draft reports for example")
 
-  expect_equal(orderly_latest(NULL, path = path, must_work = FALSE),
+  expect_equal(orderly_latest(NULL, root = path, must_work = FALSE),
                NA_character_)
 
-  id1 <- orderly_run("example", path = path, echo = FALSE)
-  expect_equal(orderly_latest(NULL, path = path, draft = TRUE),
+  id1 <- orderly_run("example", root = path, echo = FALSE)
+  expect_equal(orderly_latest(NULL, root = path, draft = TRUE),
                id1)
-  expect_equal(orderly_latest(NULL, path = path, draft = FALSE,
+  expect_equal(orderly_latest(NULL, root = path, draft = FALSE,
                               must_work = FALSE), NA_character_)
   Sys.sleep(0.1)
-  id2 <- orderly_run("example", path = path, echo = FALSE)
-  expect_equal(orderly_latest("example", path = path, draft = TRUE), id2)
-  expect_equal(orderly_latest(NULL, path = path, draft = TRUE),
+  id2 <- orderly_run("example", root = path, echo = FALSE)
+  expect_equal(orderly_latest("example", root = path, draft = TRUE), id2)
+  expect_equal(orderly_latest(NULL, root = path, draft = TRUE),
                id2)
-  expect_equal(orderly_latest(NULL, path = path, draft = FALSE,
+  expect_equal(orderly_latest(NULL, root = path, draft = FALSE,
                               must_work = FALSE), NA_character_)
 
-  orderly_commit(id2, path = path)
-  expect_equal(orderly_latest("example", path = path, draft = TRUE), id1)
-  expect_equal(orderly_latest("example", path = path), id2)
+  orderly_commit(id2, root = path)
+  expect_equal(orderly_latest("example", root = path, draft = TRUE), id1)
+  expect_equal(orderly_latest("example", root = path), id2)
 })
 
 
 test_that("Behaviour with rogue files", {
   path <- prepare_orderly_example("minimal")
-  id1 <- orderly_run("example", path = path, echo = FALSE)
-  id2 <- orderly_run("example", path = path, echo = FALSE)
-  p1 <- orderly_commit(id1, path = path)
-  p2 <- orderly_commit(id2, path = path)
-  expect_equal(orderly_latest("example", path = path), id2)
+  id1 <- orderly_run("example", root = path, echo = FALSE)
+  id2 <- orderly_run("example", root = path, echo = FALSE)
+  p1 <- orderly_commit(id1, root = path)
+  p2 <- orderly_commit(id2, root = path)
+  expect_equal(orderly_latest("example", root = path), id2)
 
   zip_dir(file.path(path, "archive", "example", id2))
 
   expect_error(
-    orderly_latest("example", path = path),
+    orderly_latest("example", root = path),
     "Unexpected files within orderly directory '.*archive/example': '.*\\.zip'")
 })
 
 
 test_that("orderly_last_id", {
   path <- prepare_orderly_example("minimal")
-  id1 <- orderly_run("example", path = path, echo = FALSE)
-  id2 <- orderly_run("example", path = path, echo = FALSE)
-  expect_equal(orderly_last_id(path = path), id2)
-  expect_identical(orderly_last_id(path = path, draft = FALSE),
+  id1 <- orderly_run("example", root = path, echo = FALSE)
+  id2 <- orderly_run("example", root = path, echo = FALSE)
+  expect_equal(orderly_last_id(root = path), id2)
+  expect_identical(orderly_last_id(root = path, draft = FALSE),
                    NA_character_)
-  orderly_commit(id2, path = path)
-  expect_equal(orderly_last_id(path = path), id1)
-  expect_equal(orderly_last_id(path = path, draft = FALSE), id2)
+  orderly_commit(id2, root = path)
+  expect_equal(orderly_last_id(root = path), id1)
+  expect_equal(orderly_last_id(root = path, draft = FALSE), id2)
 })
 
 
 test_that("orderly_find_report", {
   path <- prepare_orderly_example("minimal")
-  id1 <- orderly_run("example", path = path, echo = FALSE)
-  id2 <- orderly_run("example", path = path, echo = FALSE)
+  id1 <- orderly_run("example", root = path, echo = FALSE)
+  id2 <- orderly_run("example", root = path, echo = FALSE)
 
   p <- orderly_find_report("latest", "example", config = path)
   expect_equal(normalizePath(p),
@@ -191,8 +191,8 @@ test_that("orderly_find_report", {
 
 test_that("orderly_locate", {
   path <- prepare_orderly_example("minimal")
-  id1 <- orderly_run("example", path = path, echo = FALSE)
-  id2 <- orderly_run("example", path = path, echo = FALSE)
+  id1 <- orderly_run("example", root = path, echo = FALSE)
+  id2 <- orderly_run("example", root = path, echo = FALSE)
 
   expect_equal(
     normalizePath(orderly_locate("latest", "example", path, draft = TRUE)),
@@ -229,8 +229,8 @@ test_that("orderly_open", {
   mockery::stub(orderly_open, "open_directory", identity)
 
   path <- prepare_orderly_example("minimal")
-  id <- orderly_run("example", path = path, echo = FALSE)
-  res <- orderly_open(id, path = path)
+  id <- orderly_run("example", root = path, echo = FALSE)
+  res <- orderly_open(id, root = path)
   expect_equal(normalizePath(res),
                normalizePath(file.path(path, "draft", "example", id)))
 })
@@ -240,8 +240,8 @@ test_that("orderly_open_latest", {
   mockery::stub(orderly_open_latest, "open_directory", identity)
 
   path <- prepare_orderly_example("minimal")
-  id <- orderly_run("example", path = path, echo = FALSE)
-  res <- orderly_open_latest(path = path, draft = TRUE)
+  id <- orderly_run("example", root = path, echo = FALSE)
+  res <- orderly_open_latest(root = path, draft = TRUE)
   expect_equal(normalizePath(res),
                normalizePath(file.path(path, "draft", "example", id)))
 })

--- a/tests/testthat/test-readme.R
+++ b/tests/testthat/test-readme.R
@@ -5,11 +5,11 @@ test_that("auto copy README.md",  {
   ## in report directory create a file called README.md
   report_path <- file.path(path, "src", "example")
   file.create(file.path(report_path, "README.md"))
-  id <- orderly_run("example", path = path, echo = FALSE)
+  id <- orderly_run("example", root = path, echo = FALSE)
   p <- file.path(path, "draft", "example", id)
   expect_true(file.exists(file.path(p, "README.md")))
-  orderly_commit(id, path = path)
-  con <- orderly_db("destination", path = path)
+  orderly_commit(id, root = path)
+  con <- orderly_db("destination", root = path)
   on.exit(DBI::dbDisconnect(con))
   dat <- DBI::dbReadTable(con, "file_input")
   expect_equal(sum(dat$filename == "README.md"), 1)
@@ -20,11 +20,11 @@ test_that("lowercase README.md",  {
   ## in report directory create a file called README.md
   report_path <- file.path(path, "src", "example")
   file.create(file.path(report_path, "readme.MD"))
-  id <- orderly_run("example", path = path, echo = FALSE)
+  id <- orderly_run("example", root = path, echo = FALSE)
   p <- file.path(path, "draft", "example", id)
   expect_true(file.exists(file.path(p, "README.md")))
-  orderly_commit(id, path = path)
-  con <- orderly_db("destination", path = path)
+  orderly_commit(id, root = path)
+  con <- orderly_db("destination", root = path)
   on.exit(DBI::dbDisconnect(con))
   dat <- DBI::dbReadTable(con, "file_input")
   expect_equal(sum(dat$filename == "README.md"), 1)
@@ -46,11 +46,11 @@ test_that("list README.md as resource",  {
 
   file.create(file.path(path_example, "README.md"))
   messages <- capture_messages(
-    id <- orderly_run("example", path = path, echo = FALSE))
+    id <- orderly_run("example", root = path, echo = FALSE))
   # ...make sure none of the messages contain "unexpected"
   expect_true(any(grep("readme", messages)))
-  orderly_commit(id, path = path)
-  con <- orderly_db("destination", path = path)
+  orderly_commit(id, root = path)
+  con <- orderly_db("destination", root = path)
   on.exit(DBI::dbDisconnect(con))
   dat <- DBI::dbReadTable(con, "file_input")
   expect_equal(sum(dat$filename == "README.md"), 2)
@@ -79,7 +79,7 @@ test_that("list README.md as artefact",  {
            )
   writeLines(yml, file.path(yml_path))
 
-  expect_error(orderly_run("example", path = path),
+  expect_error(orderly_run("example", root = path),
                "README.md should not be listed as an artefact")
 })
 
@@ -87,10 +87,10 @@ test_that("readme db",  {
   path <- prepare_orderly_example("minimal")
   report_path <- file.path(path, "src", "example")
   file.create(file.path(report_path, "README.md"))
-  id <- orderly_run("example", path = path, echo = FALSE)
-  orderly_commit(id, path = path)
+  id <- orderly_run("example", root = path, echo = FALSE)
+  orderly_commit(id, root = path)
 
-  con <- orderly_db("destination", path = path)
+  con <- orderly_db("destination", root = path)
   ## read the file input table
   d <- DBI::dbReadTable(con, "file_input")
   DBI::dbDisconnect(con)

--- a/tests/testthat/test-readme.R
+++ b/tests/testthat/test-readme.R
@@ -5,11 +5,11 @@ test_that("auto copy README.md",  {
   ## in report directory create a file called README.md
   report_path <- file.path(path, "src", "example")
   file.create(file.path(report_path, "README.md"))
-  id <- orderly_run("example", config = path, echo = FALSE)
+  id <- orderly_run("example", path = path, echo = FALSE)
   p <- file.path(path, "draft", "example", id)
   expect_true(file.exists(file.path(p, "README.md")))
-  orderly_commit(id, config = path)
-  con <- orderly_db("destination", config = path)
+  orderly_commit(id, path = path)
+  con <- orderly_db("destination", path = path)
   on.exit(DBI::dbDisconnect(con))
   dat <- DBI::dbReadTable(con, "file_input")
   expect_equal(sum(dat$filename == "README.md"), 1)
@@ -20,11 +20,11 @@ test_that("lowercase README.md",  {
   ## in report directory create a file called README.md
   report_path <- file.path(path, "src", "example")
   file.create(file.path(report_path, "readme.MD"))
-  id <- orderly_run("example", config = path, echo = FALSE)
+  id <- orderly_run("example", path = path, echo = FALSE)
   p <- file.path(path, "draft", "example", id)
   expect_true(file.exists(file.path(p, "README.md")))
-  orderly_commit(id, config = path)
-  con <- orderly_db("destination", config = path)
+  orderly_commit(id, path = path)
+  con <- orderly_db("destination", path = path)
   on.exit(DBI::dbDisconnect(con))
   dat <- DBI::dbReadTable(con, "file_input")
   expect_equal(sum(dat$filename == "README.md"), 1)
@@ -46,11 +46,11 @@ test_that("list README.md as resource",  {
 
   file.create(file.path(path_example, "README.md"))
   messages <- capture_messages(
-    id <- orderly_run("example", config = path, echo = FALSE))
+    id <- orderly_run("example", path = path, echo = FALSE))
   # ...make sure none of the messages contain "unexpected"
   expect_true(any(grep("readme", messages)))
-  orderly_commit(id, config = path)
-  con <- orderly_db("destination", config = path)
+  orderly_commit(id, path = path)
+  con <- orderly_db("destination", path = path)
   on.exit(DBI::dbDisconnect(con))
   dat <- DBI::dbReadTable(con, "file_input")
   expect_equal(sum(dat$filename == "README.md"), 2)
@@ -79,7 +79,7 @@ test_that("list README.md as artefact",  {
            )
   writeLines(yml, file.path(yml_path))
 
-  expect_error(orderly_run("example", config = path),
+  expect_error(orderly_run("example", path = path),
                "README.md should not be listed as an artefact")
 })
 
@@ -87,10 +87,10 @@ test_that("readme db",  {
   path <- prepare_orderly_example("minimal")
   report_path <- file.path(path, "src", "example")
   file.create(file.path(report_path, "README.md"))
-  id <- orderly_run("example", config = path, echo = FALSE)
-  orderly_commit(id, config = path)
+  id <- orderly_run("example", path = path, echo = FALSE)
+  orderly_commit(id, path = path)
 
-  con <- orderly_db("destination", config = path)
+  con <- orderly_db("destination", path = path)
   ## read the file input table
   d <- DBI::dbReadTable(con, "file_input")
   DBI::dbDisconnect(con)

--- a/tests/testthat/test-recipe-read.R
+++ b/tests/testthat/test-recipe-read.R
@@ -167,28 +167,28 @@ test_that("resource case matters", {
 
 test_that("dependencies must be scalar", {
   path <- prepare_orderly_example("depends")
-  id <- orderly_run("example", config = path, echo = FALSE)
+  id <- orderly_run("example", path = path, echo = FALSE)
 
   filename <- file.path(path, "src", "depend", "orderly.yml")
   dat <- yaml_read(filename)
   dat$depends$example$use$previous.rds <- character(0)
   yaml_write(dat, filename)
 
-  expect_error(orderly_run("depend", config = path, echo = FALSE),
+  expect_error(orderly_run("depend", path = path, echo = FALSE),
                "depends:example:use must all be scalar character")
 })
 
 
 test_that("dependencies must exist", {
   path <- prepare_orderly_example("depends")
-  id <- orderly_run("example", config = path, echo = FALSE)
+  id <- orderly_run("example", path = path, echo = FALSE)
 
   filename <- file.path(path, "src", "depend", "orderly.yml")
   dat <- yaml_read(filename)
   dat$depends$example$use$previous.rds <- "unknown.file"
   yaml_write(dat, filename)
 
-  expect_error(orderly_run("depend", config = path, echo = FALSE),
+  expect_error(orderly_run("depend", path = path, echo = FALSE),
                "Did not find file unknown.file at")
 })
 
@@ -198,7 +198,7 @@ test_that("data field is optional", {
   report_path <- file.path(path, "src", "example")
 
   ## expect no error
-  expect_error(orderly_run("example", config = path, echo = FALSE), NA)
+  expect_error(orderly_run("example", path = path, echo = FALSE), NA)
 })
 
 

--- a/tests/testthat/test-recipe-read.R
+++ b/tests/testthat/test-recipe-read.R
@@ -167,28 +167,28 @@ test_that("resource case matters", {
 
 test_that("dependencies must be scalar", {
   path <- prepare_orderly_example("depends")
-  id <- orderly_run("example", path = path, echo = FALSE)
+  id <- orderly_run("example", root = path, echo = FALSE)
 
   filename <- file.path(path, "src", "depend", "orderly.yml")
   dat <- yaml_read(filename)
   dat$depends$example$use$previous.rds <- character(0)
   yaml_write(dat, filename)
 
-  expect_error(orderly_run("depend", path = path, echo = FALSE),
+  expect_error(orderly_run("depend", root = path, echo = FALSE),
                "depends:example:use must all be scalar character")
 })
 
 
 test_that("dependencies must exist", {
   path <- prepare_orderly_example("depends")
-  id <- orderly_run("example", path = path, echo = FALSE)
+  id <- orderly_run("example", root = path, echo = FALSE)
 
   filename <- file.path(path, "src", "depend", "orderly.yml")
   dat <- yaml_read(filename)
   dat$depends$example$use$previous.rds <- "unknown.file"
   yaml_write(dat, filename)
 
-  expect_error(orderly_run("depend", path = path, echo = FALSE),
+  expect_error(orderly_run("depend", root = path, echo = FALSE),
                "Did not find file unknown.file at")
 })
 
@@ -198,7 +198,7 @@ test_that("data field is optional", {
   report_path <- file.path(path, "src", "example")
 
   ## expect no error
-  expect_error(orderly_run("example", path = path, echo = FALSE), NA)
+  expect_error(orderly_run("example", root = path, echo = FALSE), NA)
 })
 
 

--- a/tests/testthat/test-remote-path.R
+++ b/tests/testthat/test-remote-path.R
@@ -27,8 +27,8 @@ test_that("get remote", {
 
 test_that("pull report", {
   path1 <- prepare_orderly_example("demo")
-  id <- orderly_run("multifile-artefact", path = path1, echo = FALSE)
-  orderly_commit(id, path = path1)
+  id <- orderly_run("multifile-artefact", root = path1, echo = FALSE)
+  orderly_commit(id, root = path1)
 
   path2 <- prepare_orderly_example("demo")
   pull_archive("multifile-artefact", "latest", path2, remote = path1)
@@ -55,8 +55,8 @@ test_that("pull report: already done", {
   path1 <- prepare_orderly_example("minimal")
   path2 <- prepare_orderly_example("minimal")
 
-  id <- orderly_run("example", path = path1, echo = FALSE)
-  orderly_commit(id, path = path1)
+  id <- orderly_run("example", root = path1, echo = FALSE)
+  orderly_commit(id, root = path1)
 
   remote <- orderly_remote_path(path1)
 
@@ -72,8 +72,8 @@ test_that("pull report: already done", {
 
 test_that("push report (path)", {
   ours <- prepare_orderly_example("demo")
-  id <- orderly_run("multifile-artefact", path = ours, echo = FALSE)
-  orderly_commit(id, path = ours)
+  id <- orderly_run("multifile-artefact", root = ours, echo = FALSE)
+  orderly_commit(id, root = ours)
 
   theirs <- prepare_orderly_example("demo")
 
@@ -90,8 +90,8 @@ test_that("push report: already done", {
   path1 <- prepare_orderly_example("minimal")
   path2 <- prepare_orderly_example("minimal")
 
-  id <- orderly_run("example", path = path1, echo = FALSE)
-  orderly_commit(id, path = path1)
+  id <- orderly_run("example", root = path1, echo = FALSE)
+  orderly_commit(id, root = path1)
 
   remote <- orderly_remote_path(path2)
 
@@ -127,7 +127,7 @@ test_that("remote_report_versions", {
 test_that("orderly_run", {
   dat <- prepare_orderly_remote_example()
   expect_error(
-    orderly_run_remote("example", path = dat$config),
+    orderly_run_remote("example", root = dat$config),
     "'orderly_remote_path' remotes do not run")
 })
 
@@ -136,10 +136,10 @@ test_that("orderly_publish", {
   dat <- prepare_orderly_remote_example()
 
   p <- file.path(dat$path_remote, "archive", "example", dat$id1)
-  orderly_publish_remote("example", dat$id1, path = dat$config)
+  orderly_publish_remote("example", dat$id1, root = dat$config)
   expect_equal(yaml_read(path_orderly_published_yml(p)),
                list(published = TRUE))
-  orderly_publish_remote("example", dat$id1, FALSE, path = dat$config)
+  orderly_publish_remote("example", dat$id1, FALSE, root = dat$config)
   expect_equal(yaml_read(path_orderly_published_yml(p)),
                list(published = FALSE))
 })
@@ -160,16 +160,16 @@ test_that("pull dependencies", {
   dat <- prepare_orderly_remote_example()
 
   expect_message(
-    pull_dependencies("depend", path = dat$config, remote = dat$remote),
+    pull_dependencies("depend", root = dat$config, remote = dat$remote),
     "\\[ pull\\s+ \\]  example:")
   expect_equal(orderly_list_archive(dat$config),
                data_frame(name = "example", id = dat$id2))
 
   ## and update
-  id3 <- orderly_run("example", path = dat$path_remote, echo = FALSE)
-  orderly_commit(id3, path = dat$path_remote)
+  id3 <- orderly_run("example", root = dat$path_remote, echo = FALSE)
+  orderly_commit(id3, root = dat$path_remote)
   expect_message(
-    pull_dependencies("depend", path = dat$config, remote = dat$remote),
+    pull_dependencies("depend", root = dat$config, remote = dat$remote),
     "\\[ pull\\s+ \\]  example:")
   expect_equal(orderly_list_archive(dat$config),
                data_frame(name = "example", id = c(dat$id2, id3)))

--- a/tests/testthat/test-remote-path.R
+++ b/tests/testthat/test-remote-path.R
@@ -27,8 +27,8 @@ test_that("get remote", {
 
 test_that("pull report", {
   path1 <- prepare_orderly_example("demo")
-  id <- orderly_run("multifile-artefact", config = path1, echo = FALSE)
-  orderly_commit(id, config = path1)
+  id <- orderly_run("multifile-artefact", path = path1, echo = FALSE)
+  orderly_commit(id, path = path1)
 
   path2 <- prepare_orderly_example("demo")
   pull_archive("multifile-artefact", "latest", path2, remote = path1)
@@ -55,8 +55,8 @@ test_that("pull report: already done", {
   path1 <- prepare_orderly_example("minimal")
   path2 <- prepare_orderly_example("minimal")
 
-  id <- orderly_run("example", config = path1, echo = FALSE)
-  orderly_commit(id, config = path1)
+  id <- orderly_run("example", path = path1, echo = FALSE)
+  orderly_commit(id, path = path1)
 
   remote <- orderly_remote_path(path1)
 
@@ -72,8 +72,8 @@ test_that("pull report: already done", {
 
 test_that("push report (path)", {
   ours <- prepare_orderly_example("demo")
-  id <- orderly_run("multifile-artefact", config = ours, echo = FALSE)
-  orderly_commit(id, config = ours)
+  id <- orderly_run("multifile-artefact", path = ours, echo = FALSE)
+  orderly_commit(id, path = ours)
 
   theirs <- prepare_orderly_example("demo")
 
@@ -90,8 +90,8 @@ test_that("push report: already done", {
   path1 <- prepare_orderly_example("minimal")
   path2 <- prepare_orderly_example("minimal")
 
-  id <- orderly_run("example", config = path1, echo = FALSE)
-  orderly_commit(id, config = path1)
+  id <- orderly_run("example", path = path1, echo = FALSE)
+  orderly_commit(id, path = path1)
 
   remote <- orderly_remote_path(path2)
 
@@ -127,7 +127,7 @@ test_that("remote_report_versions", {
 test_that("orderly_run", {
   dat <- prepare_orderly_remote_example()
   expect_error(
-    orderly_run_remote("example", config = dat$config),
+    orderly_run_remote("example", path = dat$config),
     "'orderly_remote_path' remotes do not run")
 })
 
@@ -136,10 +136,10 @@ test_that("orderly_publish", {
   dat <- prepare_orderly_remote_example()
 
   p <- file.path(dat$path_remote, "archive", "example", dat$id1)
-  orderly_publish_remote("example", dat$id1, config = dat$config)
+  orderly_publish_remote("example", dat$id1, path = dat$config)
   expect_equal(yaml_read(path_orderly_published_yml(p)),
                list(published = TRUE))
-  orderly_publish_remote("example", dat$id1, FALSE, config = dat$config)
+  orderly_publish_remote("example", dat$id1, FALSE, path = dat$config)
   expect_equal(yaml_read(path_orderly_published_yml(p)),
                list(published = FALSE))
 })
@@ -160,16 +160,16 @@ test_that("pull dependencies", {
   dat <- prepare_orderly_remote_example()
 
   expect_message(
-    pull_dependencies("depend", config = dat$config, remote = dat$remote),
+    pull_dependencies("depend", path = dat$config, remote = dat$remote),
     "\\[ pull\\s+ \\]  example:")
   expect_equal(orderly_list_archive(dat$config),
                data_frame(name = "example", id = dat$id2))
 
   ## and update
-  id3 <- orderly_run("example", config = dat$path_remote, echo = FALSE)
-  orderly_commit(id3, config = dat$path_remote)
+  id3 <- orderly_run("example", path = dat$path_remote, echo = FALSE)
+  orderly_commit(id3, path = dat$path_remote)
   expect_message(
-    pull_dependencies("depend", config = dat$config, remote = dat$remote),
+    pull_dependencies("depend", path = dat$config, remote = dat$remote),
     "\\[ pull\\s+ \\]  example:")
   expect_equal(orderly_list_archive(dat$config),
                data_frame(name = "example", id = c(dat$id2, id3)))

--- a/tests/testthat/test-remote.R
+++ b/tests/testthat/test-remote.R
@@ -24,7 +24,7 @@ test_that("pull_archive with wrong version", {
   dat <- prepare_orderly_remote_example()
 
   expect_error(
-    pull_archive("example", new_report_id(), path = dat$config,
+    pull_archive("example", new_report_id(), root = dat$config,
                  remote = dat$remote),
     paste0("Version '.+?' not found at '.+?': valid versions are:.+",
            dat$id1))
@@ -35,16 +35,16 @@ test_that("pull dependencies", {
   dat <- prepare_orderly_remote_example()
 
   expect_message(
-    pull_dependencies("depend", path = dat$config, remote = dat$remote),
+    pull_dependencies("depend", root = dat$config, remote = dat$remote),
     "\\[ pull\\s+ \\]  example:")
   expect_equal(orderly_list_archive(dat$config),
                data_frame(name = "example", id = dat$id2))
 
   ## and update
-  id3 <- orderly_run("example", path = dat$path_remote, echo = FALSE)
-  orderly_commit(id3, path = dat$path_remote)
+  id3 <- orderly_run("example", root = dat$path_remote, echo = FALSE)
+  orderly_commit(id3, root = dat$path_remote)
   expect_message(
-    pull_dependencies("depend", path = dat$config, remote = dat$remote),
+    pull_dependencies("depend", root = dat$config, remote = dat$remote),
     "\\[ pull\\s+ \\]  example:")
   expect_equal(orderly_list_archive(dat$config),
                data_frame(name = "example", id = c(dat$id2, id3)))

--- a/tests/testthat/test-remote.R
+++ b/tests/testthat/test-remote.R
@@ -24,7 +24,7 @@ test_that("pull_archive with wrong version", {
   dat <- prepare_orderly_remote_example()
 
   expect_error(
-    pull_archive("example", new_report_id(), config = dat$config,
+    pull_archive("example", new_report_id(), path = dat$config,
                  remote = dat$remote),
     paste0("Version '.+?' not found at '.+?': valid versions are:.+",
            dat$id1))
@@ -35,16 +35,16 @@ test_that("pull dependencies", {
   dat <- prepare_orderly_remote_example()
 
   expect_message(
-    pull_dependencies("depend", config = dat$config, remote = dat$remote),
+    pull_dependencies("depend", path = dat$config, remote = dat$remote),
     "\\[ pull\\s+ \\]  example:")
   expect_equal(orderly_list_archive(dat$config),
                data_frame(name = "example", id = dat$id2))
 
   ## and update
-  id3 <- orderly_run("example", config = dat$path_remote, echo = FALSE)
-  orderly_commit(id3, config = dat$path_remote)
+  id3 <- orderly_run("example", path = dat$path_remote, echo = FALSE)
+  orderly_commit(id3, path = dat$path_remote)
   expect_message(
-    pull_dependencies("depend", config = dat$config, remote = dat$remote),
+    pull_dependencies("depend", path = dat$config, remote = dat$remote),
     "\\[ pull\\s+ \\]  example:")
   expect_equal(orderly_list_archive(dat$config),
                data_frame(name = "example", id = c(dat$id2, id3)))

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -143,12 +143,12 @@ test_that("orderly_data", {
   path <- prepare_orderly_example("minimal")
   on.exit(unlink(path, recursive = TRUE))
 
-  d <- orderly_data("example", config = path)
+  d <- orderly_data("example", path = path)
   expect_is(d, "environment")
   expect_is(d$dat, "data.frame")
 
   e1 <- new.env(parent = baseenv())
-  e <- orderly_data("example", config = path, envir = e1)
+  e <- orderly_data("example", path = path, envir = e1)
   expect_identical(e, e1)
 
   expect_identical(e$dat, d$dat)
@@ -197,16 +197,17 @@ test_that("close too many devices", {
   info <- recipe_read(file.path(path, "src/example"), config)
   envir <- orderly_environment(NULL)
   info <- recipe_prepare(config, "example")
+  config <- orderly_config(path)
   expect_error(recipe_run(info, NULL, envir, config = config, echo = FALSE),
                "Report closed 1 more devices than it opened")
 })
 
 test_that("included example", {
   path <- prepare_orderly_example("example")
-  id <- orderly_run("example", list(cyl = 4), config = path, echo = FALSE)
-  p <- orderly_commit(id, config = path)
+  id <- orderly_run("example", list(cyl = 4), path = path, echo = FALSE)
+  p <- orderly_commit(id, path = path)
   expect_true(is_directory(p))
-  con <- orderly_db("destination", config = path)
+  con <- orderly_db("destination", path = path)
   on.exit(DBI::dbDisconnect(con))
   dat <- DBI::dbReadTable(con, "report_version")
   expect_equal(dat$description, NA_character_)
@@ -215,11 +216,11 @@ test_that("included example", {
 
 test_that("included other", {
   path <- prepare_orderly_example("other")
-  id <- orderly_run("other", list(nmin = 0), config = path, echo = FALSE)
-  p <- orderly_commit(id, config = path)
+  id <- orderly_run("other", list(nmin = 0), path = path, echo = FALSE)
+  p <- orderly_commit(id, path = path)
   info <- recipe_read(file.path(path_src(path), "other"),
                       orderly_config(path))
-  con <- orderly_db("destination", config = path)
+  con <- orderly_db("destination", path = path)
   on.exit(DBI::dbDisconnect(con))
   dat <- DBI::dbReadTable(con, "report_version")
   expect_equal(dat$description, info$description)
@@ -242,7 +243,7 @@ test_that("connection", {
 
   data <- orderly_data("example",
                        envir = new.env(parent = .GlobalEnv),
-                       config = path)
+                       path = path)
   expect_is(data$con, "SQLiteConnection")
   expect_is(DBI::dbReadTable(data$con, "data"), "data.frame")
   DBI::dbDisconnect(data$con)
@@ -252,8 +253,8 @@ test_that("connection", {
 test_that("connection is saved to db", {
   path <- prepare_orderly_example("minimal")
 
-  id1 <- orderly_run("example", config = path, echo = FALSE)
-  orderly_commit(id1, config = path)
+  id1 <- orderly_run("example", path = path, echo = FALSE)
+  orderly_commit(id1, path = path)
 
   path_example <- file.path(path, "src", "example")
   yml <- file.path(path_example, "orderly.yml")
@@ -261,10 +262,10 @@ test_that("connection is saved to db", {
   dat <- list(connection = list(con = "source"))
   writeLines(c(txt, yaml::as.yaml(dat)), yml)
 
-  id2 <- orderly_run("example", config = path, echo = FALSE)
-  orderly_commit(id2, config = path)
+  id2 <- orderly_run("example", path = path, echo = FALSE)
+  orderly_commit(id2, path = path)
 
-  con <- orderly_db("destination", config = path)
+  con <- orderly_db("destination", path = path)
   on.exit(DBI::dbDisconnect(con))
   d <- DBI::dbGetQuery(con, "SELECT id, connection FROM report_version")
   expect_equal(d$connection[d$id == id1], 0L)
@@ -287,10 +288,10 @@ test_that("no data", {
 
   data <- orderly_data("example",
                        envir = new.env(parent = .GlobalEnv),
-                       config = path)
+                       path = path)
   expect_equal(ls(data, all.names = TRUE), character(0))
 
-  id <- orderly_run("example", config = path, echo = FALSE)
+  id <- orderly_run("example", path = path, echo = FALSE)
   p <- file.path(path_draft(path), "example", id, "data.rds")
   expect_true(file.exists(p))
   expect_equal(readRDS(p), mtcars)
@@ -301,16 +302,16 @@ test_that("use artefact", {
 
   path_example <- file.path(path, "src", "example")
   path_depend <- file.path(path, "src", "depend")
-  id1 <- orderly_run("example", config = path, echo = FALSE)
+  id1 <- orderly_run("example", path = path, echo = FALSE)
   orderly_log_break()
   path_orig <- file.path(path_draft(path), "example", id1, "data.rds")
   expect_true(file.exists(path_orig))
 
   data <- orderly_data("depend",
                        envir = new.env(parent = .GlobalEnv),
-                       config = path)
+                       path = path)
   expect_identical(ls(data), character(0))
-  id2 <- orderly_run("depend", config = path, echo = FALSE)
+  id2 <- orderly_run("depend", path = path, echo = FALSE)
   orderly_log_break()
   path_previous <- file.path(path_draft(path), "depend", id2, "previous.rds")
   expect_true(file.exists(path_previous))
@@ -322,9 +323,9 @@ test_that("use artefact", {
   expect_equal(d$meta$depends$hash, hash_files(path_previous, FALSE))
 
   ## Then rebuild the original:
-  id3 <- orderly_run("example", config = path, echo = FALSE)
+  id3 <- orderly_run("example", path = path, echo = FALSE)
   orderly_log_break()
-  id4 <- orderly_run("depend", config = path, echo = FALSE)
+  id4 <- orderly_run("depend", path = path, echo = FALSE)
   orderly_log_break()
   path_orig2 <- file.path(path_draft(path), "example", id3, "data.rds")
   path_previous2 <- file.path(path_draft(path), "depend", id4, "previous.rds")
@@ -335,32 +336,32 @@ test_that("use artefact", {
               hash_files(path_previous, FALSE))
 
   ## Then we need to commit things and check that it all still works OK.
-  expect_error(orderly_commit(id2, config = path),
+  expect_error(orderly_commit(id2, path = path),
                "Report uses draft id - commit first")
-  p1 <- orderly_commit(id1, config = path)
-  p2 <- orderly_commit(id2, config = path)
-  expect_error(orderly_commit(id4, config = path), id3)
-  p3 <- orderly_commit(id3, config = path)
-  p4 <- orderly_commit(id4, config = path)
+  p1 <- orderly_commit(id1, path = path)
+  p2 <- orderly_commit(id2, path = path)
+  expect_error(orderly_commit(id4, path = path), id3)
+  p3 <- orderly_commit(id3, path = path)
+  p4 <- orderly_commit(id4, path = path)
 })
 
 test_that("Can't commit report using nonexistant id", {
   path <- prepare_orderly_example("depends")
-  id1 <- orderly_run("example", config = path, echo = FALSE)
-  id2 <- orderly_run("depend", config = path, echo = FALSE)
+  id1 <- orderly_run("example", path = path, echo = FALSE)
+  id2 <- orderly_run("depend", path = path, echo = FALSE)
   unlink(file.path(path, "draft", "example", id1), recursive = TRUE)
-  expect_error(orderly_commit(id2, config = path),
+  expect_error(orderly_commit(id2, path = path),
                "Report uses nonexistant id")
 })
 
 test_that("resources", {
   path <- prepare_orderly_example("resources")
-  id <- orderly_run("use_resource", config = path, echo = FALSE)
+  id <- orderly_run("use_resource", path = path, echo = FALSE)
   p <- file.path(path, "draft", "use_resource", id)
   expect_true(file.exists(file.path(p, "meta/data.csv")))
-  p <- orderly_commit(id, config = path)
+  p <- orderly_commit(id, path = path)
 
-  con <- orderly_db("destination", config = path)
+  con <- orderly_db("destination", path = path)
   d <- DBI::dbGetQuery(
     con, "SELECT * FROM file_input WHERE file_purpose = 'resource'")
 
@@ -375,7 +376,7 @@ test_that("markdown", {
   skip_on_appveyor() # See https://github.com/jgm/pandoc/issues/5037
   path <- prepare_orderly_example("knitr")
 
-  id <- orderly_run("example", config = path, echo = FALSE)
+  id <- orderly_run("example", path = path, echo = FALSE)
 
   report <- file.path(path, "draft", "example", id, "report.html")
   expect_true(file.exists(report))
@@ -386,8 +387,8 @@ test_that("database is not loaded unless needed", {
   vars <- c(SOME_ENVVAR = "source.sqlite")
   path <- withr::with_envvar(vars, prepare_orderly_example("nodb"))
 
-  expect_identical(as.list(orderly_data("example", config = path)), list())
-  id <- orderly_run("example", config = path, echo = FALSE)
+  expect_identical(as.list(orderly_data("example", path = path)), list())
+  id <- orderly_run("example", path = path, echo = FALSE)
   expect_true(
     file.exists(file.path(path, "draft", "example", id, "mygraph.png")))
   expect_error(orderly_db("source", path), "SOME_ENVVAR")
@@ -396,7 +397,7 @@ test_that("database is not loaded unless needed", {
 test_that("id file", {
   path <- prepare_orderly_example("minimal")
   tmp <- tempfile()
-  id <- orderly_run("example", config = path, id_file = tmp, echo = FALSE)
+  id <- orderly_run("example", path = path, id_file = tmp, echo = FALSE)
   expect_true(file.exists(tmp))
   expect_equal(readLines(tmp), id)
 })
@@ -406,14 +407,14 @@ test_that("test_start, test_restart", {
   on.exit(setwd(owd))
 
   path <- prepare_orderly_example("minimal")
-  orderly_test_start("example", config = path)
+  orderly_test_start("example", path = path)
 
   expect_equal(normalizePath(dirname(getwd())),
                normalizePath(file.path(path, "draft/example")))
   id <- basename(getwd())
   expect_equal(orderly_list_drafts(path)$id, id)
 
-  expect_error(orderly_test_start("example", config = path),
+  expect_error(orderly_test_start("example", path = path),
                "Already running in test mode")
 
   orderly_test_restart()
@@ -432,7 +433,7 @@ test_that("test mode artefacts", {
   on.exit(setwd(owd))
 
   path <- prepare_orderly_example("minimal")
-  orderly_test_start("example", config = path)
+  orderly_test_start("example", path = path)
   on.exit(orderly_test_end(), add = FALSE)
 
   expect_false(orderly_test_check())
@@ -458,9 +459,9 @@ test_that("test mode end", {
 test_that("run with message", {
   path <- prepare_orderly_example("changelog")
   test_message <- "[label1] test"
-  id <- orderly_run("example", config = path, echo = FALSE,
+  id <- orderly_run("example", path = path, echo = FALSE,
                     message = test_message)
-  p <- orderly_commit(id, config = path)
+  p <- orderly_commit(id, path = path)
 
   expect_equal(changelog_read_json(p),
                data_frame(
@@ -475,7 +476,7 @@ test_that("no unexpected artefact", {
   path_example <- file.path(path, "src", "example")
   # we're not expecting an 'unexpected' message at this point
   # grab all messages...
-  messages <- capture_messages(orderly_run("example", config = path,
+  messages <- capture_messages(orderly_run("example", path = path,
                                            id_file = tmp, echo = FALSE))
   # ...make sure none of the messages contain "unexpected"
   expect_false(any(grep("unexpected", messages)))
@@ -484,9 +485,9 @@ test_that("no unexpected artefact", {
 
 test_that("renamed dependencies are expected", {
   path <- prepare_orderly_example("depends")
-  orderly_run("example", config = path, echo = FALSE)
+  orderly_run("example", path = path, echo = FALSE)
   messages <- capture_messages(
-    orderly_run("depend", config = path, echo = FALSE))
+    orderly_run("depend", path = path, echo = FALSE))
   expect_false(any(grep("unexpected", messages)))
 })
 
@@ -504,7 +505,7 @@ test_that("non-existent package", {
   write(sprintf("packages: %s", "non_existent_package"),
         file = yml_path, append = TRUE)
   # has orderly detected that the package does not exist>
-  expect_error(orderly_run("example", config = path, id_file = tmp,
+  expect_error(orderly_run("example", path = path, id_file = tmp,
                            echo = FALSE),
                "Missing packages: 'non_existent_package'")
 })
@@ -524,7 +525,7 @@ test_that("multiple non-existent packages", {
   write(sprintf("  - %s", "non_existent_package_2"),
         file = yml_path, append = TRUE)
   # has orderly detected that the package does not exist>
-  expect_error(orderly_run("example", config = path, id_file = tmp,
+  expect_error(orderly_run("example", path = path, id_file = tmp,
                            echo = FALSE),
                paste("Missing packages:",
                      "'non_existent_package', 'non_existent_package_2'"))
@@ -533,11 +534,11 @@ test_that("multiple non-existent packages", {
 test_that("use multiple versions of an artefact", {
   path <- prepare_orderly_example("depends")
 
-  id1 <- orderly_run("example", config = path, echo = FALSE)
-  id2 <- orderly_run("example", config = path, echo = FALSE)
-  orderly_commit(id2, config = path)
+  id1 <- orderly_run("example", path = path, echo = FALSE)
+  id2 <- orderly_run("example", path = path, echo = FALSE)
+  orderly_commit(id2, path = path)
 
-  id3 <- orderly_run("depend2", config = path, echo = FALSE)
+  id3 <- orderly_run("depend2", path = path, echo = FALSE)
 
   p1 <- file.path(path, "draft", "depend2", id3,
                   c("previous1.rds", "previous2.rds"))
@@ -569,7 +570,7 @@ test_that("required field OK", {
   minimal_yml <- c(minimal_yml, sprintf("%s: %s", req_fields[2], "character"))
   writeLines(minimal_yml, yml_path)
   
-  id <- orderly_run("example", config = path, id_file = tmp, echo = FALSE)
+  id <- orderly_run("example", path = path, id_file = tmp, echo = FALSE)
   p <- file.path(path_draft(path), "example", id, "mygraph.png")
   expect_true(file.exists(p))
 })
@@ -601,7 +602,7 @@ test_that("missing required field", {
       err_msg <- sprintf("Fields missing from .*: %s",
                         paste(missing_required, collapse = ", ")
                         )
-      expect_error(orderly_run("example", config = path, id_file = tmp,
+      expect_error(orderly_run("example", path = path, id_file = tmp,
                                echo = FALSE),
                    regexp = err_msg)
     }
@@ -630,7 +631,7 @@ test_that("required field wrong type", {
   
   # first required field wont give an error, the second will
   err_msg <- sprintf("'.*orderly.yml:%s' must be character", req_fields[2])
-  expect_error(orderly_run("example", config = path, id_file = tmp, 
+  expect_error(orderly_run("example", path = path, id_file = tmp,
                            echo = FALSE),
                regexp = err_msg)
 })
@@ -650,11 +651,11 @@ test_that("can't commit failed run", {
 
   append_lines('stop("some error")',
                file.path(path, "src", "example", "script.R"))
-  expect_error(orderly_run("example", config = path, echo = FALSE),
+  expect_error(orderly_run("example", path = path, echo = FALSE),
                "some error")
   id <- dir(file.path(path, "draft", "example"))
 
-  expect_error(orderly_commit(id, config = path),
+  expect_error(orderly_commit(id, path = path),
                "Did not find run metadata file for example/")
 })
 
@@ -663,9 +664,9 @@ test_that("can't commit report twice", {
   path <- prepare_orderly_example("minimal")
   on.exit(unlink(path, recursive = TRUE))
 
-  id <- orderly_run("example", config = path, echo = FALSE)
+  id <- orderly_run("example", path = path, echo = FALSE)
   dir.create(file.path(path, "archive", "example", id), FALSE, TRUE)
-  expect_error(orderly_commit(id, config = path),
+  expect_error(orderly_commit(id, path = path),
                "Report example/.* appears to have already been copied")
 })
 
@@ -675,7 +676,7 @@ test_that("open after run", {
   mockery::stub(orderly_run, "open_directory", mock)
 
   path <- prepare_orderly_example("minimal")
-  id <- orderly_run("example", config = path, echo = FALSE, open = TRUE)
+  id <- orderly_run("example", path = path, echo = FALSE, open = TRUE)
 
   expect_equal(length(mock), 1)
   args <- mockery::mock_args(mock)[[1]]
@@ -689,9 +690,9 @@ test_that("missing parameters throws an error", {
   path <- prepare_orderly_example("example")
   on.exit(unlink(path, recursive = TRUE))
 
-  expect_error(orderly_run("example", config = path),
+  expect_error(orderly_run("example", path = path),
                "Missing parameters: 'cyl'")
-  expect_error(orderly_run("example", list(cl = 2), config = path),
+  expect_error(orderly_run("example", list(cl = 2), path = path),
                "Missing parameters: 'cyl'")
 })
 
@@ -716,7 +717,7 @@ test_that("modify resources", {
         file = script_path, append = TRUE)
 
   # has orderly detected that the package does not exist>
-  expect_error(orderly_run("use_resource", config = path, id_file = tmp,
+  expect_error(orderly_run("use_resource", path = path, id_file = tmp,
                            echo = FALSE),
                "Script has modified resources: meta/data.csv")
   ## modify 2 resources
@@ -732,7 +733,7 @@ test_that("modify resources", {
         file = script_path, append = TRUE)
 
   # has orderly detected that the package does not exist>
-  expect_error(orderly_run("multiple_resources", config = path, id_file = tmp,
+  expect_error(orderly_run("multiple_resources", path = path, id_file = tmp,
                            echo = FALSE),
                "Script has modified resources: meta/data.csv, meta/data2.csv")
 })
@@ -749,7 +750,7 @@ test_that("delete resources", {
         file = script_path, append = TRUE)
 
   # has orderly detected that the package does not exist>
-  expect_error(orderly_run("use_resource", config = path, id_file = tmp,
+  expect_error(orderly_run("use_resource", path = path, id_file = tmp,
                            echo = FALSE),
                "Script deleted the following resources: meta/data.csv")
   ## delete 2 resources
@@ -768,20 +769,20 @@ test_that("delete resources", {
   error_message <-
     sprintf("Script deleted the following resources: %s, %s",
             "meta/data.csv", "meta/data2.csv")
-  expect_error(orderly_run("multiple_resources", config = path, id_file = tmp,
+  expect_error(orderly_run("multiple_resources", path = path, id_file = tmp,
                            echo = FALSE),
                error_message)
 })
 
 test_that("multiple resources", {
   path <- prepare_orderly_example("resources")
-  id <- orderly_run("multiple_resources", config = path, echo = FALSE)
+  id <- orderly_run("multiple_resources", path = path, echo = FALSE)
   p <- file.path(path, "draft", "multiple_resources", id)
   expect_true(file.exists(file.path(p, "meta/data.csv")))
   expect_true(file.exists(file.path(p, "meta/data2.csv")))
-  p <- orderly_commit(id, config = path)
+  p <- orderly_commit(id, path = path)
 
-  con <- orderly_db("destination", config = path)
+  con <- orderly_db("destination", path = path)
   on.exit(DBI::dbDisconnect(con))
   d <- DBI::dbReadTable(con, "file_input")
   d <- d[d$file_purpose == "resource", ]
@@ -801,7 +802,7 @@ test_that("producing a directory is an error", {
   writeLines(
     'dir.create("mygraph.png")',
     file.path(path, "src", "example", "script.R"))
-  expect_error(orderly_run("example", config = path, echo = FALSE),
+  expect_error(orderly_run("example", path = path, echo = FALSE),
                "Produced a directory artefact: 'mygraph.png'",
                fixed = TRUE)
 })
@@ -809,9 +810,9 @@ test_that("producing a directory is an error", {
 
 test_that("can run report with a view", {
   path <- prepare_orderly_example("demo")
-  id <- orderly_run("view", config = path, echo = FALSE)
-  orderly_commit(id, config = path)
-  con <- orderly_db("destination", config = path)
+  id <- orderly_run("view", path = path, echo = FALSE)
+  orderly_commit(id, path = path)
+  con <- orderly_db("destination", path = path)
   on.exit(DBI::dbDisconnect(con))
   res <- DBI::dbReadTable(con, "report_version_view")
   expect_equal(res$database, "source")
@@ -820,39 +821,39 @@ test_that("can run report with a view", {
 
 test_that("can run a report from orderly with no database", {
   path <- prepare_orderly_example("db0")
-  id <- orderly_run("example", config = path, echo = FALSE)
+  id <- orderly_run("example", path = path, echo = FALSE)
   expect_true(file.exists(
     file.path(path, "draft", "example", id, "mygraph.png")))
-  p <- orderly_commit(id, config = path)
+  p <- orderly_commit(id, path = path)
   expect_true(file.exists(file.path(p, "mygraph.png")))
 })
 
 
 test_that("can run a report from orderly with one (named) database", {
   path <- prepare_orderly_example("db1")
-  id <- orderly_run("example", config = path, echo = FALSE)
+  id <- orderly_run("example", path = path, echo = FALSE)
   expect_true(file.exists(
     file.path(path, "draft", "example", id, "mygraph.png")))
-  p <- orderly_commit(id, config = path)
+  p <- orderly_commit(id, path = path)
   expect_true(file.exists(file.path(p, "mygraph.png")))
 })
 
 
 test_that("can run a report from orderly with two databases", {
   path <- prepare_orderly_example("db2")
-  id <- orderly_run("example", config = path, echo = FALSE)
+  id <- orderly_run("example", path = path, echo = FALSE)
   expect_true(file.exists(
     file.path(path, "draft", "example", id, "mygraph.png")))
-  p <- orderly_commit(id, config = path)
+  p <- orderly_commit(id, path = path)
   expect_true(file.exists(file.path(p, "mygraph.png")))
 })
 
 
 test_that("Can use connections with two databases", {
   path <- prepare_orderly_example("db2")
-  id <- orderly_run("connection", config = path, echo = FALSE)
+  id <- orderly_run("connection", path = path, echo = FALSE)
   expect_true(file.exists(
     file.path(path, "draft", "connection", id, "mygraph.png")))
-  p <- orderly_commit(id, config = path)
+  p <- orderly_commit(id, path = path)
   expect_true(file.exists(file.path(p, "mygraph.png")))
 })

--- a/tests/testthat/test-tools.R
+++ b/tests/testthat/test-tools.R
@@ -1,7 +1,7 @@
 test_that("unpack archive", {
   path <- prepare_orderly_example("minimal")
-  id <- orderly_run("example", path = path, echo = FALSE)
-  p <- orderly_commit(id, path = path)
+  id <- orderly_run("example", root = path, echo = FALSE)
+  p <- orderly_commit(id, root = path)
 
   zip <- zip_dir(p)
 

--- a/tests/testthat/test-tools.R
+++ b/tests/testthat/test-tools.R
@@ -1,7 +1,7 @@
 test_that("unpack archive", {
   path <- prepare_orderly_example("minimal")
-  id <- orderly_run("example", config = path, echo = FALSE)
-  p <- orderly_commit(id, config = path)
+  id <- orderly_run("example", path = path, echo = FALSE)
+  p <- orderly_commit(id, path = path)
 
   zip <- zip_dir(p)
 

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -89,7 +89,7 @@ test_that("secrets", {
   cl$write("/secret/users/alice", list(password = "ALICE"))
   cl$write("/secret/users/bob", list(password = "BOB"))
 
-  config <- list(path = tempfile(),
+  config <- list(root = tempfile(),
                  vault_server = srv$addr)
 
   x <- list(name = "alice",
@@ -120,7 +120,7 @@ test_that("resolve secret env", {
   cl$write("/secret/users/alice", list(password = "ALICE"))
   cl$write("/secret/users/bob", list(password = "BOB"))
 
-  config <- list(path = tempfile(),
+  config <- list(root = tempfile(),
                  vault_server = srv$addr)
 
   x <- list(user = "$ORDERLY_USER",

--- a/tests/testthat/test-z-demo.R
+++ b/tests/testthat/test-z-demo.R
@@ -4,7 +4,7 @@ test_that("orderly_demo", {
   path <- create_orderly_demo()
   expect_true(file.exists(path))
 
-  con <- orderly_db("destination", path = path)
+  con <- orderly_db("destination", root = path)
   on.exit(DBI::dbDisconnect(con))
   ## displayname and description are the only two nullable columns
   ## (VIMC-2357)
@@ -24,9 +24,9 @@ test_that("git demo", {
   capture.output(path2 <- prepare_orderly_git_example(run_report = TRUE))
 
   expect_equal(
-    nrow(orderly_list2(path = path1[["local"]], draft = FALSE)), 0)
+    nrow(orderly_list2(root = path1[["local"]], draft = FALSE)), 0)
   expect_equal(
-    nrow(orderly_list2(path = path2[["local"]], draft = FALSE)), 1)
+    nrow(orderly_list2(root = path2[["local"]], draft = FALSE)), 1)
 })
 
 

--- a/tests/testthat/test-z-demo.R
+++ b/tests/testthat/test-z-demo.R
@@ -4,7 +4,7 @@ test_that("orderly_demo", {
   path <- create_orderly_demo()
   expect_true(file.exists(path))
 
-  con <- orderly_db("destination", config = path)
+  con <- orderly_db("destination", path = path)
   on.exit(DBI::dbDisconnect(con))
   ## displayname and description are the only two nullable columns
   ## (VIMC-2357)
@@ -24,9 +24,9 @@ test_that("git demo", {
   capture.output(path2 <- prepare_orderly_git_example(run_report = TRUE))
 
   expect_equal(
-    nrow(orderly_list2(config = path1[["local"]], draft = FALSE)), 0)
+    nrow(orderly_list2(path = path1[["local"]], draft = FALSE)), 0)
   expect_equal(
-    nrow(orderly_list2(config = path2[["local"]], draft = FALSE)), 1)
+    nrow(orderly_list2(path = path2[["local"]], draft = FALSE)), 1)
 })
 
 

--- a/tests/testthat/test-z-remote-api.R
+++ b/tests/testthat/test-z-remote-api.R
@@ -12,20 +12,20 @@ test_that("end-to-end", {
   name <- "internal-2017-population-TUV-MHL"
   id <- "20170823-113855-5091025f"
 
-  v <- remote_report_names(path = path, remote = remote)
+  v <- remote_report_names(root = path, remote = remote)
   expect_true(name %in% v)
 
   expect_equal(
-    remote_report_versions("unknown", path = path, remote = remote),
+    remote_report_versions("unknown", root = path, remote = remote),
     character(0))
 
-  v <- remote_report_versions(name, path = path, remote = remote)
+  v <- remote_report_versions(name, root = path, remote = remote)
   expect_true(id %in% v)
 
   dest <- file.path(path, "archive", name, id)
   unlink(dest, recursive = TRUE)
-  pull_archive(name, id, path = path, remote = remote)
+  pull_archive(name, id, root = path, remote = remote)
   expect_true(file.exists(dest))
 
-  orderly_run_remote(name, path = path, remote = remote)
+  orderly_run_remote(name, root = path, remote = remote)
 })

--- a/tests/testthat/test-z-remote-api.R
+++ b/tests/testthat/test-z-remote-api.R
@@ -12,20 +12,20 @@ test_that("end-to-end", {
   name <- "internal-2017-population-TUV-MHL"
   id <- "20170823-113855-5091025f"
 
-  v <- remote_report_names(config = path, remote = remote)
+  v <- remote_report_names(path = path, remote = remote)
   expect_true(name %in% v)
 
   expect_equal(
-    remote_report_versions("unknown", config = path, remote = remote),
+    remote_report_versions("unknown", path = path, remote = remote),
     character(0))
 
-  v <- remote_report_versions(name, config = path, remote = remote)
+  v <- remote_report_versions(name, path = path, remote = remote)
   expect_true(id %in% v)
 
   dest <- file.path(path, "archive", name, id)
   unlink(dest, recursive = TRUE)
-  pull_archive(name, id, config = path, remote = remote)
+  pull_archive(name, id, path = path, remote = remote)
   expect_true(file.exists(dest))
 
-  orderly_run_remote(name, config = path, remote = remote)
+  orderly_run_remote(name, path = path, remote = remote)
 })

--- a/tests/testthat/test-z-runner.R
+++ b/tests/testthat/test-z-runner.R
@@ -111,8 +111,8 @@ test_that("publish", {
   runner <- orderly_runner(path)
 
   name <- "example"
-  id <- orderly_run(name, config = path, echo = FALSE)
-  orderly_commit(id, name, config = path)
+  id <- orderly_run(name, path = path, echo = FALSE)
+  orderly_commit(id, name, path = path)
 
   res <- runner$publish(name, id)
 
@@ -129,8 +129,8 @@ test_that("rebuild", {
   runner <- orderly_runner(path)
 
   name <- "example"
-  id <- orderly_run(name, config = path, echo = FALSE)
-  orderly_commit(id, name, config = path)
+  id <- orderly_run(name, path = path, echo = FALSE)
+  orderly_commit(id, name, path = path)
 
   path_db <- file.path(path, "orderly.sqlite")
   file.remove(path_db)
@@ -206,19 +206,19 @@ test_that("cleanup", {
   path <- prepare_orderly_example("minimal")
   on.exit(unlink(path, recursive = TRUE))
 
-  id <- orderly_run("example", config = path, echo = FALSE)
-  orderly_commit(id, config = path)
+  id <- orderly_run("example", path = path, echo = FALSE)
+  orderly_commit(id, path = path)
 
   writeLines("1 + 1", file.path(path, "src/example/script.R"))
-  expect_error(orderly_run("example", config = path, echo = FALSE),
+  expect_error(orderly_run("example", path = path, echo = FALSE),
                "Script did not produce")
 
   runner <- orderly_runner(path)
   expect_message(runner$cleanup(), "clean.+draft/example")
   expect_silent(runner$cleanup())
 
-  expect_equal(nrow(orderly_list2(TRUE, config = path)), 0L)
-  expect_equal(orderly_list2(FALSE, config = path)$id, id)
+  expect_equal(nrow(orderly_list2(TRUE, path = path)), 0L)
+  expect_equal(orderly_list2(FALSE, path = path)$id, id)
 })
 
 

--- a/tests/testthat/test-z-runner.R
+++ b/tests/testthat/test-z-runner.R
@@ -111,8 +111,8 @@ test_that("publish", {
   runner <- orderly_runner(path)
 
   name <- "example"
-  id <- orderly_run(name, path = path, echo = FALSE)
-  orderly_commit(id, name, path = path)
+  id <- orderly_run(name, root = path, echo = FALSE)
+  orderly_commit(id, name, root = path)
 
   res <- runner$publish(name, id)
 
@@ -129,8 +129,8 @@ test_that("rebuild", {
   runner <- orderly_runner(path)
 
   name <- "example"
-  id <- orderly_run(name, path = path, echo = FALSE)
-  orderly_commit(id, name, path = path)
+  id <- orderly_run(name, root = path, echo = FALSE)
+  orderly_commit(id, name, root = path)
 
   path_db <- file.path(path, "orderly.sqlite")
   file.remove(path_db)
@@ -206,19 +206,19 @@ test_that("cleanup", {
   path <- prepare_orderly_example("minimal")
   on.exit(unlink(path, recursive = TRUE))
 
-  id <- orderly_run("example", path = path, echo = FALSE)
-  orderly_commit(id, path = path)
+  id <- orderly_run("example", root = path, echo = FALSE)
+  orderly_commit(id, root = path)
 
   writeLines("1 + 1", file.path(path, "src/example/script.R"))
-  expect_error(orderly_run("example", path = path, echo = FALSE),
+  expect_error(orderly_run("example", root = path, echo = FALSE),
                "Script did not produce")
 
   runner <- orderly_runner(path)
   expect_message(runner$cleanup(), "clean.+draft/example")
   expect_silent(runner$cleanup())
 
-  expect_equal(nrow(orderly_list2(TRUE, path = path)), 0L)
-  expect_equal(orderly_list2(FALSE, path = path)$id, id)
+  expect_equal(nrow(orderly_list2(TRUE, root = path)), 0L)
+  expect_equal(orderly_list2(FALSE, root = path)$id, id)
 })
 
 
@@ -367,10 +367,10 @@ test_that("prevent git changes", {
         driver = "orderly::orderly_remote_path",
         primary = TRUE,
         master_only = TRUE,
-        args = list(path = path[["origin"]])),
+        args = list(root = path[["origin"]])),
       other = list(
         driver = "orderly::orderly_remote_path",
-        args = list(path = path[["origin"]]))))
+        args = list(root = path[["origin"]]))))
 
   path_local <- path[["local"]]
   writeLines(yaml::as.yaml(cfg), file.path(path_local, "orderly_config.yml"))
@@ -404,20 +404,20 @@ test_that("prevent git changes", {
 test_that("allow ref logic", {
   path <- unzip_git_demo()
   config <- list(server_options = list(master_only = FALSE),
-                 path = path)
+                 root = path)
 
   expect_false(runner_allow_ref(FALSE, config))
   expect_true(runner_allow_ref(TRUE, config))
   expect_true(runner_allow_ref(NULL, config))
 
   config <- list(server_options = list(master_only = TRUE),
-                 path = path)
+                 root = path)
   expect_false(runner_allow_ref(FALSE, config))
   expect_true(runner_allow_ref(TRUE, config))
   expect_false(runner_allow_ref(NULL, config))
 
   config <- list(server_options = list(master_only = FALSE),
-                 path = tempfile())
+                 root = tempfile())
   expect_false(runner_allow_ref(FALSE, config))
   expect_false(runner_allow_ref(TRUE, config))
   expect_false(runner_allow_ref(NULL, config))

--- a/vignettes/orderly.Rmd
+++ b/vignettes/orderly.Rmd
@@ -86,7 +86,7 @@ to create the reports.
 
 As an example, we have a directory at `path` that contains
 orderly sources.  Typically this would be in the working directory
-(and in that case the `config` argument may be omitted) but for this
+(and in that case the `path` argument may be omitted) but for this
 vignette the path will be passed in explicitly.
 
 The `orderly.yml` to describe the creation of a report might look like:
@@ -198,7 +198,7 @@ Reports are run by *name*.  In the above configuration the report
 is called `example` because it is in the directory `src/example`.
 A list of report names can be returned by running
 ``` {r }
-orderly::orderly_list(config = path)
+orderly::orderly_list(path = path)
 ```
 
 If the report requires parameters then these must be passed through
@@ -206,7 +206,7 @@ too; in the above case the report takes the parameter `cyl` which
 must be passed through as a named list.  So we might run this
 report as
 ``` {r collapse = TRUE}
-id <- orderly::orderly_run("example", list(cyl = 4), config = path)
+id <- orderly::orderly_run("example", list(cyl = 4), path = path)
 ```
 
 ``` {r echo = FALSE, results = "hide"}
@@ -260,12 +260,12 @@ by other applications.
 
 You can see the list of draft reports like so:
 ``` {r }
-orderly::orderly_list_drafts(config = path)
+orderly::orderly_list_drafts(path = path)
 ```
 
 Once you're happy with a report, then "commit" it with
 ``` {r collapse = TRUE}
-orderly::orderly_commit(id, config = path)
+orderly::orderly_commit(id, path = path)
 ```
 
 **THIS WILL CHANGE A LITTLE I THINK** - but mostly in how the index
@@ -288,7 +288,7 @@ should not contain spaces (nor should it change as this will change
 the key report id and you'll lose a chain of history), then edit
 the file `orderly.yml` within that directory.
 ``` {r }
-orderly::orderly_new("new", config = path)
+orderly::orderly_new("new", path = path)
 ```
 
 As a report becomes more complex, the function

--- a/vignettes/orderly.Rmd
+++ b/vignettes/orderly.Rmd
@@ -86,7 +86,7 @@ to create the reports.
 
 As an example, we have a directory at `path` that contains
 orderly sources.  Typically this would be in the working directory
-(and in that case the `path` argument may be omitted) but for this
+(and in that case the `root` argument may be omitted) but for this
 vignette the path will be passed in explicitly.
 
 The `orderly.yml` to describe the creation of a report might look like:
@@ -198,7 +198,7 @@ Reports are run by *name*.  In the above configuration the report
 is called `example` because it is in the directory `src/example`.
 A list of report names can be returned by running
 ``` {r }
-orderly::orderly_list(path = path)
+orderly::orderly_list(root = path)
 ```
 
 If the report requires parameters then these must be passed through
@@ -206,7 +206,7 @@ too; in the above case the report takes the parameter `cyl` which
 must be passed through as a named list.  So we might run this
 report as
 ``` {r collapse = TRUE}
-id <- orderly::orderly_run("example", list(cyl = 4), path = path)
+id <- orderly::orderly_run("example", list(cyl = 4), root = path)
 ```
 
 ``` {r echo = FALSE, results = "hide"}
@@ -260,12 +260,12 @@ by other applications.
 
 You can see the list of draft reports like so:
 ``` {r }
-orderly::orderly_list_drafts(path = path)
+orderly::orderly_list_drafts(root = path)
 ```
 
 Once you're happy with a report, then "commit" it with
 ``` {r collapse = TRUE}
-orderly::orderly_commit(id, path = path)
+orderly::orderly_commit(id, root = path)
 ```
 
 **THIS WILL CHANGE A LITTLE I THINK** - but mostly in how the index
@@ -288,7 +288,7 @@ should not contain spaces (nor should it change as this will change
 the key report id and you'll lose a chain of history), then edit
 the file `orderly.yml` within that directory.
 ``` {r }
-orderly::orderly_new("new", path = path)
+orderly::orderly_new("new", root = path)
 ```
 
 As a report becomes more complex, the function

--- a/vignettes/src/orderly.R
+++ b/vignettes/src/orderly.R
@@ -85,7 +85,7 @@ tree <- function(path, header = path) {
 
 ## As an example, we have a directory at `path` that contains
 ## orderly sources.  Typically this would be in the working directory
-## (and in that case the `config` argument may be omitted) but for this
+## (and in that case the `path` argument may be omitted) but for this
 ## vignette the path will be passed in explicitly.
 
 ## The `orderly.yml` to describe the creation of a report might look like:
@@ -192,14 +192,14 @@ yaml_output(readLines(file.path(path, "orderly_config.yml")))
 ## Reports are run by *name*.  In the above configuration the report
 ## is called `example` because it is in the directory `src/example`.
 ## A list of report names can be returned by running
-orderly::orderly_list(config = path)
+orderly::orderly_list(path = path)
 
 ## If the report requires parameters then these must be passed through
 ## too; in the above case the report takes the parameter `cyl` which
 ## must be passed through as a named list.  So we might run this
 ## report as
 ##+ collapse = TRUE
-id <- orderly::orderly_run("example", list(cyl = 4), config = path)
+id <- orderly::orderly_run("example", list(cyl = 4), path = path)
 
 ### need this for later:
 ##+ echo = FALSE, results = "hide"
@@ -248,11 +248,11 @@ plain_output(tree(path, "<root>"))
 ## by other applications.
 
 ## You can see the list of draft reports like so:
-orderly::orderly_list_drafts(config = path)
+orderly::orderly_list_drafts(path = path)
 
 ## Once you're happy with a report, then "commit" it with
 ##+ collapse = TRUE
-orderly::orderly_commit(id, config = path)
+orderly::orderly_commit(id, path = path)
 
 ## **THIS WILL CHANGE A LITTLE I THINK** - but mostly in how the index
 ## is built and how we might synchronise reports across people and
@@ -272,7 +272,7 @@ plain_output(tree(path, "<root>"))
 ## should not contain spaces (nor should it change as this will change
 ## the key report id and you'll lose a chain of history), then edit
 ## the file `orderly.yml` within that directory.
-orderly::orderly_new("new", config = path)
+orderly::orderly_new("new", path = path)
 
 ## As a report becomes more complex, the function
 ## `orderly::orderly_test_start` will become useful; this function

--- a/vignettes/src/orderly.R
+++ b/vignettes/src/orderly.R
@@ -85,7 +85,7 @@ tree <- function(path, header = path) {
 
 ## As an example, we have a directory at `path` that contains
 ## orderly sources.  Typically this would be in the working directory
-## (and in that case the `path` argument may be omitted) but for this
+## (and in that case the `root` argument may be omitted) but for this
 ## vignette the path will be passed in explicitly.
 
 ## The `orderly.yml` to describe the creation of a report might look like:
@@ -192,14 +192,14 @@ yaml_output(readLines(file.path(path, "orderly_config.yml")))
 ## Reports are run by *name*.  In the above configuration the report
 ## is called `example` because it is in the directory `src/example`.
 ## A list of report names can be returned by running
-orderly::orderly_list(path = path)
+orderly::orderly_list(root = path)
 
 ## If the report requires parameters then these must be passed through
 ## too; in the above case the report takes the parameter `cyl` which
 ## must be passed through as a named list.  So we might run this
 ## report as
 ##+ collapse = TRUE
-id <- orderly::orderly_run("example", list(cyl = 4), path = path)
+id <- orderly::orderly_run("example", list(cyl = 4), root = path)
 
 ### need this for later:
 ##+ echo = FALSE, results = "hide"
@@ -248,11 +248,11 @@ plain_output(tree(path, "<root>"))
 ## by other applications.
 
 ## You can see the list of draft reports like so:
-orderly::orderly_list_drafts(path = path)
+orderly::orderly_list_drafts(root = path)
 
 ## Once you're happy with a report, then "commit" it with
 ##+ collapse = TRUE
-orderly::orderly_commit(id, path = path)
+orderly::orderly_commit(id, root = path)
 
 ## **THIS WILL CHANGE A LITTLE I THINK** - but mostly in how the index
 ## is built and how we might synchronise reports across people and
@@ -272,7 +272,7 @@ plain_output(tree(path, "<root>"))
 ## should not contain spaces (nor should it change as this will change
 ## the key report id and you'll lose a chain of history), then edit
 ## the file `orderly.yml` within that directory.
-orderly::orderly_new("new", path = path)
+orderly::orderly_new("new", root = path)
 
 ## As a report becomes more complex, the function
 ## `orderly::orderly_test_start` will become useful; this function


### PR DESCRIPTION
The orderly config object is not one that is returnable to the user,
so the 'config' argument that we have been using makes no sense.

This is a mass rename of all the arguments that I can find that might
be exposed to the user, plus updating the roxygen docs, tests and the
vignettes to reflect the change
