### PR TITLE
VIMC-2969: Update R in the orderly container, unpinning MRAN

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,6 +7,8 @@ RUN apt-get update && apt-get -y install \
   sqlite3 \
   wget
 
+RUN sed  -i'' '/mran.microsoft.com/d' /usr/local/lib/R/etc/Rprofile.site
+
 # R package dependencies, including a few extras that we'll want handy
 RUN install2.r \
   DBI \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocker/r-ver:3.5.0
+FROM rocker/r-ver:3.5.3
 
 RUN apt-get update && apt-get -y install \
   git \


### PR DESCRIPTION
This PR will update the version of R used from 3.5.0 to 3.5.3

At the same time, it will unpin the MRAN "snapshot" repository that is used, instead using CRAN.  This will stop some annoying issues with not being able to install packages that were not on CRAN when this version of R was released