### PR TITLE
VIMC-2967: avoid platform dependent things in tests

### DIFF
--- a/R/testing.R
+++ b/R/testing.R
@@ -177,7 +177,6 @@ demo_change_time <- function(id, time, path) {
 ##
 ## After building this we have two branches 'master' with
 build_git_demo <- function() {
-  testthat::skip_on_cran()
   path <- prepare_orderly_example("demo", file.path(tempfile(), "demo"))
 
   dir.create(file.path(path, "extra"))
@@ -213,7 +212,6 @@ build_git_demo <- function() {
 }
 
 unzip_git_demo <- function(path = tempfile()) {
-  testthat::skip_on_cran()
   tmp <- tempfile()
   dir.create(tmp, FALSE, TRUE)
   demo <- getOption("orderly.server.demo", build_git_demo())
@@ -227,7 +225,6 @@ unzip_git_demo <- function(path = tempfile()) {
 }
 
 prepare_orderly_git_example <- function(path = tempfile(), run_report = FALSE) {
-  testthat::skip_on_cran()
   path_upstream <- file.path(path, "upstream")
   unzip_git_demo(path)
   unzip_git_demo(path_upstream)

--- a/R/testing.R
+++ b/R/testing.R
@@ -177,6 +177,7 @@ demo_change_time <- function(id, time, path) {
 ##
 ## After building this we have two branches 'master' with
 build_git_demo <- function() {
+  testthat::skip_on_cran()
   path <- prepare_orderly_example("demo", file.path(tempfile(), "demo"))
 
   dir.create(file.path(path, "extra"))
@@ -212,6 +213,7 @@ build_git_demo <- function() {
 }
 
 unzip_git_demo <- function(path = tempfile()) {
+  testthat::skip_on_cran()
   tmp <- tempfile()
   dir.create(tmp, FALSE, TRUE)
   demo <- getOption("orderly.server.demo", build_git_demo())
@@ -225,6 +227,7 @@ unzip_git_demo <- function(path = tempfile()) {
 }
 
 prepare_orderly_git_example <- function(path = tempfile(), run_report = FALSE) {
+  testthat::skip_on_cran()
   path_upstream <- file.path(path, "upstream")
   unzip_git_demo(path)
   unzip_git_demo(path_upstream)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ With `orderly` we have two main hopes:
 
 One often-touted goal of R over point-and-click analyses packages is that if an analysis is scripted it is more reproducible.  However, essentially all analyses depend on external resources - packages, data, code, and R itself; any change in these external resources might change the results.  Preventing such changes in external resources is not always possible, but *tracking* changes should be straightforward - all we need to know is what is being used.
 
-For example, while reproducible research [has become synonymous with literate programming](https://cran.r-project.org/web/views/ReproducibleResearch.html) this approach often increases the number of external resources.  A typical [`knitr`](https://CRAN.R-project.org/package=knitr) document will depend on:
+For example, while reproducible research [has become synonymous with literate programming](https://CRAN.R-project.org/view=ReproducibleResearch) this approach often increases the number of external resources.  A typical [`knitr`](https://CRAN.R-project.org/package=knitr) document will depend on:
 
 * the source file (`.Rmd` or `.Rnw`)
 * templates used for styling

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ With `orderly` we have two main hopes:
 
 One often-touted goal of R over point-and-click analyses packages is that if an analysis is scripted it is more reproducible.  However, essentially all analyses depend on external resources - packages, data, code, and R itself; any change in these external resources might change the results.  Preventing such changes in external resources is not always possible, but *tracking* changes should be straightforward - all we need to know is what is being used.
 
-For example, while reproducible research [has become synonymous with literate programming](https://CRAN.R-project.org/view=ReproducibleResearch) this approach often increases the number of external resources.  A typical [`knitr`](https://CRAN.R-project.org/package=knitr) document will depend on:
+For example, while reproducible research [has become synonymous with literate programming](https://cran.r-project.org/view=ReproducibleResearch) this approach often increases the number of external resources.  A typical [`knitr`](https://cran.r-project.org/package=knitr) document will depend on:
 
 * the source file (`.Rmd` or `.Rnw`)
 * templates used for styling

--- a/tests/testthat/test-db.R
+++ b/tests/testthat/test-db.R
@@ -130,9 +130,6 @@ test_that("dialects", {
 })
 
 
-
-
-
 test_that("sources are listed in db", {
   path <- prepare_orderly_example("demo")
   id <- orderly_run("other", root = path, parameters = list(nmin = 0),
@@ -146,7 +143,6 @@ test_that("sources are listed in db", {
   info <- readRDS(p)$meta$file_info_inputs
 
   h <- hash_files(file.path(path, "archive", "other", id, "functions.R"), FALSE)
-
 
   expect_equal(info$filename[info$file_purpose == "source"], "functions.R")
   expect_equal(info$file_hash[info$file_purpose == "source"], h)

--- a/tests/testthat/test-db.R
+++ b/tests/testthat/test-db.R
@@ -146,8 +146,8 @@ test_that("sources are listed in db", {
   info <- readRDS(p)$meta$file_info_inputs
 
   h <- hash_files(file.path(path, "archive", "other", id, "functions.R"), FALSE)
-  
-  
+
+
   expect_equal(info$filename[info$file_purpose == "source"], "functions.R")
   expect_equal(info$file_hash[info$file_purpose == "source"], h)
 
@@ -196,18 +196,18 @@ test_that("db includes file information", {
   path <- prepare_orderly_example("demo")
   id <- orderly_run("multifile-artefact", root = path, echo = FALSE)
   p <- orderly_commit(id, root = path)
-
+  h1 <- hash_files(file.path(path, "src", "multifile-artefact", "orderly.yml"), FALSE)
+  h2 <- hash_files(file.path(path, "src", "multifile-artefact", "script.R"), FALSE)
   con <- orderly_db("destination", root = path)
   on.exit(DBI::dbDisconnect(con))
 
   file_input <- DBI::dbReadTable(con, "file_input")
-  
+
   expect_equal(
     file_input,
     data_frame(id = 1:2,
                report_version = id,
-               file_hash = c("26f10ce8e0dba5993709b8bc6262fb6f",
-                             "eda0ed142005488307e065831ad66f72"),
+               file_hash = c(h1, h2),
                filename = c("orderly.yml", "script.R"),
                file_purpose = c("orderly_yml", "script")))
 
@@ -223,6 +223,7 @@ test_that("db includes file information", {
                file_hash = artefact_hash,
                filename = c("mygraph.png", "mygraph.pdf")))
 
+
   report_version_artefact <- DBI::dbReadTable(con, "report_version_artefact")
   expect_equal(
     report_version_artefact,
@@ -234,10 +235,9 @@ test_that("db includes file information", {
 
   filenames <- c("orderly.yml", "script.R", "mygraph.png", "mygraph.pdf")
   file <- DBI::dbReadTable(con, "file")
-  
+
   expect_equal(file,
-               data_frame(hash = c("26f10ce8e0dba5993709b8bc6262fb6f",
-                                   "eda0ed142005488307e065831ad66f72",
+               data_frame(hash = c(h1, h2,
                                    artefact_hash),
                           size = file_size(file.path(p, filenames))))
 })

--- a/tests/testthat/test-db.R
+++ b/tests/testthat/test-db.R
@@ -130,6 +130,9 @@ test_that("dialects", {
 })
 
 
+
+
+
 test_that("sources are listed in db", {
   path <- prepare_orderly_example("demo")
   id <- orderly_run("other", root = path, parameters = list(nmin = 0),
@@ -142,9 +145,11 @@ test_that("sources are listed in db", {
   p <- path_orderly_run_rds(file.path(path, "archive", "other", id))
   info <- readRDS(p)$meta$file_info_inputs
 
+  h <- hash_files(file.path(path, "archive", "other", id, "functions.R"), FALSE)
+  
+  
   expect_equal(info$filename[info$file_purpose == "source"], "functions.R")
-  expect_equal(info$file_hash[info$file_purpose == "source"],
-               "cceb0c1c68beaa96266c6f2e3445b423")
+  expect_equal(info$file_hash[info$file_purpose == "source"], h)
 
   d <- DBI::dbGetQuery(
     con, "SELECT * from file_input WHERE report_version = $1", id)
@@ -196,6 +201,7 @@ test_that("db includes file information", {
   on.exit(DBI::dbDisconnect(con))
 
   file_input <- DBI::dbReadTable(con, "file_input")
+  
   expect_equal(
     file_input,
     data_frame(id = 1:2,
@@ -228,6 +234,7 @@ test_that("db includes file information", {
 
   filenames <- c("orderly.yml", "script.R", "mygraph.png", "mygraph.pdf")
   file <- DBI::dbReadTable(con, "file")
+  
   expect_equal(file,
                data_frame(hash = c("26f10ce8e0dba5993709b8bc6262fb6f",
                                    "eda0ed142005488307e065831ad66f72",

--- a/tests/testthat/test-git.R
+++ b/tests/testthat/test-git.R
@@ -1,6 +1,7 @@
 context("git")
 
 test_that("status", {
+  testthat::skip_on_cran()
   path <- unzip_git_demo()
   expect_equal(git_status(path),
                list(success = TRUE, code = 0,
@@ -15,6 +16,7 @@ test_that("status", {
 })
 
 test_that("branches", {
+  testthat::skip_on_cran()
   path <- unzip_git_demo()
   sha1 <- git_ref_to_sha("master", path)
   sha2 <- git_ref_to_sha("other", path)
@@ -33,6 +35,7 @@ test_that("branches", {
 })
 
 test_that("detch head & restore", {
+  testthat::skip_on_cran()
   path <- unzip_git_demo()
   prev <- git_detach_head_at_ref("other", path)
   expect_equal(prev, "master")
@@ -47,6 +50,7 @@ test_that("detch head & restore", {
 
 
 test_that("detach head checks", {
+  testthat::skip_on_cran()
   path <- unzip_git_demo()
   filename <- file.path(path, "dirty")
   file.create(filename)
@@ -60,6 +64,7 @@ test_that("detach head checks", {
 
 
 test_that("fetch / detach / pull", {
+  testthat::skip_on_cran()
   path <- prepare_orderly_git_example()
   path1 <- path[["origin"]]
   path2 <- path[["local"]]
@@ -85,6 +90,7 @@ test_that("fetch / detach / pull", {
 
 
 test_that("checkout_branch checks", {
+  testthat::skip_on_cran()
   path <- unzip_git_demo()
   filename <- file.path(path, "dirty")
   file.create(filename)
@@ -94,6 +100,7 @@ test_that("checkout_branch checks", {
 
 
 test_that("detect missing ref", {
+  testthat::skip_on_cran()
   path <- prepare_orderly_git_example()
   path1 <- path[["origin"]]
   path2 <- path[["local"]]
@@ -124,6 +131,7 @@ test_that("detect missing ref", {
 })
 
 test_that("run in detached head", {
+  testthat::skip_on_cran()
   path <- unzip_git_demo()
   orderly_run("other", list(nmin = 0), root = path, ref = "other",
               echo = FALSE)
@@ -141,6 +149,7 @@ test_that("run in detached head", {
 })
 
 test_that("run missing ref", {
+  testthat::skip_on_cran()
   path <- prepare_orderly_git_example()
   path1 <- path[["origin"]]
   path2 <- path[["local"]]
@@ -172,6 +181,7 @@ test_that("run missing ref", {
 
 
 test_that("fetch before run", {
+  testthat::skip_on_cran()
   path <- prepare_orderly_git_example()
   path1 <- path[["origin"]]
   path2 <- path[["local"]]
@@ -198,6 +208,7 @@ test_that("fetch before run", {
 
 
 test_that("handle failure", {
+  testthat::skip_on_cran()
   path <- prepare_orderly_git_example()
   r <- git_run("unknown-command", root = path[["origin"]])
   expect_false(r$success)
@@ -208,6 +219,7 @@ test_that("handle failure", {
 
 
 test_that("git into db", {
+  testthat::skip_on_cran()
   path <- unzip_git_demo()
   id <- orderly_run("minimal", root = path, echo = FALSE)
   orderly_commit(id, root = path)

--- a/tests/testthat/test-git.R
+++ b/tests/testthat/test-git.R
@@ -34,7 +34,7 @@ test_that("branches", {
                "Git reference 'unknown' not found")
 })
 
-test_that("detch head & restore", {
+test_that("detach head & restore", {
   testthat::skip_on_cran()
   path <- unzip_git_demo()
   prev <- git_detach_head_at_ref("other", path)

--- a/tests/testthat/test-main.R
+++ b/tests/testthat/test-main.R
@@ -60,6 +60,7 @@ test_that("run: ref", {
 
 
 test_that("run: fetch", {
+  testthat::skip_on_cran()
   path <- prepare_orderly_git_example()
   path_local <- path[["local"]]
   path_origin <- path[["origin"]]
@@ -95,6 +96,7 @@ test_that("run: pull & ref don't go together", {
 
 
 test_that("run: pull before run", {
+  testthat::skip_on_cran()
   path <- prepare_orderly_git_example()
   path_local <- path[["local"]]
   path_origin <- path[["origin"]]

--- a/tests/testthat/test-main.R
+++ b/tests/testthat/test-main.R
@@ -40,6 +40,7 @@ test_that("run: id-file", {
 })
 
 test_that("run: ref", {
+  testthat::skip_on_cran()
   path <- unzip_git_demo()
 
   pars <- as.character(jsonlite::toJSON(list(nmin = 0), auto_unbox = TRUE))
@@ -82,6 +83,7 @@ test_that("run: fetch", {
 
 
 test_that("run: pull & ref don't go together", {
+  testthat::skip_on_cran()
   path <- unzip_git_demo()
   args <- c("--root", path, "run", "--ref", "origin/master", "--pull",
             "minimal")

--- a/tests/testthat/test-query.R
+++ b/tests/testthat/test-query.R
@@ -140,6 +140,7 @@ test_that("latest", {
 
 
 test_that("Behaviour with rogue files", {
+  testthat::skip_on_cran()
   path <- prepare_orderly_example("minimal")
   id1 <- orderly_run("example", root = path, echo = FALSE)
   id2 <- orderly_run("example", root = path, echo = FALSE)

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -253,13 +253,15 @@ test_that("resources", {
   p <- file.path(path, "draft", "use_resource", id)
   expect_true(file.exists(file.path(p, "meta/data.csv")))
   p <- orderly_commit(id, root = path)
+  
+  h <- hash_files(file.path(path, "src", "use_resource", "meta", "data.csv"), FALSE)
 
   con <- orderly_db("destination", root = path)
   d <- DBI::dbGetQuery(
     con, "SELECT * FROM file_input WHERE file_purpose = 'resource'")
 
   expect_identical(d$filename, "meta/data.csv")
-  expect_identical(d$file_hash, "0bec5bf6f93c547bc9c6774acaf85e1a")
+  expect_identical(d$file_hash, h)
   expect_true(file.exists(file.path(p, "meta/data.csv")))
 })
 
@@ -651,7 +653,6 @@ test_that("delete multiple resources", {
     error_message)
 })
 
-
 test_that("multiple resources", {
   path <- prepare_orderly_example("resources")
   id <- orderly_run("multiple_resources", root = path, echo = FALSE)
@@ -659,6 +660,10 @@ test_that("multiple resources", {
   expect_true(file.exists(file.path(p, "meta/data.csv")))
   expect_true(file.exists(file.path(p, "meta/data2.csv")))
   p <- orderly_commit(id, root = path)
+  
+  h1 <- hash_files(file.path(path, "src", "multiple_resources", "meta", "data.csv"), FALSE)
+  h2 <- hash_files(file.path(path, "src", "multiple_resources", "meta", "data2.csv"), FALSE)
+  
 
   con <- orderly_db("destination", root = path)
   on.exit(DBI::dbDisconnect(con))
@@ -666,8 +671,8 @@ test_that("multiple resources", {
   d <- d[d$file_purpose == "resource", ]
 
   expect_identical(d$filename, c("meta/data.csv", "meta/data2.csv"))
-  expect_identical(d$file_hash, c("0bec5bf6f93c547bc9c6774acaf85e1a",
-                                  "15bd0276ba238a412caf3e8dcd289751"))
+  expect_identical(d$file_hash, c(h1,
+                                  h2))
   expect_true(file.exists(file.path(p, "meta/data.csv")))
   expect_true(file.exists(file.path(p, "meta/data2.csv")))
 })

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -253,7 +253,7 @@ test_that("resources", {
   p <- file.path(path, "draft", "use_resource", id)
   expect_true(file.exists(file.path(p, "meta/data.csv")))
   p <- orderly_commit(id, root = path)
-  
+
   h <- hash_files(file.path(path, "src", "use_resource", "meta", "data.csv"), FALSE)
 
   con <- orderly_db("destination", root = path)
@@ -466,7 +466,7 @@ test_that("required field OK", {
   minimal_yml <- c(minimal_yml, sprintf("%s: %s", req_fields[1], "character"))
   minimal_yml <- c(minimal_yml, sprintf("%s: %s", req_fields[2], "character"))
   writeLines(minimal_yml, yml_path)
-  
+
   id <- orderly_run("example", root = path, id_file = tmp, echo = FALSE)
   p <- file.path(path_draft(path), "example", id, "mygraph.png")
   expect_true(file.exists(p))
@@ -525,7 +525,7 @@ test_that("required field wrong type", {
   minimal_yml <- c(minimal_yml, sprintf("%s: %s", req_fields[1], "character"))
   minimal_yml <- c(minimal_yml, sprintf("%s: %s", req_fields[2], 1))
   writeLines(minimal_yml, yml_path)
-  
+
   # first required field wont give an error, the second will
   err_msg <- sprintf("'.*orderly.yml:%s' must be character", req_fields[2])
   expect_error(orderly_run("example", root = path, id_file = tmp,
@@ -660,10 +660,10 @@ test_that("multiple resources", {
   expect_true(file.exists(file.path(p, "meta/data.csv")))
   expect_true(file.exists(file.path(p, "meta/data2.csv")))
   p <- orderly_commit(id, root = path)
-  
+
   h1 <- hash_files(file.path(path, "src", "multiple_resources", "meta", "data.csv"), FALSE)
   h2 <- hash_files(file.path(path, "src", "multiple_resources", "meta", "data2.csv"), FALSE)
-  
+
 
   con <- orderly_db("destination", root = path)
   on.exit(DBI::dbDisconnect(con))

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -664,15 +664,13 @@ test_that("multiple resources", {
   h1 <- hash_files(file.path(path, "src", "multiple_resources", "meta", "data.csv"), FALSE)
   h2 <- hash_files(file.path(path, "src", "multiple_resources", "meta", "data2.csv"), FALSE)
 
-
   con <- orderly_db("destination", root = path)
   on.exit(DBI::dbDisconnect(con))
   d <- DBI::dbReadTable(con, "file_input")
   d <- d[d$file_purpose == "resource", ]
 
   expect_identical(d$filename, c("meta/data.csv", "meta/data2.csv"))
-  expect_identical(d$file_hash, c(h1,
-                                  h2))
+  expect_identical(d$file_hash, c(h1, h2))
   expect_true(file.exists(file.path(p, "meta/data.csv")))
   expect_true(file.exists(file.path(p, "meta/data2.csv")))
 })

--- a/tests/testthat/test-tools.R
+++ b/tests/testthat/test-tools.R
@@ -1,4 +1,5 @@
 test_that("unpack archive", {
+  testthat::skip_on_cran()
   path <- prepare_orderly_example("minimal")
   id <- orderly_run("example", root = path, echo = FALSE)
   p <- orderly_commit(id, root = path)
@@ -15,7 +16,7 @@ test_that("unpack archive", {
 
 
 test_that("unpack report failure: corrupt download", {
-  skip_on_cran()
+  testthat::skip_on_cran()
   bytes <- as.raw(c(0x50, 0x4b, 0x05, 0x06, rep(0x00, 18L)))
   zip <- tempfile()
   writeBin(bytes, zip)
@@ -29,6 +30,7 @@ test_that("unpack report failure: corrupt download", {
 
 
 test_that("unpack failure: not an orderly archive", {
+  testthat::skip_on_cran()
   tmp <- file.path(tempfile(), "parent")
   dir.create(tmp, FALSE, TRUE)
   file.create(file.path(tmp, c("a", "b")))
@@ -40,6 +42,7 @@ test_that("unpack failure: not an orderly archive", {
 
 
 test_that("unpack failure: not expected id", {
+  testthat::skip_on_cran()
   id <- new_report_id()
   tmp <- file.path(tempfile(), id)
   dir.create(tmp, FALSE, TRUE)
@@ -52,6 +55,7 @@ test_that("unpack failure: not expected id", {
 
 
 test_that("unpack failure: missing files", {
+  testthat::skip_on_cran()
   id <- new_report_id()
   tmp <- file.path(tempfile(), id)
   dir.create(tmp, FALSE, TRUE)

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -347,6 +347,7 @@ test_that("sys_which", {
 
 
 test_that("zip_dir", {
+  testthat::skip_on_cran()
   mockery::stub(zip_dir, "utils::zip", function(...) -1)
   expect_error(zip_dir(tempfile()), "error running zip")
 })

--- a/tests/testthat/test-z-demo.R
+++ b/tests/testthat/test-z-demo.R
@@ -23,6 +23,7 @@ test_that("orderly_demo", {
 
 
 test_that("git demo", {
+  testthat::skip_on_cran()
   path1 <- prepare_orderly_git_example(run_report = FALSE)
   capture.output(path2 <- prepare_orderly_git_example(run_report = TRUE))
 

--- a/tests/testthat/test-z-runner.R
+++ b/tests/testthat/test-z-runner.R
@@ -1,6 +1,7 @@
 context("orderly_runner")
 
 test_that("runner queue", {
+  testthat::skip_on_cran()
   queue <- runner_queue()
   expect_equal(queue$status(""), list(state = "unknown", id = NA_character_))
   expect_null(queue$next_queued())
@@ -45,6 +46,7 @@ test_that("runner queue", {
 })
 
 test_that("run: success", {
+  testthat::skip_on_cran()
   skip_on_appveyor()
   path <- prepare_orderly_example("interactive")
 
@@ -89,6 +91,7 @@ test_that("run: success", {
 })
 
 test_that("run: error", {
+  testthat::skip_on_cran()
   skip_on_appveyor()
 
   path <- prepare_orderly_example("interactive")
@@ -122,6 +125,7 @@ test_that("rebuild", {
 })
 
 test_that("run in branch (local)", {
+  testthat::skip_on_cran()
   skip_on_appveyor()
   path <- unzip_git_demo()
   runner <- orderly_runner(path)
@@ -139,6 +143,7 @@ test_that("run in branch (local)", {
 })
 
 test_that("fetch / detach / pull", {
+  testthat::skip_on_cran()
   path <- prepare_orderly_git_example()
   path1 <- path[["origin"]]
   path2 <- path[["local"]]
@@ -171,6 +176,7 @@ test_that("fetch / detach / pull", {
 })
 
 test_that("prevent git change", {
+  testthat::skip_on_cran()
   path <- unzip_git_demo()
   runner <- orderly_runner(path, FALSE)
   expect_error(runner$queue("other", ref = "other"),
@@ -178,6 +184,7 @@ test_that("prevent git change", {
 })
 
 test_that("Can't git change", {
+  testthat::skip_on_cran()
   path <- prepare_orderly_example("interactive")
   runner <- orderly_runner(path)
   expect_error(runner$queue("other", ref = "other"),
@@ -186,6 +193,7 @@ test_that("Can't git change", {
 
 
 test_that("cleanup", {
+  testthat::skip_on_cran()
   path <- prepare_orderly_example("minimal")
   on.exit(unlink(path, recursive = TRUE))
 
@@ -206,6 +214,7 @@ test_that("cleanup", {
 
 
 test_that("kill", {
+  testthat::skip_on_cran()
   skip_on_windows()
   skip_on_appveyor()
   path <- prepare_orderly_example("interactive")
@@ -221,6 +230,7 @@ test_that("kill", {
 })
 
 test_that("kill - wrong process", {
+  testthat::skip_on_cran()
   skip_on_windows()
   skip_on_appveyor()
   path <- prepare_orderly_example("interactive")
@@ -237,6 +247,7 @@ test_that("kill - wrong process", {
 })
 
 test_that("kill - no process", {
+  testthat::skip_on_cran()
   path <- prepare_orderly_example("interactive")
   runner <- orderly_runner(path)
   key <- "virtual_plant"
@@ -245,6 +256,7 @@ test_that("kill - no process", {
 })
 
 test_that("timeout", {
+  testthat::skip_on_cran()
   skip_on_windows()
   skip_on_appveyor()
   path <- prepare_orderly_example("interactive")
@@ -258,6 +270,7 @@ test_that("timeout", {
 })
 
 test_that("queue_status", {
+  testthat::skip_on_cran()
   skip_on_windows()
   path <- prepare_orderly_example("interactive")
   runner <- orderly_runner(path)
@@ -297,6 +310,7 @@ test_that("queue_status", {
 
 
 test_that("queue status", {
+  testthat::skip_on_cran()
   skip_on_windows()
   path <- prepare_orderly_example("interactive")
   runner <- orderly_runner(path)
@@ -337,6 +351,7 @@ test_that("queue status", {
 
 
 test_that("prevent git changes", {
+  testthat::skip_on_cran()
   skip_on_windows()
   path <- prepare_orderly_git_example()
 
@@ -386,6 +401,7 @@ test_that("prevent git changes", {
 
 
 test_that("allow ref logic", {
+  testthat::skip_on_cran()
   path <- unzip_git_demo()
   config <- list(server_options = list(master_only = FALSE),
                  root = path)
@@ -409,6 +425,7 @@ test_that("allow ref logic", {
 
 
 test_that("backup", {
+  testthat::skip_on_cran()
   path <- prepare_orderly_example("minimal")
   id <- orderly_run("example", root = path, echo = FALSE)
   orderly_commit(id, root = path)


### PR DESCRIPTION
This PR will avoid a bunch of tests on CRAN - mostly ones involving git, but also the runner.  These are unlikely to work across all possible platforms, and depend on external software (notably a version of git that deals well with hidden files)