### PR TITLE
VIMC-2992: Fix slack payload

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 0.7.4
+Version: 0.7.5
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# 0.7.5
+
+* Fixes notifications to slack on report completion (VIMC-2992).
+
 # 0.7.4
 
 * The database configuration in `orderly_config.yml` now has an "args" section, rather than guessing arguments.  Old configurations are valid, with a warning to update (VIMC-1986).

--- a/R/slack.R
+++ b/R/slack.R
@@ -12,26 +12,27 @@ slack_post_success <- function(dat, config) {
 
 
 slack_data <- function(dat, remote_name, remote_url, remote_is_primary) {
-  elapsed <- format(as.difftime(dat$elapsed, units = "secs"), digits = 2)
-  if (is.null(dat$git)) {
-    git <- NULL
-  } else {
-    branch <- dat$git$branch %||% "(detached)"
-    sha <- dat$git$sha_short
-    if (!is.null(dat$git$github_url)) {
-      sha <- sprintf("<%s/tree/%s|%s>", dat$git$github_url, sha, sha)
+  id <- dat$meta$id
+  name <- dat$meta$name
+  elapsed <- format(as.difftime(dat$meta$elapsed, units = "secs"), digits = 2)
+  git <- dat$git
+
+  if (!is.null(git)) {
+    branch <- git$branch %||% "(detached)"
+    sha <- git$sha_short
+    if (!is.null(git$github_url)) {
+      sha <- sprintf("<%s/tree/%s|%s>", git$github_url, sha, sha)
     }
-    if (!is.null(dat$git$github_url) && !is.null(dat$git$branch)) {
-      branch <- sprintf("<%s/tree/%s|%s>", dat$git$github_url, branch, branch)
+    if (!is.null(git$github_url) && !is.null(git$branch)) {
+      branch <- sprintf("<%s/tree/%s|%s>", git$github_url, branch, branch)
     }
     git <- sprintf("%s@%s", branch, sha)
   }
-  id <- dat$id
 
-  report_url <- sprintf("%s/reports/%s/%s/", remote_url, dat$name, id)
-  title <- sprintf("Ran report '%s'", dat$name)
+  report_url <- sprintf("%s/reports/%s/%s/", remote_url, name, id)
+  title <- sprintf("Ran report '%s'", name)
   text <- sprintf("on server *%s* in %s", remote_name, elapsed)
-  fallback <- sprintf("Ran '%s' as '%s'; view at %s", dat$name, id, report_url)
+  fallback <- sprintf("Ran '%s' as '%s'; view at %s", name, id, report_url)
   ## NOTE: 'warning' is actually quite a nice yellow colour
   col <- if (remote_is_primary) "good" else "warning"
 

--- a/tests/testthat/test-slack.R
+++ b/tests/testthat/test-slack.R
@@ -4,13 +4,14 @@ test_that("slack payload is correct", {
   server_url <- "https://example.com"
   server_is_primary <- FALSE
   server_name <- "myserver"
-  dat <- list(elapsed = 10,
-              git = NULL,
-              id = "20181213-123456-fedcba98",
-              name = "example")
+  dat <- list(meta = list(elapsed = 10,
+                          id = "20181213-123456-fedcba98",
+                          name = "example"),
+              git = NULL)
   d <- slack_data(dat, server_name, server_url, server_is_primary)
 
-  report_url <- sprintf("%s/reports/%s/%s/", server_url, dat$name, dat$id)
+  report_url <- sprintf("%s/reports/%s/%s/", server_url,
+                        dat$meta$name, dat$meta$id)
   expect_equal(
     d,
     list(
@@ -21,9 +22,9 @@ test_that("slack payload is correct", {
         text = "on server *myserver* in 10 secs",
         color = "warning",
         fallback = sprintf("Ran '%s' as '%s'; view at %s",
-                           dat$name, dat$id, report_url),
+                           dat$meta$name, dat$meta$id, report_url),
         fields = list(list(
-          title = "id", value = sprintf("`%s`", dat$id), short = TRUE)),
+          title = "id", value = sprintf("`%s`", dat$meta$id), short = TRUE)),
         actions = list(list(
           name = "link", type = "button", text = ":clipboard: View report",
           style = "primary", url = report_url))))))
@@ -46,28 +47,28 @@ test_that("git information is collected correctly", {
   server_url <- "https://example.com"
   server_is_primary <- FALSE
   server_name <- "myserver"
-  dat <- list(elapsed = 10,
-              git = NULL,
-              id = "20181213-123456-fedcba98",
-              name = "example")
+  dat <- list(meta = list(elapsed = 10,
+                          id = "20181213-123456-fedcba98",
+                          name = "example"),
+              git = NULL)
   d <- slack_data(dat, server_name, server_url, server_is_primary)
 
   expect_equal(length(d$attachments[[1]]$fields), 1L)
 
-  dat <- list(elapsed = 10,
-              git = list(branch = "master", sha_short = "abcdefg"),
-              id = "20181213-123456-fedcba98",
-              name = "example")
+  dat <- list(meta = list(elapsed = 10,
+                          id = "20181213-123456-fedcba98",
+                          name = "example"),
+              git = list(branch = "master", sha_short = "abcdefg"))
   d <- slack_data(dat, server_name, server_url, server_is_primary)
   expect_equal(length(d$attachments[[1]]$fields), 2L)
   expect_equal(d$attachments[[1]]$fields[[2L]],
                list(title = "git", value = "master@abcdefg", short = TRUE))
 
-  dat <- list(elapsed = 10,
+  dat <- list(meta = list(elapsed = 10,
+                          id = "20181213-123456-fedcba98",
+                          name = "example"),
               git = list(branch = "master", sha_short = "abcdefg",
-                         github_url = "https://github.com/vimc/repo"),
-              id = "20181213-123456-fedcba98",
-              name = "example")
+                         github_url = "https://github.com/vimc/repo"))
   d <- slack_data(dat, server_name, server_url, server_is_primary)
   expect_equal(
     d$attachments[[1]]$fields[[2]]$value,
@@ -81,11 +82,11 @@ test_that("git information works in detached head mode", {
   server_is_primary <- FALSE
   server_name <- "myserver"
 
-  dat <- list(elapsed = 10,
+  dat <- list(meta = list(elapsed = 10,
+                          id = "20181213-123456-fedcba98",
+                          name = "example"),
               git = list(branch = NULL, sha_short = "abcdefg",
-                         github_url = "https://github.com/vimc/repo"),
-              id = "20181213-123456-fedcba98",
-              name = "example")
+                         github_url = "https://github.com/vimc/repo"))
   d <- slack_data(dat, server_name, server_url, server_is_primary)
   expect_equal(
     d$attachments[[1]]$fields[[2]]$value,
@@ -97,10 +98,10 @@ test_that("primary server changes colour", {
   server_url <- "https://example.com"
   server_is_primary <- FALSE
   server_name <- "myserver"
-  dat <- list(elapsed = 10,
-              git = NULL,
-              id = "20181213-123456-fedcba98",
-              name = "example")
+  dat <- list(meta = list(elapsed = 10,
+                          id = "20181213-123456-fedcba98",
+                          name = "example"),
+              git = NULL)
   d1 <- slack_data(dat, server_name, server_url, TRUE)
   d2 <- slack_data(dat, server_name, server_url, FALSE)
   expect_equal(d1$attachments[[1]]$color, "good")
@@ -116,10 +117,10 @@ test_that("sending messages is not a failure", {
   server_url <- "https://example.com"
   server_is_primary <- FALSE
   server_name <- "myserver"
-  dat <- list(elapsed = 10,
-              git = NULL,
-              id = "20181213-123456-fedcba98",
-              name = "example")
+  dat <- list(meta = list(elapsed = 10,
+                          id = "20181213-123456-fedcba98",
+                          name = "example"),
+              git = NULL)
   d <- slack_data(dat, server_name, server_url, server_is_primary)
 
   slack_url <- "https://httpbin.org/status/403"
@@ -130,10 +131,10 @@ test_that("sending messages is not a failure", {
 
 test_that("main interface", {
   skip_if_no_internet()
-  dat <- list(elapsed = 10,
-              git = NULL,
-              id = "20181213-123456-fedcba98",
-              name = "example")
+  dat <- list(meta = list(elapsed = 10,
+                          id = "20181213-123456-fedcba98",
+                          name = "example"),
+              git = NULL)
   config <- list(remote_identity = "myserver",
                  remote = list(
                    myserver = list(
@@ -167,10 +168,10 @@ test_that("main interface", {
     "    primary: true"),
     file.path(path, "orderly_config.yml"))
 
-  dat <- list(elapsed = 10,
-              git = NULL,
-              id = "20181213-123456-fedcba98",
-              name = "example")
+  dat <- list(meta = list(elapsed = 10,
+                          id = "20181213-123456-fedcba98",
+                          name = "example"),
+              git = NULL)
 
   config <- withr::with_envvar(
     c("ORDERLY_API_SERVER_IDENTITY" = "production"),

--- a/tests/testthat/test-slack.R
+++ b/tests/testthat/test-slack.R
@@ -209,7 +209,7 @@ test_that("exit on no httr", {
 ## underlying data changes again, while the above tests with mock data
 ## will continue to work.
 test_that("slack payload is correct given actual run data", {
-  path <- prepare_orderly_git_example()[["origin"]]
+  path <- prepare_orderly_git_example()
   path1 <- path[["origin"]]
   id <- orderly_run("minimal", root = path1, echo = FALSE)
   p <- file.path(path1, "draft", "minimal", id)


### PR DESCRIPTION
This PR will fix a bug that crept in during the metadata rework.

The data used in constructing the slack message changed slightly and this broke the slack notification.  That leads to confusing error messages after a successful report run using orderly web.

Code changes here are minimal, the tests are updated and then a new integration test has been added to prevent future regressions