### PR TITLE
VIMC-2768: Move custom fields into a separate table

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 0.6.5
+Version: 0.6.6
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # 0.6.6
 
-* The database schema now represents the "custom" fields in a way that makes it more obvious which fields are in fact custom, using new tables `custom_fields` (holding metadata about the fields) and `report_version_custom` (linking these to the report versions) (VIMC-2768)
+* The database schema now represents the "custom" fields in a way that makes it more obvious which fields are in fact custom, using new tables `custom_fields` (holding metadata about the fields) and `report_version_custom_fields` (linking these to the report versions) (VIMC-2768)
 
 # 0.6.5
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# 0.6.6
+
+* The database schema now represents the "custom" fields in a way that makes it more obvious which fields are in fact custom, using new tables `custom_fields` (holding metadata about the fields) and `report_version_custom` (linking these to the report versions) (VIMC-2768)
+
 # 0.6.5
 
 * The orderly "runner" (`orderly_runner`) will now periodically backup the destination database, which will be useful in cases where other applications store information in it (VIMC-2882)

--- a/R/db2.R
+++ b/R/db2.R
@@ -179,14 +179,8 @@ report_db_open_existing <- function(con, config) {
                  paste(squote(custom_extra), collapse = ", ")))
   }
 
-  if (!DBI::dbExistsTable(con, "changelog_label")) {
-    ## This DB needs rebuilding, but this at least will give a
-    ## sensible error message:
-    label <- data_frame(label = character(0), public = logical(0))
-  } else {
-    label <- DBI::dbReadTable(con, "changelog_label")
-    label$public <- as.logical(label$public)
-  }
+  label <- DBI::dbReadTable(con, "changelog_label")
+  label$public <- as.logical(label$public)
   ok <- setequal(label$id, config$changelog$id) &&
     identical(label$public[match(label$id, config$changelog$id)],
               config$changelog$public %||% logical(0))

--- a/R/db2.R
+++ b/R/db2.R
@@ -8,7 +8,7 @@
 ## namespace/module feature so that implementation details can be
 ## hidden away a bit further.
 
-ORDERLY_SCHEMA_VERSION <- "0.0.7"
+ORDERLY_SCHEMA_VERSION <- "0.0.8"
 
 ## These will be used in a few places and even though they're not
 ## super likely to change it would be good
@@ -28,6 +28,7 @@ report_db_schema_read <- function(fields = NULL, dialect = "sqlite") {
 
   d <- set_names(lapply(names(d), preprepare), names(d))
 
+  ## Delete with VIMC-2929
   if (!is.null(fields)) {
     f <- set_names(Map(function(t, n) list(type = t, nullable = n),
                        fields$type, !fields$required),
@@ -104,6 +105,11 @@ report_db_schema_read <- function(fields = NULL, dialect = "sqlite") {
     sql <- c(sql, unlist(lapply(tables, "[[", "sql_fk"), FALSE, FALSE))
   }
   values <- drop_null(lapply(tables, "[[", "values"))
+  if (!is.null(fields)) {
+    values$custom_fields <- data_frame(
+      id = fields$name,
+       description = fields$description)
+  }
 
   list(tables = tables,
        sql = sql,
@@ -153,21 +159,17 @@ report_db_init_create <- function(con, config, dialect) {
 
 
 report_db_open_existing <- function(con, config) {
-  sql <- sprintf("SELECT * FROM %s LIMIT 0", ORDERLY_MAIN_TABLE)
-  d <- DBI::dbGetQuery(con, sql)
-  custom_name <- config$fields$name
-  msg <- setdiff(custom_name, names(d))
-  if (length(msg) > 0L) {
+  custom_db <- DBI::dbReadTable(con, "custom_fields")$id
+  custom_config <- config$fields$name
+  custom_msg <- setdiff(custom_config, custom_db)
+  if (length(custom_msg) > 0L) {
     stop(sprintf("custom fields %s not present in existing database",
-                 paste(squote(msg), collapse = ", ")))
+                 paste(squote(custom_msg), collapse = ", ")))
   }
-
-  schema <- report_db_schema(config$fields, report_db_dialect(con))
-  cols <- names(schema$tables[[ORDERLY_MAIN_TABLE]]$columns)
-  extra <- setdiff(names(d), cols)
-  if (length(extra) > 0L) {
+  custom_extra <- setdiff(custom_db, custom_config)
+  if (length(custom_extra) > 0L) {
     stop(sprintf("custom fields %s in database not present in config",
-                 paste(squote(extra), collapse = ", ")))
+                 paste(squote(custom_extra), collapse = ", ")))
   }
 
   if (!DBI::dbExistsTable(con, "changelog_label")) {
@@ -283,10 +285,22 @@ report_data_import <- function(con, workdir, config) {
     git_sha = dat_rds$git$sha %||% NA_character_,
     git_branch = dat_rds$git$branch %||% NA_character_,
     git_clean = git_clean)
+  ## TODO: Delete with VIMC-2929
   if (!is.null(dat_rds$meta$extra_fields)) {
     report_version <- cbind(report_version, dat_rds$meta$extra_fields)
   }
   DBI::dbWriteTable(con, "report_version", report_version, append = TRUE)
+
+  if (!is.null(dat_rds$meta$extra_fields)) {
+    custom <- vcapply(dat_rds$meta$extra_fields, function(x) as.character(x))
+    custom <- custom[!is.na(custom)]
+    report_version_custom <- data_frame(
+      report_version = id,
+      key = names(custom),
+      value = unname(custom))
+    DBI::dbWriteTable(con, "report_version_custom", report_version_custom,
+                      append = TRUE)
+  }
 
   if (!is.null(dat_rds$meta$view)) {
     report_version_view <- cbind(report_version = id, dat_rds$meta$view,

--- a/R/db2.R
+++ b/R/db2.R
@@ -31,7 +31,7 @@ report_db_schema_read <- function(fields = NULL, dialect = "sqlite") {
   ## Delete with VIMC-2929
   if (!is.null(fields)) {
     f <- set_names(Map(function(t, n) list(type = t, nullable = n),
-                       fields$type, !fields$required),
+                       rep("character", nrow(fields)), !fields$required),
                    fields$name)
     d[[ORDERLY_MAIN_TABLE]]$columns <- c(d[[ORDERLY_MAIN_TABLE]]$columns, f)
   }

--- a/R/db2.R
+++ b/R/db2.R
@@ -293,12 +293,12 @@ report_data_import <- function(con, workdir, config) {
   if (!is.null(dat_rds$meta$extra_fields)) {
     custom <- vcapply(dat_rds$meta$extra_fields, function(x) as.character(x))
     custom <- custom[!is.na(custom)]
-    report_version_custom <- data_frame(
+    report_version_custom_fields <- data_frame(
       report_version = id,
       key = names(custom),
       value = unname(custom))
-    DBI::dbWriteTable(con, "report_version_custom", report_version_custom,
-                      append = TRUE)
+    DBI::dbWriteTable(con, "report_version_custom_fields",
+                      report_version_custom_fields, append = TRUE)
   }
 
   if (!is.null(dat_rds$meta$view)) {

--- a/R/db2.R
+++ b/R/db2.R
@@ -108,7 +108,7 @@ report_db_schema_read <- function(fields = NULL, dialect = "sqlite") {
   if (!is.null(fields)) {
     values$custom_fields <- data_frame(
       id = fields$name,
-       description = fields$description)
+      description = fields$description)
   }
 
   list(tables = tables,

--- a/R/db2.R
+++ b/R/db2.R
@@ -159,6 +159,13 @@ report_db_init_create <- function(con, config, dialect) {
 
 
 report_db_open_existing <- function(con, config) {
+  version_db <- DBI::dbReadTable(con, ORDERLY_SCHEMA_TABLE)$schema_version
+  version_package <- ORDERLY_SCHEMA_VERSION
+  if (numeric_version(version_db) < numeric_version(version_package)) {
+    stop("orderly db needs rebuilding with orderly::orderly_rebuild()",
+         call. = FALSE)
+  }
+
   custom_db <- DBI::dbReadTable(con, "custom_fields")$id
   custom_config <- config$fields$name
   custom_msg <- setdiff(custom_config, custom_db)
@@ -185,14 +192,6 @@ report_db_open_existing <- function(con, config) {
               config$changelog$public %||% logical(0))
   if (!ok) {
     stop("changelog labels have changed: rebuild with orderly::orderly_rebuild",
-         call. = FALSE)
-  }
-
-  d <- DBI::dbReadTable(con, ORDERLY_SCHEMA_TABLE)
-  if (numeric_version(d$schema_version) <
-      numeric_version(ORDERLY_SCHEMA_VERSION)) {
-    ## with this approach we can't ever upgrade, but at least we throw
-    stop("orderly db needs rebuilding with orderly::orderly_rebuild()",
          call. = FALSE)
   }
 }

--- a/R/new.R
+++ b/R/new.R
@@ -78,7 +78,7 @@ orderly_new_system <- function(dest, config) {
     fields <- config$fields
     desc <- ifelse(is.na(fields$description), fields$name, fields$description)
     req <- ifelse(fields$required, "required", "optional")
-    str <- sprintf("%s -- %s (%s)", desc, fields$type, req)
+    str <- sprintf("%s -- character (%s)", desc, req)
     str <- vcapply(strwrap(str, prefix = "# ", simplify = FALSE),
                    paste, collapse = "\n")
     ex <- sprintf(ifelse(fields$required, "%s: ~", "# %s:"), fields$name)

--- a/R/recipe_read.R
+++ b/R/recipe_read.R
@@ -27,8 +27,7 @@ recipe_read <- function(path, config, validate = TRUE) {
   ## Fill any any missing optional fields:
   i <- !(config$fields$name %in% names(info))
   if (any(i)) {
-    info[config$fields$name[i]] <-
-      lapply(config$fields$type[i], set_mode, x = NA)
+    info[config$fields$name[i]] <- NA_character_
   }
 
   fieldname <- function(name) {
@@ -96,8 +95,7 @@ recipe_read <- function(path, config, validate = TRUE) {
     el <- config$fields[i, ]
     x <- info[[el$name]]
     if (!is.null(x) || el$required) {
-      assert_type(x, el$type, fieldname(el$name))
-      assert_scalar(x, fieldname(el$name))
+      assert_scalar_character(x, fieldname(el$name))
     }
   }
 

--- a/R/util.R
+++ b/R/util.R
@@ -197,10 +197,6 @@ pasteq <- function(x, sep = ", ") {
   paste(squote(x), collapse = ", ")
 }
 
-set_mode <- function(x, mode) {
-  storage.mode(x) <- mode
-  x
-}
 
 capture_log <- function(expr, filename) {
   con <- file(filename, "w")

--- a/inst/database/schema.yml
+++ b/inst/database/schema.yml
@@ -41,6 +41,19 @@ report_version:
     # NOTE: fields listed in orderly_config.yml will also be
     # included here.
 
+# Custom fields - all coerced into text.
+report_version_custom:
+  columns:
+    - id: {type: SERIAL}
+    - report_version: {fk: report_version.id}
+    - key: {fk: custom_fields.id}
+    - value: {type: TEXT}
+
+custom_fields:
+  columns:
+    - id: {type: TEXT}
+    - description: {type: TEXT, nullable: true}
+
 # The extracted data
 #
 # I think that it would be nice to record the number of rows and

--- a/inst/database/schema.yml
+++ b/inst/database/schema.yml
@@ -42,7 +42,7 @@ report_version:
     # included here.
 
 # Custom fields - all coerced into text.
-report_version_custom:
+report_version_custom_fields:
   columns:
     - id: {type: SERIAL}
     - report_version: {fk: report_version.id}

--- a/tests/testthat/test-db.R
+++ b/tests/testthat/test-db.R
@@ -16,18 +16,11 @@ test_that("custom fields", {
 
   expect_true(DBI::dbExistsTable(con, "orderly_schema"))
 
-  ## TODO: should the db initialisation here check that the custom
-  ## fields are all OK?  But that will happen rather a lot and that's
-  ## not great either.  But then performance probably does not matter.
-
   config <- orderly_config_get(path)
   expect_error(report_db_init(con, config, TRUE),
                "Table 'orderly_schema' already exists")
 
-  d <- DBI::dbReadTable(con, "report_version")
-  d <- d[setdiff(names(d), "author")]
-  DBI::dbWriteTable(con, "report_version", d, overwrite = TRUE)
-
+  DBI::dbExecute(con, "DELETE FROM custom_fields WHERE id = 'author'")
   expect_error(report_db_init(con, config, FALSE),
                "custom fields 'author' not present in existing database")
 

--- a/tests/testthat/test-db.R
+++ b/tests/testthat/test-db.R
@@ -165,3 +165,20 @@ test_that("backup", {
     DBI::dbReadTable(con, "report_version"))
   expect_equal(dat_orig, dat_backup)
 })
+
+
+test_that("db includes custom fields", {
+  path <- prepare_orderly_example("demo")
+  id <- orderly_run("minimal", root = path, echo = FALSE)
+  orderly_commit(id, root = path)
+  con <- orderly_db("destination", root = path)
+  on.exit(DBI::dbDisconnect(con))
+  d <- DBI::dbReadTable(con, "report_version_custom_fields")
+  expect_equal(d$report_version, rep(id, 3))
+  v <- c("requester", "author", "comment")
+  expect_setequal(d$key, v)
+  expect_equal(d$value[match(v, d$key)],
+               c("Funder McFunderface",
+                 "Researcher McResearcherface",
+                 "This is a comment"))
+})


### PR DESCRIPTION
This PR makes it easier for external applications (i.e., OrderlyWeb) to interact with custom fields by putting them elsewhere than the main table (VIMC-2929 will remove them from the main table).

Two new tables are created:
* `custom_fields`, which holds the field definitions
* `report_version_custom_fields`, which holds the fields associated with each version

The fields are all constrained to be `TEXT` so this part of validation comes out of the config.

Once OrderlyWeb supports this new format, the old approach can be removed - this can be done in a separate PR (and for ease of deploy probably should be) - the ticket is VIMC-2929 and I've got a branch for this ([content](https://github.com/vimc/orderly/tree/vimc-2929), [compare](https://github.com/vimc/orderly/compare/vimc-2768...vimc-2929)) that is small enough it can either be rebased onto later work or reimplemented