### PR TITLE
VIMC-1986: improve the db configuration

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 0.7.3
+Version: 0.7.4
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# 0.7.4
+
+* The database configuration in `orderly_config.yml` now has an "args" section, rather than guessing arguments.  Old configurations are valid, with a warning to update (VIMC-1986).
+
 # 0.7.3
 
 * Function `orderly_unzip_archive` / `unzip_archive` has been removed in preparation for release.

--- a/inst/examples/changelog/orderly_config.yml
+++ b/inst/examples/changelog/orderly_config.yml
@@ -1,7 +1,8 @@
 database:
   source:
     driver: RSQLite::SQLite
-    dbname: source.sqlite
+    args:
+      dbname: source.sqlite
 
 changelog:
   label1:

--- a/inst/examples/db1/orderly_config.yml
+++ b/inst/examples/db1/orderly_config.yml
@@ -1,4 +1,5 @@
 database:
   source1:
     driver: RSQLite::SQLite
-    dbname: source1.sqlite
+    args:
+      dbname: source1.sqlite

--- a/inst/examples/db2/orderly_config.yml
+++ b/inst/examples/db2/orderly_config.yml
@@ -1,7 +1,9 @@
 database:
   source1:
     driver: RSQLite::SQLite
-    dbname: source1.sqlite
+    args:
+      dbname: source1.sqlite
   source2:
     driver: RSQLite::SQLite
-    dbname: source2.sqlite
+    args:
+      dbname: source2.sqlite

--- a/inst/examples/demo/orderly_config.yml
+++ b/inst/examples/demo/orderly_config.yml
@@ -1,7 +1,9 @@
 database:
   source:
     driver: RSQLite::SQLite
-    dbname: source.sqlite
+    args:
+      dbname: source.sqlite
+
 fields:
   requester:
     required: true

--- a/inst/examples/depends/orderly_config.yml
+++ b/inst/examples/depends/orderly_config.yml
@@ -1,4 +1,5 @@
 database:
   source:
     driver: RSQLite::SQLite
-    dbname: source.sqlite
+    args:
+      dbname: source.sqlite

--- a/inst/examples/example/orderly_config.yml
+++ b/inst/examples/example/orderly_config.yml
@@ -1,7 +1,8 @@
 database:
   source:
     driver: RSQLite::SQLite
-    dbname: source.sqlite
+    args:
+      dbname: source.sqlite
 
 changelog:
   label1:

--- a/inst/examples/interactive/orderly_config.yml
+++ b/inst/examples/interactive/orderly_config.yml
@@ -1,4 +1,5 @@
 database:
   source:
     driver: RSQLite::SQLite
-    dbname: source.sqlite
+    args:
+      dbname: source.sqlite

--- a/inst/examples/minimal/orderly_config.yml
+++ b/inst/examples/minimal/orderly_config.yml
@@ -1,4 +1,5 @@
 database:
   source:
     driver: RSQLite::SQLite
-    dbname: source.sqlite
+    args:
+      dbname: source.sqlite

--- a/inst/examples/nodb/orderly_config.yml
+++ b/inst/examples/nodb/orderly_config.yml
@@ -1,4 +1,5 @@
 database:
   source:
     driver: RSQLite::SQLite
-    dbname: $SOME_ENVVAR
+    args:
+      dbname: $SOME_ENVVAR

--- a/inst/examples/other/orderly_config.yml
+++ b/inst/examples/other/orderly_config.yml
@@ -1,4 +1,5 @@
 database:
   source:
     driver: RSQLite::SQLite
-    dbname: source.sqlite
+    args:
+      dbname: source.sqlite

--- a/inst/examples/resources/orderly_config.yml
+++ b/inst/examples/resources/orderly_config.yml
@@ -1,4 +1,5 @@
 database:
   source:
     driver: RSQLite::SQLite
-    dbname: source.sqlite
+    args:
+      dbname: source.sqlite

--- a/inst/orderly_config_example.yml
+++ b/inst/orderly_config_example.yml
@@ -10,14 +10,15 @@
 #   database:
 #     source:
 #       driver: RPostgres::Postgres
-#       host: localhost
-#       port: 5432
-#       user: myuser
-#       dbname: databasename
-#       password: p4ssw0rd
+#       args:
+#         host: localhost
+#         port: 5432
+#         user: myuser
+#         dbname: databasename
+#         password: p4ssw0rd
 #
-# All arguments other than driver are optional and will be passed
-# through during the 'DBI::dbConnect()' call.
+# All arguments in the "args" block will be passed through during the
+# 'DBI::dbConnect()' call.
 #
 # If using SQLite, then the "dbname" argument will be interpreted
 # relative to the orderly root if not absolute .  Be sure to exclude
@@ -35,7 +36,8 @@ database: ~
 #
 #   destination:
 #     driver: RSQLite::SQLite
-#     dbname: different.sqlite
+#     args:
+#       dbname: different.sqlite
 
 # In addition, it may contain a 'fields' section defining custom
 # fields, for example:

--- a/scripts/schema/orderly_config.yml
+++ b/scripts/schema/orderly_config.yml
@@ -1,11 +1,12 @@
 # This is what we'll set up via docker
 destination:
   driver: RPostgres::Postgres
-  host: orderly-db
-  port: 5432
-  user: postgres
-  dbname: orderly
-  password: schemaspy
+  args:
+    host: orderly-db
+    port: 5432
+    user: postgres
+    dbname: orderly
+    password: schemaspy
 
 # Compatible with montagu-reports, but later we'll need this to be
 # tuneable I think.

--- a/tests/testthat/example/orderly_config.yml
+++ b/tests/testthat/example/orderly_config.yml
@@ -1,8 +1,9 @@
 database:
   source:
     driver: RPostgres::Postgres
-    host: montagu.dide.ic.ac.uk
-    port: 8888
-    user: vimc
-    dbname: montagu
-    password: changeme
+    args:
+      host: montagu.dide.ic.ac.uk
+      port: 8888
+      user: vimc
+      dbname: montagu
+      password: changeme

--- a/tests/testthat/example_config.yml
+++ b/tests/testthat/example_config.yml
@@ -1,7 +1,8 @@
 database:
   source:
     driver: RSQLite::SQLite
-    dbname: source.sqlite
+    args:
+      dbname: source.sqlite
 
 fields:
   requester:

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -240,3 +240,20 @@ test_that("warn when reading old-style configuration", {
   expect_warning(orderly_config(path),
                  "Use of 'source' is deprecated and will be removed")
 })
+
+
+test_that("warn when reading old-style db config", {
+  path <- prepare_orderly_example("minimal")
+  content <- c(
+    "database:",
+    "  source:",
+    "    driver: RSQLite::SQLite",
+    "    dbname: source.sqlite")
+  writeLines(content, file.path(path, "orderly_config.yml"))
+  expect_warning(
+    orderly_config(path),
+    "Please move your database arguments")
+  withr::with_options(
+    list(orderly.nowarnings = TRUE),
+    expect_warning(orderly_config(path), NA))
+})

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -20,11 +20,12 @@ test_that("environment variables", {
   dat <- list(database =
                 list(source =
                        list(driver = "RSQLite::SQLite",
-                            host = "OURHOST",
-                            port = "OURPORT",
-                            user = "OURUSER",
-                            dbname = "OURDBNAME",
-                            password = "$OURPASSWORD")))
+                            args = list(
+                              host = "OURHOST",
+                              port = "OURPORT",
+                              user = "OURUSER",
+                              dbname = "OURDBNAME",
+                              password = "$OURPASSWORD"))))
   writeLines(yaml::as.yaml(dat), path_orderly_config_yml(path))
 
   cfg <- orderly_config(path)

--- a/tests/testthat/test-db.R
+++ b/tests/testthat/test-db.R
@@ -57,7 +57,7 @@ test_that("no transient db", {
   config <- list(destination = list(
                    driver = c("RSQLite", "SQLite"),
                    args = list(dbname = ":memory:")),
-                 root = ".")
+                 root = tempdir())
   expect_error(orderly_db_args(config$destination, config = config),
                "Cannot use a transient SQLite database with orderly")
 })

--- a/tests/testthat/test-envir.R
+++ b/tests/testthat/test-envir.R
@@ -5,8 +5,9 @@ test_that("set env", {
   cfg <- c("database:",
            "  source:",
            "    driver: RSQLite::SQLite",
-           "    dbname: source.sqlite",
-           "    user: $MY_USER")
+           "    args:",
+           "      dbname: source.sqlite",
+           "      user: $MY_USER")
   writeLines(cfg, file.path(path, "orderly_config.yml"))
 
   config <- orderly_config(path)

--- a/tests/testthat/test-migrate.R
+++ b/tests/testthat/test-migrate.R
@@ -1,7 +1,9 @@
 context("migrations")
 
-
 test_that("0.3.2 -> 0.3.3", {
+  oo <- options(orderly.nowarnings = TRUE)
+  on.exit(options(oo))
+
   path <- unpack_reference("0.3.2")
   cmp <- unpack_reference("0.4.8")
   orderly_migrate(path, to = "0.3.3")
@@ -22,6 +24,9 @@ test_that("0.3.2 -> 0.3.3", {
 
 
 test_that("roll back migration", {
+  oo <- options(orderly.nowarnings = TRUE)
+  on.exit(options(oo))
+
   path <- unpack_reference("0.3.2")
   hash <- hash_files(list.files(path, recursive = TRUE, full.names = TRUE))
   orderly_migrate(path, to = "0.3.3")
@@ -62,6 +67,9 @@ test_that("failed migrations are rolled back", {
 
 
 test_that("failed migrations can be skipped", {
+  oo <- options(orderly.nowarnings = TRUE)
+  on.exit(options(oo))
+
   path <- unpack_reference("0.3.2")
   hash <- hash_files(list.files(path, recursive = TRUE, full.names = TRUE))
 
@@ -92,6 +100,9 @@ test_that("failed migrations can be skipped", {
 
 
 test_that("failed migrations warned in dry run", {
+  oo <- options(orderly.nowarnings = TRUE)
+  on.exit(options(oo))
+
   path <- unpack_reference("0.3.2")
   hash <- hash_files(list.files(path, recursive = TRUE, full.names = TRUE))
 
@@ -115,6 +126,9 @@ test_that("failed migrations warned in dry run", {
 
 
 test_that("dry run", {
+  oo <- options(orderly.nowarnings = TRUE)
+  on.exit(options(oo))
+
   path <- unpack_reference("0.3.2")
   hash <- hash_files(list.files(path, recursive = TRUE, full.names = TRUE))
   orderly_migrate(path, to = "0.3.3", dry_run = TRUE)
@@ -125,6 +139,9 @@ test_that("dry run", {
 
 
 test_that("migrate_plan default is used", {
+  oo <- options(orderly.nowarnings = TRUE)
+  on.exit(options(oo))
+
   path <- unpack_reference("0.3.2")
   expect_equal(migrate_plan(path), available_migrations())
   expect_equal(migrate_plan(path, to = "0.0.1"),
@@ -169,6 +186,9 @@ test_that("require migration", {
 
 
 test_that("can't commit old version", {
+  oo <- options(orderly.nowarnings = TRUE)
+  on.exit(options(oo))
+
   path <- unpack_reference("0.3.2")
   patch_orderly_config(path)
   contents <- orderly_list_archive(path)
@@ -186,6 +206,9 @@ test_that("can't commit old version", {
 
 
 test_that("don't migrate new orderly", {
+  oo <- options(orderly.nowarnings = TRUE)
+  on.exit(options(oo))
+
   path <- prepare_orderly_example("minimal")
   p <- path_orderly_archive_version(path)
   unlink(p)
@@ -225,6 +248,9 @@ test_that("database migrations", {
 
 
 test_that("automatic migrations", {
+  oo <- options(orderly.nowarnings = TRUE)
+  on.exit(options(oo))
+
   path <- unpack_reference("0.5.1")
   patch_orderly_config(path)
   con <- orderly_db("destination", path, validate = FALSE)
@@ -239,6 +265,9 @@ test_that("automatic migrations", {
 
 
 test_that("migrate 0.5.4 -> 0.5.5", {
+  oo <- options(orderly.nowarnings = TRUE)
+  on.exit(options(oo))
+
   path <- unpack_reference("0.5.4")
   orderly_migrate(path, to = "0.5.5")
   orderly_rebuild(path)
@@ -254,10 +283,13 @@ test_that("migrate 0.5.4 -> 0.5.5", {
 
 
 test_that("rebuild db with incorrect schema information", {
+  oo <- options(orderly.nowarnings = TRUE)
+  on.exit(options(oo))
+
   path <- unpack_reference("0.5.17")
   patch_orderly_config(path)
   con <- orderly_db("destination", path, validate = FALSE)
-  on.exit(DBI::dbDisconnect(con))
+  on.exit(DBI::dbDisconnect(con), add = TRUE)
 
   DBI::dbExecute(
     con,
@@ -292,6 +324,9 @@ test_that("migrate 0.5.18 -> 0.6.0", {
 
 
 test_that("migrate 0.6.0 -> 0.6.1", {
+  oo <- options(orderly.nowarnings = TRUE)
+  on.exit(options(oo))
+
   path <- unpack_reference("0.6.0")
 
   reports <- subset(orderly_list_archive(path), name == "use_resource")
@@ -307,6 +342,9 @@ test_that("migrate 0.6.0 -> 0.6.1", {
 
 
 test_that("migrate 0.6.1 -> 0.6.2", {
+  oo <- options(orderly.nowarnings = TRUE)
+  on.exit(options(oo))
+
   path <- unpack_reference("0.6.0")
 
   reports <- subset(orderly_list_archive(path), name == "use_resource")
@@ -322,6 +360,9 @@ test_that("migrate 0.6.1 -> 0.6.2", {
 
 
 test_that("migrate 0.6.1 -> 0.6.7", {
+  oo <- options(orderly.nowarnings = TRUE)
+  on.exit(options(oo))
+
   path <- unpack_reference("0.6.0")
 
   reports <- subset(orderly_list_archive(path), name == "changelog")
@@ -335,7 +376,7 @@ test_that("migrate 0.6.1 -> 0.6.7", {
   expect_is(changelog, "data.frame")
   expect_true("id" %in% names(changelog))
   con <- orderly_db("destination", root = path)
-  on.exit(DBI::dbDisconnect(con))
+  on.exit(DBI::dbDisconnect(con), add = TRUE)
 
   cmp <- DBI::dbReadTable(con, "changelog")
   cmp$from_file <- as.logical(cmp$from_file)
@@ -347,6 +388,9 @@ test_that("migrate 0.6.1 -> 0.6.7", {
 
 
 test_that("migrate => 0.6.8", {
+  oo <- options(orderly.nowarnings = TRUE)
+  on.exit(options(oo))
+
   path <- unpack_reference("0.6.0")
 
   con <- orderly_db("destination", path, validate = FALSE)

--- a/tests/testthat/test-recipe-read.R
+++ b/tests/testthat/test-recipe-read.R
@@ -309,7 +309,9 @@ test_that("warn old style db", {
 
   file.rename(file.path(path, "orderly_config.yml.new"),
               file.path(path, "orderly_config.yml"))
-  cfg <- orderly_config(path)
+  expect_warning(
+    cfg <- orderly_config(path),
+    "Please move your database arguments")
 
   expect_warning(
     recipe_read(file.path(path, "src", "example"), cfg),

--- a/tests/testthat/test-z-runner.R
+++ b/tests/testthat/test-z-runner.R
@@ -344,7 +344,8 @@ test_that("prevent git changes", {
     database = list(
       source = list(
         driver = "RSQLite::SQLite",
-        dbname = "dbname: source.sqlite")),
+        args = list(
+          dbname = "dbname: source.sqlite"))),
     remote = list(
       main = list(
         driver = "orderly::orderly_remote_path",

--- a/vignettes/src/orderly.R
+++ b/vignettes/src/orderly.R
@@ -165,20 +165,22 @@ yaml_output(readLines(file.path(path, "orderly_config.yml")))
 ## contains a field `driver` which must declare a DBI-compatible
 ## driver (realistically this is going to be `RSQLite::SQLite` for a
 ## local SQLite database and `RPostgres::Posgres` for accessing a
-## postgres database), and then any arguments to be passed through to
-## `DBI::dbConnect` along with the driver.  For SQLite this is just
-## going to be `dbname` but for postgres this will include `host`,
-## `port`, `user`, `dbname` and `password`.  For example:
+## postgres database), and then a block `args` which contains any
+## arguments to be passed through to `DBI::dbConnect` along with the
+## driver.  For SQLite this is just going to be `dbname` but for
+## postgres this will include `host`, `port`, `user`, `dbname` and
+## `password`.  For example:
 
 ## ```yaml
 ## database:
 ##   source:
 ##     driver: RSQLite::SQLite
-##     host: dbhost
-##     port: 5432
-##     user: myusername
-##     password: s3cret
-##     dbname: mydb
+##     args:
+##       host: dbhost
+##       port: 5432
+##       user: myusername
+##       password: s3cret
+##       dbname: mydb
 ## ```
 
 ## In order to run anything (as below) the working directory must be
@@ -296,11 +298,12 @@ orderly::orderly_new("new", root = path)
 ## database:
 ##   source:
 ##     driver: RPostgres::Postgres
-##     host: localhost
-##     port: 5432
-##     user: myuser
-##     dbname: databasename
-##     password: p4ssw0rd
+##     args:
+##       host: localhost
+##       port: 5432
+##       user: myuser
+##       dbname: databasename
+##       password: p4ssw0rd
 ## ```
 
 ## you might write
@@ -309,11 +312,12 @@ orderly::orderly_new("new", root = path)
 ## database:
 ##   source:
 ##     driver: RPostgres::Postgres
-##     host: $MY_DBHOST
-##     port: $MY_DBPORT
-##     user: $MY_DBUSER
-##     dbname: $MY_DBNAME
-##     password: $MY_PASSWORD
+##     args:
+##       host: $MY_DBHOST
+##       port: $MY_DBPORT
+##       user: $MY_DBUSER
+##       dbname: $MY_DBNAME
+##       password: $MY_PASSWORD
 ## ```
 
 ## environment variables, as used this way **must** begin with a


### PR DESCRIPTION
This PR will harmonise the database configuration with dettl and with the api server configuration by moving the arguments into an explicit block, so that:

```
db:
  driver: pkg::fn
  arg1: value
  arg2: value
```

becomes

```
db:
  driver: pkg::fn
  args:
    arg1: value
    arg2: value
```

This is handled in the same way as the work on database/source, where using the old style is supported for a while, with a warning.

Moving to this layout will allow us to support orderly-level options alongside the drivers in the future (e.g., `cache: false` for preventing caching of database into the `data` directory).

(almost all the lines in the diff here are updating the configurations; there are only a handful of lines of code changed)