### PR TITLE
VIMC-2942: Compute all file hashes before run

### DIFF
--- a/R/recipe_read.R
+++ b/R/recipe_read.R
@@ -47,11 +47,11 @@ recipe_read <- function(path, config, validate = TRUE) {
   if (!is.null(info$packages)) {
     assert_character(info$packages, fieldname("packages"))
   }
+
+  recipe_read_check_sources(info$sources, info$resources, filename, path)
   if (!is.null(info$sources)) {
     assert_character(info$sources, fieldname("sources"))
     assert_file_exists(file.path(path, info$sources))
-    ## TODO: check relative path
-    info$resources <- c(info$resources, info$sources)
   }
   if (!is.null(info$connection)) {
     if (length(config$database) == 0L) {
@@ -224,6 +224,21 @@ recipe_read_check_resources <- function(x, filename, path) {
   ## being used.
   x
 }
+
+
+recipe_read_check_sources <- function(sources, resources, filename, path) {
+  if (is.null(sources)) {
+    return()
+  }
+  assert_character(sources, sprintf("%s:%s", filename, "sources"))
+  assert_file_exists(sources, workdir = path, name = "Source file")
+  err <- intersect(sources, resources)
+  if (length(err)) {
+    stop("Do not list source files (sources) as resources:%s",
+         paste(sprintf("\n  - %s", err), collapse = ""))
+  }
+}
+
 
 recipe_read_check_depends <- function(x, filename, config, validate) {
   ## TODO: this is going to assume that the artefacts are all in place

--- a/R/recipe_read.R
+++ b/R/recipe_read.R
@@ -234,8 +234,9 @@ recipe_read_check_sources <- function(sources, resources, filename, path) {
   assert_file_exists(sources, workdir = path, name = "Source file")
   err <- intersect(sources, resources)
   if (length(err)) {
-    stop("Do not list source files (sources) as resources:%s",
-         paste(sprintf("\n  - %s", err), collapse = ""))
+    stop(sprintf("Do not list source files (sources) as resources:%s",
+                 paste(sprintf("\n  - %s", err), collapse = "")),
+         call. = FALSE)
   }
 }
 

--- a/R/recipe_run.R
+++ b/R/recipe_run.R
@@ -715,8 +715,6 @@ recipe_check_hashes <- function(pre, post, name1, name2) {
                  paste(changed, collapse = ", ")),
          call. = FALSE)
   }
-
-  stop("This should never happen")
 }
 
 

--- a/R/recipe_run.R
+++ b/R/recipe_run.R
@@ -809,7 +809,7 @@ recipe_copy_global <- function(info, config) {
     ## of the copy will strip all leading path fragments (path/to/x
     ## becoming x).
     if (any(is_directory(global_src))) {
-      stop("directory global resources not yet handled")
+      stop("global resources cannot yet be directories")
     }
     orderly_log("global", info$global_resources)
     file_copy(global_src, ".", recursive = TRUE)

--- a/R/recipe_run.R
+++ b/R/recipe_run.R
@@ -284,33 +284,13 @@ recipe_run <- function(info, parameters, envir, config, echo = TRUE) {
   recipe_check_device_stack(prep$n_dev)
   hash_artefacts <- recipe_check_artefacts(info)
 
-  ## TODO: this should go into the preparation (orderly_prepare_data
-  ## or similar)
-  if (file_exists("README.md", check_case = FALSE)) {
-    readme <- dir(pattern = "readme.md", ignore.case = TRUE)
-    info_readme <- file_info(readme)
-  } else {
-    info_readme <- NULL
-  }
-
-  ## and this too...
-  if (is.null(info$sources)) {
-    info_sources <- NULL
-  } else {
-    info_sources <- file_info(info$sources)
-  }
-
-  ## This will move into the prep eventually...
-  info_orderly_yml <- file_info("orderly.yml")
-  info_script <- file_info(info$script)
-
   hash_data_csv <- con_csv$mset(prep$data)
   hash_data_rds <- con_rds$mset(prep$data)
   stopifnot(identical(hash_data_csv, hash_data_rds))
 
-  post_run_resources <- get_resource_info(info)
-  compare_resource_hashes(resource_info$hash_resources,
-                          post_run_resources$hash_resources)
+  ## Ensure that inputs were not modified when the report was run:
+  recipe_check_file_inputs(info)
+  recipe_check_depends(info)
 
   if (is.null(info$depends)) {
     depends <- NULL
@@ -331,29 +311,6 @@ recipe_run <- function(info, parameters, envir, config, echo = TRUE) {
 
   session <- session_info()
   session$git <- info$git
-
-  if (is.null(resource_info$hash_resources)) {
-    info_resources <- NULL
-  } else {
-    ## TODO: fix this upstream and that will help the
-    ## source-as-global problem
-    resources <- setdiff(names(resource_info$hash_resources),
-                         info_sources$filename)
-    info_resources <- file_info(resources)
-  }
-  if (is.null(resource_info$hash_global)) {
-    info_global <- NULL
-  } else {
-    info_global <- file_info(names(resource_info$hash_global))
-  }
-
-  file_info_inputs <- file_in_data(
-    orderly_yml = info_orderly_yml,
-    script = info_script,
-    readme = info_readme,
-    source = info_sources,
-    resource = info_resources,
-    global = info_global)
 
   artefacts <- data_frame(
     format = list_to_character(info$artefacts[, "format"], FALSE),
@@ -376,7 +333,7 @@ recipe_run <- function(info, parameters, envir, config, echo = TRUE) {
                extra_fields = extra_fields,
                connection = !is.null(info$connection),
                packages = info$packages,
-               file_info_inputs = file_info_inputs,
+               file_info_inputs = info$inputs,
                file_info_artefacts = file_info_artefacts,
                artefacts = artefacts,
                depends = depends,
@@ -490,97 +447,22 @@ recipe_prepare_workdir <- function(info, message, config) {
   }
   src <- normalizePath(info$path, mustWork = TRUE)
   dir_create(info$workdir)
-  owd <- setwd(info$workdir)
-  on.exit(setwd(owd))
+  info$owd <- setwd(info$workdir)
+  on.exit(setwd(info$owd))
 
+  ## TODO: this supports a script in a subdirectory, but I don't think
+  ## that is supported yet, and it's not clear it's a desirable thing
   dir.create(dirname(info$script), FALSE, TRUE)
-
   file_copy(file.path(src, info$script), info$script)
   file_copy(file.path(src, "orderly.yml"), "orderly.yml")
 
-  # README logic:
-  # if there's a readme we copy it
-  # if they also list it as a resource let them know that's redundant (edited)
-  # if they also list it as an artefact then error
-  src_files <- dir(src)
-  readme_file <- src_files[tolower(src_files) == "readme.md"]
-  ## Two readme files e.g. README.md and Readme.MD can happen on unix systems
-  ## I t is not clear what we should do here.
-  if (length(readme_file) == 1) {
-    ## we copy the readme.md file to README.md irrespective of what
-    ## case filename the user has used
-    file_copy(file.path(src, readme_file), "README.md")
-    ## now check if README is a resource
-    if (length(info$resources) > 0) {
-      if (any(grepl("README.md", info$resources, ignore.case = FALSE))) {
-        ## WARNING
-        orderly_log("readme",
-                    "README.md should not be listed as a resource")
-      }
-    }
-    ## now check if README is an artefact
-    expected <- unlist(info$artefacts[, "filenames"], use.names = FALSE)
-    if (length(expected) > 0) {
-      if (any(grepl("README.md", expected, ignore.case = FALSE))) {
-        stop("README.md should not be listed as an artefact")
-      }
-    }
-  }
-  
-  if (!is.null(info$resources)) {
-    dir_create(dirname(info$resources))
-    ## There's a bit of awfulness in R's path handling to deal with here.
-    path_resources_src <- file.path(src, info$resources)
-    i <- is_directory(path_resources_src)
-    file_copy(path_resources_src[!i], info$resources[!i])
-    for (j in which(i)) {
-      file_copy(path_resources_src[j], dirname(info$resources[j]),
-                recursive = TRUE)
-    }
-  }
+  info <- recipe_copy_readme(info, src)
+  info <- recipe_copy_resources(info, src)
+  info <- recipe_copy_global(info, config)
+  info <- recipe_copy_depends(info)
 
-  if (!is.null(info$depends)) {
-    dep_src <- file.path(info$depends$path, info$depends$filename)
-    dep_dst <- file.path(info$workdir, info$depends$as)
-    dir_create(dirname(dep_dst))
-    info$depends$id_requested <- info$depends$id
-    info$depends$id <- basename(info$depends$path)
-
-    str <- sprintf("%s@%s:%s -> %s",
-                   info$depends$name,
-                   info$depends$id,
-                   info$depends$filename,
-                   info$depends$as)
-    orderly_log("depends", str)
-    file_copy(dep_src, dep_dst)
-  }
-
-  if (!is.null(info$global_resources)) {
-    root_path <- normalizePath(config$root, mustWork = TRUE)
-    global_resource_dir <- file.path(root_path, config$global_resources)
-    assert_file_exists(x = info$global_resources, check_case = TRUE,
-                       workdir = global_resource_dir,
-                       name = sprintf("Global resources in '%s'",
-                                      global_resource_dir))
-
-    path_global_recs <- file.path(global_resource_dir, info$global_resources)
-    dest_resources_src <- file.path(info$workdir, info$global_resources)
-    file_copy(path_global_recs, info$workdir, recursive = TRUE)
-  }
-
-  ## if we are using resources or global resources...
-  if (!is.null(info$resources) || !is.null(info$global_resources)) {
-    ## ...hash the resources + calculate the file size,
-    ## before we the report has a chance to modify them
-    resource_info <- get_resource_info(info)
-  } else {
-    resource_info <- NULL
-  }
-
+  info$inputs <- recipe_file_inputs(info)
   info$changelog <- changelog_load(src, message, info, config)
-
-  info$owd <- owd
-  info$resource_info <- resource_info
   info
 }
 
@@ -620,6 +502,7 @@ recipe_exists_artefacts <- function(info, id) {
 }
 
 recipe_unexpected_artefacts <- function(info, id) {
+  ## TODO: filter out globals
   # expected artefacts
   expected <- unlist(info$artefacts[, "filenames"], use.names = FALSE)
   # expected resources
@@ -728,48 +611,6 @@ orderly_prepare_data <- function(config, info, parameters, envir) {
   ret
 }
 
-get_resource_info <- function(info) {
-  hash_resources <- hash_files(expand_directory_list(info$resources))
-  if (length(hash_resources) > 0L) {
-    orderly_log("resources",
-                sprintf("%s: %s", names(hash_resources), hash_resources))
-  } else {
-    hash_resources <- NULL
-  }
-
-  hash_global <- hash_files(expand_directory_list(info$global_resources))
-  if (length(hash_global) > 0L) {
-    orderly_log("global",
-                sprintf("%s: %s", names(hash_global), hash_global))
-  } else {
-    hash_global <- NULL
-  }
-  list(hash_resources = hash_resources, hash_global = hash_global)
-}
-
-compare_resource_hashes <- function(pre_run_hashes, post_run_hashes) {
-  ## compare resource hashes here
-  found <- names(post_run_hashes)
-  expected <- names(pre_run_hashes)
-
-  ## we expected a resource but can't find it.
-  not_found <- which(!(expected %in% found))
-  if (any(not_found)) {
-    stop("Script deleted the following resources: ",
-         paste(expected[not_found], collapse = ", "))
-  }
-
-  ## at this point the set of found == the set of expected
-  found_hash <- post_run_hashes[found] ## put the hashes in the same order
-  expected_hash <- pre_run_hashes[found]
-  hash_miss <- which(found_hash != expected_hash)
-  if (any(hash_miss)) {
-    stop("Script has modified resources: ",
-         paste(found[hash_miss], collapse = ", "))
-  }
-}
-
-
 
 recipe_current_run_set <- function(info) {
   cache$current <- info
@@ -819,4 +660,160 @@ orderly_run_info <- function() {
 test_mode_end <- function(env = .GlobalEnv) {
   suppressWarnings(rm(list = "Q", envir = env))
   tryCatch(orderly_test_end(), error = function(e) NULL)
+}
+
+
+recipe_file_inputs <- function(info) {
+  file_in_data(
+    orderly_yml = file_info("orderly.yml"),
+    script = file_info(info$script),
+    readme = file_info(info$readme),
+    source = file_info(info$sources),
+    resource = file_info(info$resources),
+    global = file_info(info$global_resources))
+}
+
+
+recipe_check_file_inputs <- function(info) {
+  pre <- info$inputs
+  post <- recipe_file_inputs(info)
+  recipe_check_hashes(pre, post, "input", "inputs")
+}
+
+
+recipe_check_depends <- function(info) {
+  pre <- info$depends
+  if (!is.null(info$depends)) {
+    pre <- data_frame(filename = info$depends$as,
+                      file_hash = info$depends$hash)
+    post <- file_info(info$depends$as)[c("filename", "file_hash")]
+    recipe_check_hashes(pre, post, "dependency", "dependencies")
+  }
+}
+
+
+recipe_check_hashes <- function(pre, post, name1, name2) {
+  if (identical(pre, post)) {
+    return(NULL)
+  }
+
+  missing <- post$filename[is.na(post$file_hash)]
+  if (length(missing) > 0L) {
+    stop(sprintf("Script deleted %s: %s",
+                 ngettext(length(missing), name1, name2),
+                 paste(missing, collapse = ", ")),
+         call. = FALSE)
+  }
+
+  changed <- pre$filename[!(pre$file_hash %in% post$file_hash)]
+  if (length(changed) > 0L) {
+    stop(sprintf("Script has modified %s: %s",
+                 ngettext(length(changed), name1, name2),
+                 paste(changed, collapse = ", ")),
+         call. = FALSE)
+  }
+
+  stop("This should never happen")
+}
+
+
+recipe_copy_readme <- function(info, src) {
+  ## README logic:
+  ## * if there's a readme we copy it
+  ## * any casing is OK as input, but we always store in canonical case
+  ## * if they also list it as a resource let them know that's redundant
+  ## * if they also list it as an artefact then error
+  src_files <- dir(src)
+  readme_file <- src_files[tolower(src_files) == "readme.md"]
+
+  ## Two readme files e.g. README.md and Readme.MD can happen on unix
+  ## systems; it is not clear what we should do here, so we just
+  ## ignore the readme silently for now.
+  if (length(readme_file) == 1) {
+    ## we copy the readme.md file to README.md irrespective of what
+    ## case filename the user has used
+    file_copy(file.path(src, readme_file), "README.md")
+    info$readme <- "README.md"
+
+    ## now check if README is a resource
+    if (length(info$resources) > 0) {
+      i <- grepl("README.md", info$resources, ignore.case = FALSE)
+      if (any(i)) {
+        ## WARNING
+        orderly_log("readme",
+                    "README.md should not be listed as a resource")
+        info$resources <- info$resources[!i]
+      }
+    }
+
+    ## now check if README is an artefact
+    artefact_files <- unlist(info$artefacts[, "filenames"], use.names = FALSE)
+    if (any(grepl("README.md", artefact_files, ignore.case = TRUE))) {
+      stop("README.md should not be listed as an artefact")
+    }
+  }
+
+  info
+}
+
+
+recipe_copy_resources <- function(info, src) {
+  if (length(info$resources) > 0L) {
+    resources <- info$resources
+    i <- is_directory(file.path(src, resources))
+    if (any(i)) {
+      resources <- as.list(resources)
+      resources[i] <- lapply(resources[i], function(p)
+        file.path(p, dir(file.path(src, p),
+                         recursive = TRUE, all.files = TRUE)))
+      resources <- unlist(resources)
+    }
+
+    dir_create(dirname(resources))
+    orderly_log("resource", resources)
+    file_copy(file.path(src, resources), resources)
+
+    info$resources <- resources
+  }
+  info
+}
+
+
+recipe_copy_global <- function(info, config) {
+  if (!is.null(info$global_resources)) {
+    global_path <- file.path(config$root, config$global_resources)
+
+    assert_file_exists(
+      info$global_resources, check_case = TRUE, workdir = global_path,
+      name = sprintf("Global resources in '%s'", global_path))
+
+    orderly_log("global", info$global_resources)
+    global_src <- file.path(global_path, info$global_resources)
+    dir_create(dirname(info$global_resources))
+    file_copy(global_src, ".", recursive = TRUE)
+
+    if (any(is_directory(info$global_resources))) {
+      stop("directory global resources not yet handled")
+    }
+  }
+  info
+}
+
+recipe_copy_depends <- function(info) {
+  if (!is.null(info$depends)) {
+    dep_src <- file.path(info$depends$path, info$depends$filename)
+    dep_dst <- file.path(info$workdir, info$depends$as)
+    dir_create(dirname(dep_dst))
+    info$depends$id_requested <- info$depends$id
+    info$depends$id <- basename(info$depends$path)
+
+    str <- sprintf("%s@%s:%s -> %s",
+                   info$depends$name,
+                   info$depends$id,
+                   info$depends$filename,
+                   info$depends$as)
+    orderly_log("depends", str)
+    file_copy(dep_src, dep_dst)
+  }
+  info
 }

--- a/R/util.R
+++ b/R/util.R
@@ -168,6 +168,12 @@ file_copy <- function(..., overwrite = TRUE) {
 }
 
 
+file_copy_with_path <- function(src, dest) {
+  dir.create(dirname(dest), FALSE, TRUE)
+  file_copy(src, dest)
+}
+
+
 file_move <- function(from, to) {
   ok <- file.rename(from, to)
   if (any(!ok)) {
@@ -698,6 +704,9 @@ file_size <- function(path) {
 
 
 file_info <- function(path, workdir = NULL) {
+  if (is.null(path)) {
+    return(NULL)
+  }
   if (!is.null(workdir)) {
     return(withr::with_dir(workdir, file_info(path)))
   }

--- a/R/util.R
+++ b/R/util.R
@@ -168,12 +168,6 @@ file_copy <- function(..., overwrite = TRUE) {
 }
 
 
-file_copy_with_path <- function(src, dest) {
-  dir.create(dirname(dest), FALSE, TRUE)
-  file_copy(src, dest)
-}
-
-
 file_move <- function(from, to) {
   ok <- file.rename(from, to)
   if (any(!ok)) {
@@ -527,20 +521,6 @@ copy_directory <- function(src, as, rollback_on_error = FALSE) {
   if (rollback_on_error) {
     on.exit()
   }
-}
-
-expand_directory_list <- function(files) {
-  if (is.null(files)) {
-    return(NULL)
-  }
-  i <- is_directory(files)
-  extra <- unlist(lapply(files[i], list_all_files), use.names = FALSE)
-  union(files[!i], extra)
-}
-
-list_all_files <- function(path) {
-  sort_c(dir(path, recursive = TRUE, full.names = TRUE, all.files = TRUE,
-             no.. = TRUE))
 }
 
 

--- a/R/util.R
+++ b/R/util.R
@@ -138,15 +138,11 @@ dir_create <- function(x) {
 }
 
 hash_files <- function(filenames, named = TRUE) {
-  if (is.null(filenames)) {
-    set_names(character(0), if (named) character(0) else NULL)
-  } else {
-    h <- tools::md5sum(filenames)
-    if (!named) {
-      names(h) <- NULL
-    }
-    h
+  h <- tools::md5sum(filenames)
+  if (!named) {
+    names(h) <- NULL
   }
+  h
 }
 
 hash_object <- function(object) {

--- a/tests/testthat/test-global.R
+++ b/tests/testthat/test-global.R
@@ -45,3 +45,20 @@ test_that("global resources end up in db", {
                hash_files(file.path(path, "global", "data.csv"), FALSE))
   expect_equal(d$filename[i], "data.csv")
 })
+
+
+## We can relax this once VIMC-2961 is resolved
+test_that("directories of global resources are forbidden", {
+  path <- prepare_orderly_example("global")
+  p_global <- file.path(path, "global", "dir")
+  dir.create(p_global)
+
+  p_orderly <- file.path(path, "src", "example", "orderly.yml")
+  d <- yaml_read(p_orderly)
+  d$global_resources <- "dir"
+  yaml_write(d, p_orderly)
+
+  expect_error(
+    orderly_run("example", root = path),
+    "global resources cannot yet be directories")
+})

--- a/tests/testthat/test-readme.R
+++ b/tests/testthat/test-readme.R
@@ -48,12 +48,12 @@ test_that("list README.md as resource",  {
   messages <- capture_messages(
     id <- orderly_run("example", root = path, echo = FALSE))
   # ...make sure none of the messages contain "unexpected"
-  expect_true(any(grep("readme", messages)))
+  expect_true(any(grep("should not be listed as a resource", messages)))
   orderly_commit(id, root = path)
   con <- orderly_db("destination", root = path)
   on.exit(DBI::dbDisconnect(con))
   dat <- DBI::dbReadTable(con, "file_input")
-  expect_equal(sum(dat$filename == "README.md"), 2)
+  expect_equal(sum(dat$filename == "README.md"), 1)
 })
 
 test_that("list README.md as artefact",  {

--- a/tests/testthat/test-recipe-read.R
+++ b/tests/testthat/test-recipe-read.R
@@ -332,3 +332,18 @@ test_that("detect modified artefacts", {
     recipe_read(file.path(path, "src", "use_dependency"), config = cfg),
     "Validation of dependency 'summary.csv' failed: artefact has been modified")
 })
+
+
+test_that("sources and resources are exclusive", {
+  path <- orderly_example("demo")
+
+  p <- file.path(path, "src", "other", "orderly.yml")
+  d <- yaml_read(p)
+  d$resources <- d$sources
+  yaml_write(d, p)
+
+  config <- orderly_config(path)
+  expect_error(
+    recipe_read(file.path(path, "src", "other"), config),
+    "Do not list source files \\(sources\\) as resources:\\s+- functions\\.R")
+})

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -735,3 +735,19 @@ test_that("Can use connections with two databases", {
   p <- orderly_commit(id, root = path)
   expect_true(file.exists(file.path(p, "mygraph.png")))
 })
+
+
+test_that("prevent duplicate filenames", {
+  path <- prepare_orderly_example("depends")
+  id1 <- orderly_run("example", root = path, echo = FALSE)
+
+  p <- file.path(path, "src", "depend", "orderly.yml")
+  d <- yaml_read(p)
+  d$resources <- "previous.rds"
+  yaml_write(d, p)
+  file.create(file.path(path, "src", "depend", "previous.rds"))
+
+  expect_error(
+    orderly_run("depend", root = path, echo = FALSE),
+    "Orderly configuration implies duplicate files:\\s+- previous.rds:")
+})


### PR DESCRIPTION
This PR moves the file hash calculation quite early in the process; it's not at recipe read but I think that's ok because it requires some calculation with directories etc and feels most naturally done when we prepare the new working directory.

This expands the previous "no files changed during run" to cover _all_ files that orderly looks after (somewhat different treatment was required for the dependencies).  The logic with README.md files and how directory listings are computed has been tidied, and I found some undocumented behaviour with globals that I've annotated with  new and existing issues.