### PR TITLE
VIMC-2696: Global PK for changelog entries

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 0.6.6
+Version: 0.6.7
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/R/changelog.R
+++ b/R/changelog.R
@@ -48,7 +48,12 @@ changelog_compare <- function(new, old) {
          call. = FALSE)
   }
 
-  new[i, , drop = FALSE]
+  ret <- new[i, , drop = FALSE]
+  if (length(i) > 0L) {
+    ret <- cbind(id = ids::random_id(length(i)), ret,
+                 stringsAsFactors = FALSE)
+  }
+  ret
 }
 
 

--- a/R/changelog.R
+++ b/R/changelog.R
@@ -63,7 +63,11 @@ changelog_read_previous <- function(name, config) {
   ## that is going to end up in the configuration.
   prev <- orderly_latest(name, config, locate = FALSE,
                          draft = FALSE, must_work = FALSE)
-  changelog_read_json(file.path(config$root, "archive", name, prev))
+  if (is.na(prev)) {
+    return(NULL)
+  }
+  path <- file.path(config$root, "archive", name, prev)
+  readRDS(path_orderly_run_rds(path))$meta$changelog
 }
 
 
@@ -142,20 +146,4 @@ changelog_message_parse <- function(txt) {
   data_frame(label = label,
              value = value,
              from_file = FALSE)
-}
-
-
-changelog_save_json <- function(dat, path) {
-  if (!is.null(dat)) {
-    writeLines(jsonlite::toJSON(dat), path_changelog_json(path))
-  }
-}
-
-
-changelog_read_json <- function(path) {
-  filename <- path_changelog_json(path)
-  if (!file.exists(filename)) {
-    return(NULL)
-  }
-  jsonlite::fromJSON(filename)
 }

--- a/R/db2.R
+++ b/R/db2.R
@@ -419,6 +419,11 @@ report_data_import <- function(con, workdir, config) {
   if (!is.null(changelog)) {
     changelog <- changelog[changelog$report_version == id, , drop = FALSE]
     if (nrow(changelog) > 0L) {
+      prev <- DBI::dbGetQuery(con, "SELECT max(ordering) FROM changelog")[[1]]
+      if (is.na(prev)) {
+        prev <- 0L
+      }
+      changelog$ordering <- seq_len(nrow(changelog)) + prev
       DBI::dbWriteTable(con, "changelog", changelog, append = TRUE)
     }
   }

--- a/R/db2.R
+++ b/R/db2.R
@@ -236,7 +236,6 @@ report_db_needs_rebuild <- function(config) {
 report_data_import <- function(con, workdir, config) {
   dat_rds <- readRDS(path_orderly_run_rds(workdir))
   published <- report_is_published(workdir)
-  changelog <- changelog_read_json(workdir)
 
   ## Was not done before 0.3.3
   stopifnot(!is.null(dat_rds$meta))
@@ -416,6 +415,7 @@ report_data_import <- function(con, workdir, config) {
     filename = artefact_files)
   DBI::dbWriteTable(con, "file_artefact", file_artefact, append = TRUE)
 
+  changelog <- dat_rds$meta$changelog
   if (!is.null(changelog)) {
     changelog <- changelog[changelog$report_version == id, , drop = FALSE]
     if (nrow(changelog) > 0L) {

--- a/R/paths.R
+++ b/R/paths.R
@@ -66,11 +66,6 @@ path_changelog_txt <- function(path, type) {
 }
 
 
-path_changelog_json <- function(path, type) {
-  file.path(path, "changelog.json")
-}
-
-
 path_db_backup <- function(root, file) {
   file.path(root, "backup", "db", basename(file), fsep = "/")
 }

--- a/R/recipe_run.R
+++ b/R/recipe_run.R
@@ -297,6 +297,7 @@ recipe_run <- function(info, parameters, envir, config, echo = TRUE) {
                artefacts = info$artefacts,
                depends = depends,
                elapsed = as.numeric(elapsed, "secs"),
+               changelog = info$changelog,
                git = info$git)
 
   if (!is.null(info$data)) {
@@ -487,7 +488,6 @@ recipe_prepare_workdir <- function(info, message, config) {
   }
 
   info$changelog <- changelog_load(src, message, info, config)
-  changelog_save_json(info$changelog, info$workdir)
 
   info$owd <- owd
   info$resource_info <- resource_info
@@ -545,8 +545,7 @@ recipe_unexpected_artefacts <- function(info, id) {
   ## we expect to see all artefacts from the config, the source file
   ## and the yml config; the changelog may or may not be present, but
   ## it's never unexpected.
-  expected <- c(expected, resources, dependencies, info$script, "orderly.yml",
-                "changelog.json")
+  expected <- c(expected, resources, dependencies, info$script, "orderly.yml")
 
   # this is set to recursive to ensure that artefacts created in directories
   # are tracked

--- a/R/testing.R
+++ b/R/testing.R
@@ -119,10 +119,10 @@ demo_change_time <- function(id, time, path) {
   dat$meta$date <- as.character(time)
   saveRDS(dat, rds)
 
-  changelog <- changelog_read_json(p)
+  changelog <- dat$meta$changelog
   if (!is.null(changelog)) {
     changelog$report_version[changelog$report_version == id] <- id_new
-    changelog_save_json(changelog, p)
+    dat$meta$changelog <- changelog
   }
 
   orderly_commit(id_new, name, root = path)

--- a/R/testing.R
+++ b/R/testing.R
@@ -117,13 +117,13 @@ demo_change_time <- function(id, time, path) {
   dat$time <- time
   dat$meta$id <- id_new
   dat$meta$date <- as.character(time)
-  saveRDS(dat, rds)
-
   changelog <- dat$meta$changelog
   if (!is.null(changelog)) {
     changelog$report_version[changelog$report_version == id] <- id_new
     dat$meta$changelog <- changelog
   }
+
+  saveRDS(dat, rds)
 
   orderly_commit(id_new, name, root = path)
 

--- a/inst/database/schema.yml
+++ b/inst/database/schema.yml
@@ -193,6 +193,7 @@ changelog:
     - label: {type: TEXT, fk: changelog_label.id}
     - value: {type: TEXT}
     - from_file: {type: BOOLEAN}
+    - ordering: {type: INTEGER}
 
 parameters_type:
   columns:

--- a/inst/database/schema.yml
+++ b/inst/database/schema.yml
@@ -187,7 +187,7 @@ changelog_label:
 
 changelog:
   columns:
-    - id: {type: SERIAL}
+    - id: {type: TEXT}
     - report_version: {fk: report_version.id}
     - report_version_public: {fk: report_version.id, nullable: true}
     - label: {type: TEXT, fk: changelog_label.id}

--- a/inst/migrate/0.6.7.R
+++ b/inst/migrate/0.6.7.R
@@ -1,0 +1,27 @@
+migrate <- function(data, path, config) {
+  p <- file.path(path, "changelog.json")
+  if (!file.exists(p)) {
+    return(migration_result(FALSE, data))
+  }
+
+  name <- data$meta$name
+  id <- data$meta$id
+
+  d <- jsonlite::fromJSON(p)
+  d <- cbind(id = NA_character_, d, stringsAsFactors = FALSE)
+  i <- d$report_version == id
+  d$id[i] <- ids::random_id(sum(i))
+
+  j <- !i
+  if (any(j)) {
+    prev_id <- d$report_version[j][[1]]
+    prev_path <- file.path(config$root, "archive", name, prev_id)
+    prev_changelog <- readRDS(path_orderly_run_rds(prev_path))$meta$changelog
+    stopifnot(nrow(prev_changelog) == sum(j))
+    d$id[j] <- prev_changelog$id
+  }
+
+  data$meta$changelog <- d
+
+  migration_result(TRUE, data)
+}

--- a/tests/testthat/test-changelog.R
+++ b/tests/testthat/test-changelog.R
@@ -179,7 +179,7 @@ test_that("append changelog", {
   id1 <- orderly_run("example", root = path, echo = FALSE)
   p1 <- orderly_commit(id1, root = path)
 
-  l1 <- changelog_read_json(p1)
+  l1 <- readRDS(path_orderly_run_rds(p1))$meta$changelog
   expect_equal(l1[names(l1) != "id"],
                data_frame(label = "label1",
                           value = "value1",
@@ -200,7 +200,7 @@ test_that("append changelog", {
   id2 <- orderly_run("example", root = path, echo = FALSE)
   p2 <- orderly_commit(id2, root = path)
 
-  l2 <- changelog_read_json(p2)
+  l2 <- readRDS(path_orderly_run_rds(p2))$meta$changelog
   expect_equal(l2[names(l2) != "id"],
                data_frame(label = c("label2", "label1"),
                           value = c("value2", "value1"),
@@ -210,8 +210,8 @@ test_that("append changelog", {
 
   id3 <- orderly_run("example", root = path, echo = FALSE)
   p3 <- orderly_commit(id3, root = path)
-  expect_equal(changelog_read_json(p3),
-               changelog_read_json(p2))
+  l3 <- readRDS(path_orderly_run_rds(p3))$meta$changelog
+  expect_equal(l3, l2)
 })
 
 

--- a/tests/testthat/test-changelog.R
+++ b/tests/testthat/test-changelog.R
@@ -192,7 +192,8 @@ test_that("append changelog", {
   d <- DBI::dbReadTable(con, "changelog")
   d$from_file <- as.logical(d$from_file)
   expect_equal(d[names(l1)], l1)
-  expect_setequal(names(d), c(names(l1), "report_version_public"))
+  expect_setequal(names(d), c(names(l1), "ordering", "report_version_public"))
+  expect_equal(d$ordering, 1L)
 
   txt <- c("[label2]", "value2", readLines(path_cl))
   writeLines(txt, path_cl)
@@ -207,6 +208,8 @@ test_that("append changelog", {
                           from_file = TRUE,
                           report_version = c(id2, id1)))
   expect_equal(l2$id[[2]], l1$id)
+
+  expect_setequal(DBI::dbReadTable(con, "changelog")$ordering, 1:2)
 
   id3 <- orderly_run("example", root = path, echo = FALSE)
   p3 <- orderly_commit(id3, root = path)

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -463,7 +463,7 @@ test_that("run with message", {
                     message = test_message)
   p <- orderly_commit(id, root = path)
 
-  d <- changelog_read_json(p)
+  d <- readRDS(path_orderly_run_rds(p))$meta$changelog
   expect_equal(d[names(d) != "id"],
                data_frame(
                  label = "label1", value = "test", from_file = FALSE,

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -463,10 +463,12 @@ test_that("run with message", {
                     message = test_message)
   p <- orderly_commit(id, root = path)
 
-  expect_equal(changelog_read_json(p),
+  d <- changelog_read_json(p)
+  expect_equal(d[names(d) != "id"],
                data_frame(
                  label = "label1", value = "test", from_file = FALSE,
                  report_version = id))
+  expect_match(d$id, "^[[:xdigit:]]{32}")
 })
 
 

--- a/tests/testthat/test-z-demo.R
+++ b/tests/testthat/test-z-demo.R
@@ -16,6 +16,9 @@ test_that("orderly_demo", {
   expect_false(any(is.na(d$description[d$report == "other"])))
   expect_true(all(is.na(d$displayname[d$report == "minimal"])))
   expect_true(all(is.na(d$description[d$report == "minimal"])))
+
+  ## Ensure that the time manipulation affects the changelog too
+  expect_true(nrow(DBI::dbReadTable(con, "changelog")) > 0)
 })
 
 

--- a/vignettes/changelog.Rmd
+++ b/vignettes/changelog.Rmd
@@ -41,37 +41,10 @@ unaltered.
 
 Messages can be provided to orderly run and these are required to be in the format `[label] value`.
 
-Once a report is run (via `orderly::orderly_run()`, or via `orderly
-run` on the command line), the given changelog, along with any
+Once a report is run (via `orderly::orderly_run()`, or via `orderly run` on the command line), the given changelog, along with any
 message, is compared with the last commited version of this report,
 and entries that are introduced on this round are identified.  We add
-the report id to the entries and end up with a
-[JSON](https://en.wikipedia.org/wiki/JSON) version of the changelog, called `changelog.json`, which might look like:
-
-```json
-[
-  {
-    "report_version": "20181105-152224-a42aaa47",
-    "from_file": false,
-    "label": "public",
-    "value": "Rerunning as requested"
-  },
-  {
-    "report_version": "20181105-152224-a42aaa47",
-    "from_file": true,
-    "label": "public",
-    "value": "Started working with new version of the data.  This includes everything sent up to 2018-10-10"
-  },
-  {
-    "report_version": "20181105-100427-ef29376c",
-    "from_file": true,
-    "label": "internal",
-    "value": "Fixed incorrect plotting"
-  }
-]
-```
-
-Here, two report versions are present (`20181105-100427-ef29376c` and `20181105-152224-a42aaa47`) and the message is interleaved with the information from the changelog file.
+the report id to the entries, and a randomly generated unique id to each new entry.  This is saved in `orderly_run.rds` along with other report metadata.
 
 ## Details
 
@@ -87,8 +60,8 @@ When preparing to run an orderly report:
 
 1. we read in the plaintext changelog if it exists
 1. parse all messages provided and add as if they were a changelog entry `from_file` of `FALSE`
-1. we look for the "latest" archived version of this report and read a `changelog.json` file if it exists.  Alternatively we can use a remote copy of orderly via the api here (not implemented yet).
+1. we look for the "latest" archived version of this report and read the changelog from that reports `orderly_run.rds` file.  Alternatively we can use a remote copy of orderly via the api here (not implemented yet).
 1. filter the previous previous changelog to remove any `from_file = FALSE` entries and confirm that our new changelog can be prepended to the previous
-1. add the `id` to the "new" entries and prepend this - save the resulting data as `changelog.json`
+1. add the `id` to the "new" entries and prepend this - save the resulting data into the new report's `orderly_run.yml`
 
 For checking against the API, we will use `GET reports/:name/versions/version/latest/changelog/` with the current report name as `:name`.


### PR DESCRIPTION
This is needed for orderly web because we need something that will persist across DB rebuilds.

Before merging we should check to see the impact on the reporting portal and orderly web