### PR TITLE
VIMC-2919: Bump version and add NEWS

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 0.6.3
+Version: 0.6.4
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# 0.6.4
+
+* The `config` argument to exported functions has been renamed to `root` to better reflect what is expected to be passed in (VIMC-2919)
+
 # 0.6.3
 
 * The `orderly_run.yml` script has now been removed and `orderly_run.rds` is the sole source of truth for the orderly run metadata (VIMC-2873).


### PR DESCRIPTION
Sorry, this should have been part of the previous PR (#94) - all user-visible changes really must have a version increment.  I'd done this locally but forgotten to push