### PR TITLE
VIMC-2882: back up database periodically

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 0.6.4
+Version: 0.6.5
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# 0.6.5
+
+* The orderly "runner" (`orderly_runner`) will now periodically backup the destination database, which will be useful in cases where other applications store information in it (VIMC-2882)
+
 # 0.6.4
 
 * The `config` argument to exported functions has been renamed to `root` to better reflect what is expected to be passed in (VIMC-2919)

--- a/R/db.R
+++ b/R/db.R
@@ -110,14 +110,16 @@ orderly_rebuild <- function(root = NULL, locate = TRUE, verbose = TRUE,
 orderly_backup <- function(config = NULL, locate = TRUE) {
   config <- orderly_config_get(config, locate)
   if (config$destination$driver[[1]] == "RSQLite") {
-    src <- config$destination$args$dbname
+    curr <- orderly_db_args(config$destination, config)$args$dbname
 
-    ## TODO: make the relative path configurable
-    dest <- file.path("backup", basename(src), fsep = "/")
-    dest_full <- file.path(config$root, dest)
-    dir.create(dirname(dest_full), FALSE, TRUE)
-    orderly_log("backup", sprintf("%s => %s", src, dest))
+    dest <- path_db_backup(config$root, curr)
+    dir.create(dirname(dest), FALSE, TRUE)
 
-    sqlite_backup(src, dest_full)
+    prefix <- paste0(config$root, "/")
+    orderly_log("backup", sprintf("%s => %s",
+                                  sub(prefix, "", curr, fixed = TRUE),
+                                  sub(prefix, "", dest, fixed = TRUE)))
+
+    sqlite_backup(curr, dest)
   }
 }

--- a/R/paths.R
+++ b/R/paths.R
@@ -69,3 +69,8 @@ path_changelog_txt <- function(path, type) {
 path_changelog_json <- function(path, type) {
   file.path(path, "changelog.json")
 }
+
+
+path_db_backup <- function(root, file) {
+  file.path(root, "backup", "db", basename(file), fsep = "/")
+}

--- a/R/runner.R
+++ b/R/runner.R
@@ -39,9 +39,10 @@ R6_orderly_runner <- R6::R6Class(
     path_log = NULL,
     path_id = NULL,
 
-    con = NULL,
     data = NULL,
     has_git = NULL,
+
+    backup = NULL,
 
     initialize = function(path, allow_ref) {
       self$path <- path
@@ -55,6 +56,9 @@ R6_orderly_runner <- R6::R6Class(
       if (self$has_git && !self$allow_ref) {
         message("Disallowing reference switching in runner")
       }
+
+      do_backup <- protect(function() orderly_backup(self$config))
+      self$backup <- periodic(do_backup, 600)
 
       bin <- tempfile()
       dir.create(bin)
@@ -214,6 +218,7 @@ R6_orderly_runner <- R6::R6Class(
       } else {
         ret <-"idle"
       }
+      self$backup()
       attr(ret, "key") <- key
       ret
     },

--- a/man/orderly_runner.Rd
+++ b/man/orderly_runner.Rd
@@ -4,7 +4,7 @@
 \alias{orderly_runner}
 \title{Orderly runner}
 \usage{
-orderly_runner(path, allow_ref = NULL)
+orderly_runner(path, allow_ref = NULL, backup_period = 600)
 }
 \arguments{
 \item{path}{Path to use}
@@ -14,9 +14,23 @@ given, then we will look to see if the orderly configuration
 disallows branch changes (based on the
 \code{ORDERLY_API_SERVER_IDENTITY} environment variable and the
 \code{master_only} setting of the relevant server block.}
+
+\item{backup_period}{Period (in seconds) between DB backups.  This
+is a guide only as backups cannot happen while a task is running
+- if more than this many seconds have elapsed when the runner is
+in its idle loop a backup of the db will be performed.  This
+creates a copy of orderly's destination database in
+\code{backup/db} with the same filename as the destination
+database, even if that database typically lives outside of the
+orderly tree.  In case of corruption of the database, this
+backup can be manually moved into place.  This is only needed if
+you are storing information alongside the core orderly tables
+(as done by OrderlyWeb).}
 }
 \description{
-An orderly runner.  This is used to run reports remotely.  It's
-designed to be used in conjunction with montagu-reporting-api, so
-there is no "draft" stage.
+An orderly runner.  This is used to run reports as a server
+process.  It's designed to be used in conjunction with OrderlyWeb,
+so there is no "draft" stage and reports are committed as soon as
+they are run.  This function is not intended for human end users,
+only for creating automated tools for use with orderly.
 }

--- a/tests/testthat/test-db.R
+++ b/tests/testthat/test-db.R
@@ -154,3 +154,13 @@ test_that("sources are listed in db", {
   expect_false("resource" %in% d$file_purpose)
   expect_true("source" %in% d$file_purpose)
 })
+
+
+test_that("backup", {
+  path <- create_orderly_demo()
+  expect_message(
+    orderly_backup(path),
+    "orderly.sqlite => backup/orderly.sqlite",
+    fixed = TRUE)
+  expect_true(file.exists(file.path(path, "backup/orderly.sqlite")))
+})

--- a/tests/testthat/test-db.R
+++ b/tests/testthat/test-db.R
@@ -160,7 +160,15 @@ test_that("backup", {
   path <- create_orderly_demo()
   expect_message(
     orderly_backup(path),
-    "orderly.sqlite => backup/orderly.sqlite",
+    "orderly.sqlite => backup/db/orderly.sqlite",
     fixed = TRUE)
-  expect_true(file.exists(file.path(path, "backup/orderly.sqlite")))
+
+  dest <- path_db_backup(path, "orderly.sqlite")
+  expect_true(file.exists(dest))
+
+  dat_orig <- with_sqlite(file.path(path, "orderly.sqlite"), function(con)
+    DBI::dbReadTable(con, "report_version"))
+  dat_backup <- with_sqlite(dest, function(con)
+    DBI::dbReadTable(con, "report_version"))
+  expect_equal(dat_orig, dat_backup)
 })


### PR DESCRIPTION
This PR will add a periodic backup to be run from the runner.

The use case/issue is that if we are backing up the system with rsync we have the potential to back up an inconsistent db, which is a problem with data now being stored on the OrderlyWeb side as well as the rebuildable orderly db.

With the changes here the db is backed up every 10 minutes by default.  To make the backup process safe to inconsistencies, we first backup the backup by moving it to `<name>.prev` (which is atomic) then doing the new backup