### PR TITLE
VIMC-2855: add pulled reports into DB

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 0.7.6
+Version: 0.7.7
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,10 @@
 
 * Fixes notifications to slack on report completion (VIMC-2992).
 
+# 0.7.4
+
+* The database configuration in `orderly_config.yml` now has an "args" section, rather than guessing arguments.  Old configurations are valid, with a warning to update (VIMC-1986).
+
 # 0.7.3
 
 * Function `orderly_unzip_archive` / `unzip_archive` has been removed in preparation for release.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# 0.7.7
+
+* Pulling from remotes now imports the report into the local orderly db, and also pulls all dependent reports (VIMC-2855).
+
 # 0.7.6
 
 * Detection of modified dependencies has been improved (VIMC-2997).
@@ -5,10 +9,6 @@
 # 0.7.5
 
 * Fixes notifications to slack on report completion (VIMC-2992).
-
-# 0.7.4
-
-* The database configuration in `orderly_config.yml` now has an "args" section, rather than guessing arguments.  Old configurations are valid, with a warning to update (VIMC-1986).
 
 # 0.7.3
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # 0.7.7
 
-* Pulling from remotes now imports the report into the local orderly db, and also pulls all dependent reports (VIMC-2855).
+* Pulling from remotes now imports the report into the local orderly db, and also pulls all dependent reports (VIMC-2855, VIMC-3054).
 
 # 0.7.6
 

--- a/R/db.R
+++ b/R/db.R
@@ -141,7 +141,7 @@ orderly_rebuild <- function(root = NULL, locate = TRUE, verbose = TRUE,
 
   config <- orderly_config_get(root, locate)
 
-  if (length(migrate_plan(config$root, to = NULL)) > 0L) {
+  if (length(migrate_plan(config$archive_version, to = NULL)) > 0L) {
     orderly_log("migrate", "archive")
     orderly_migrate(config, locate = FALSE)
     ## This should trigger a rebuild, regardless of what anything else thinks

--- a/R/db2.R
+++ b/R/db2.R
@@ -191,6 +191,16 @@ report_db_open_existing <- function(con, config) {
 }
 
 
+report_db_import <- function(name, id, config) {
+  orderly_log("import", sprintf("%s:%s", name, id))
+  con <- orderly_db("destination", config)
+  on.exit(DBI::dbDisconnect(con))
+  DBI::dbBegin(con)
+  report_data_import(con, name, id, config)
+  DBI::dbCommit(con)
+}
+
+
 report_db_rebuild <- function(config, verbose = TRUE) {
   assert_is(config, "orderly_config")
   root <- config$root
@@ -204,10 +214,12 @@ report_db_rebuild <- function(config, verbose = TRUE) {
   reports <- unlist(lapply(list_dirs(path_archive(root)), list_dirs))
   if (length(reports) > 0L) {
     for (p in reports[order(basename(reports))]) {
+      id <- basename(p)
+      name <- basename(dirname(p))
       if (verbose) {
-        message(sprintf("%s (%s)", basename(p), basename(dirname(p))))
+        message(sprintf("%s (%s)", id, name))
       }
-      report_data_import(con, p, config)
+      report_data_import(con, name, id, config)
     }
   }
 
@@ -224,16 +236,18 @@ report_db_needs_rebuild <- function(config) {
 }
 
 
-report_data_import <- function(con, workdir, config) {
+report_data_import <- function(con, name, id, config) {
+  workdir <- file.path(config$root, "archive", name, id)
   dat_rds <- readRDS(path_orderly_run_rds(workdir))
 
-  ## Was not done before 0.3.3
-  stopifnot(!is.null(dat_rds$meta))
-  ## Was not done before 0.5.5
-  stopifnot(!is.null(dat_rds$meta$connection))
+  archive_version <- read_orderly_archive_version(config$root)
+  stopifnot(!is.null(dat_rds$archive_version))
+  if (dat_rds$archive_version < archive_version) {
+    stop("Report needs migrating")
+  } else if (dat_rds$archive_version > archive_version) {
+    stop("Report was created with orderly more recent than this, upgrade!")
+  }
 
-  id <- dat_rds$meta$id
-  name <- dat_rds$meta$name
 
   sql_name <- "SELECT name FROM report WHERE name = $1"
   if (nrow(DBI::dbGetQuery(con, sql_name, name)) == 0L) {

--- a/R/db2.R
+++ b/R/db2.R
@@ -246,11 +246,6 @@ report_data_import <- function(con, name, id, config) {
   } else {
     sql <- "SELECT id FROM report_version WHERE report = $1"
     prev <- max(DBI::dbGetQuery(con, sql, name)$id)
-    if (id < prev) {
-      stop(sprintf(
-        "Report id '%s' is behind existing id '%s'", id, prev),
-        call. = FALSE)
-    }
   }
 
   if (is.null(dat_rds$git$sha)) {

--- a/R/db2.R
+++ b/R/db2.R
@@ -240,15 +240,6 @@ report_data_import <- function(con, name, id, config) {
   workdir <- file.path(config$root, "archive", name, id)
   dat_rds <- readRDS(path_orderly_run_rds(workdir))
 
-  archive_version <- read_orderly_archive_version(config$root)
-  stopifnot(!is.null(dat_rds$archive_version))
-  if (dat_rds$archive_version < archive_version) {
-    stop("Report needs migrating")
-  } else if (dat_rds$archive_version > archive_version) {
-    stop("Report was created with orderly more recent than this, upgrade!")
-  }
-
-
   sql_name <- "SELECT name FROM report WHERE name = $1"
   if (nrow(DBI::dbGetQuery(con, sql_name, name)) == 0L) {
     DBI::dbWriteTable(con, "report", data_frame(name = name), append = TRUE)

--- a/R/migrate.R
+++ b/R/migrate.R
@@ -46,7 +46,7 @@ orderly_migrate <- function(root = NULL, locate = TRUE, to = NULL,
   config <- orderly_config_get(root, locate)
   root <- config$root
 
-  migrations <- migrate_plan(root, to)
+  migrations <- migrate_plan(config$archive_version, to)
 
   for (v in names(migrations)) {
     f <- source_to_function(migrations[[v]], "migrate", topenv())
@@ -55,15 +55,14 @@ orderly_migrate <- function(root = NULL, locate = TRUE, to = NULL,
 }
 
 
-migrate_plan <- function(root, to = NULL) {
-  current <- read_orderly_archive_version(root)
+migrate_plan <- function(from, to = NULL) {
   avail <- available_migrations()
 
   if (is.null(to)) {
     to <- names(avail)[[length(avail)]]
   }
 
-  apply <- numeric_version(current) < numeric_version(names(avail)) &
+  apply <- numeric_version(from) < numeric_version(names(avail)) &
     numeric_version(to) >= numeric_version(names(avail))
   avail[apply]
 }
@@ -80,18 +79,13 @@ migrate_apply <- function(root, version, fun, config, dry_run, skip_failed) {
   orderly_log("migrate", sprintf("'%s' => '%s'", previous, version))
   withCallingHandlers({
     for (p in reports) {
-      name <- basename(dirname(p))
-      id <- basename(p)
-      nm <- file.path(name, id)
-      status <- migrate_apply1(p, version, fun, config, dry_run, skip_failed)
-      orderly_log(status, nm)
+      migrate_apply1(p, version, fun, config, dry_run, skip_failed)
     }
     if (!dry_run) {
       write_orderly_archive_version(version, root)
     }
   },
   error = function(e) {
-    migrate_fail_message(name, id, e)
     if (!dry_run) {
       migrate_rollback(root, version, previous)
     }
@@ -114,18 +108,27 @@ migrate_apply1 <- function(root, version, fun, config, dry_run, skip_failed) {
 
   file_orig <- path_orderly_run_rds(root)
   dat <- readRDS(file_orig)
+  name <- dat$meta$name
+  id <- dat$meta$id
+
   version_previous <- get_version(dat$archive_version)
   if (version_previous < version) {
-    res <- fun(dat, root, config)
-    res$data$archive_version <- numeric_version(version)
-    if (!dry_run) {
-      file_copy(file_orig, file)
-      saveRDS(res$data, file_orig)
-    }
-    if (res$changed) "updated" else "ok"
+    withCallingHandlers({
+      res <- fun(dat, root, config)
+      res$data$archive_version <- numeric_version(version)
+      if (!dry_run) {
+        file_copy(file_orig, file)
+        saveRDS(res$data, file_orig)
+      }
+      changed <- res$changed
+    }, error = function(e) {
+      migrate_fail_message(name, id, e)
+    })
   } else {
-    "ok"
+    changed <- FALSE
   }
+  status <- if (changed) "updated" else "ok"
+  orderly_log(status, sprintf("%s/%s", name, id))
 }
 
 
@@ -212,5 +215,31 @@ check_orderly_archive_version <- function(config) {
                  as.character(used), as.character(curr)),
          "Run orderly::orderly_migrate() to fix",
          call. = FALSE)
+  }
+}
+
+
+migrate_single <- function(path, config) {
+  assert_is(config, "orderly_config")
+  dat_rds <- readRDS(path_orderly_run_rds(path))
+
+  report_archive_version <- dat_rds$archive_version
+  archive_version <- config$archive_version
+
+  if (report_archive_version > archive_version) {
+    ## TODO: better message here
+    stop("Report was created with orderly more recent than this, upgrade!")
+  } else if (report_archive_version == archive_version) {
+    return()
+  }
+
+  migrations <- migrate_plan(report_archive_version, archive_version)
+
+  for (v in names(migrations)) {
+    fun <- source_to_function(migrations[[v]], "migrate", topenv())
+    orderly_log("migrate", sprintf("'%s' => '%s'", report_archive_version, v))
+    migrate_apply1(path, v, fun, config,
+                   dry_run = FALSE, skip_failed = FALSE)
+    report_archive_version <- v
   }
 }

--- a/R/migrate.R
+++ b/R/migrate.R
@@ -207,15 +207,18 @@ check_orderly_archive_version <- function(config) {
   used <- numeric_version(config$archive_version)
   curr <- cache$current_archive_version
   if (used == "0.0.0" && nrow(orderly_list_archive(config)) == 0L) {
+    orderly_log("info",
+                sprintf("Writing initial orderly archive version as %s", curr))
     write_orderly_archive_version(curr, config$root)
     used <- curr
-  }
-  if (used < curr) {
+    config$archive_version <- curr
+  } else if (used < curr) {
     stop(sprintf("orderly archive needs migrating from %s => %s\n",
                  as.character(used), as.character(curr)),
          "Run orderly::orderly_migrate() to fix",
          call. = FALSE)
   }
+  config
 }
 
 

--- a/R/recipe_commit.R
+++ b/R/recipe_commit.R
@@ -22,7 +22,7 @@
 ##' orderly::orderly_list_archive(root = path)
 orderly_commit <- function(id, name = NULL, root = NULL, locate = TRUE) {
   config <- orderly_config_get(root, locate)
-  check_orderly_archive_version(config)
+  config <- check_orderly_archive_version(config)
   if (is.null(name)) {
     name <- orderly_find_name(id, config, draft = TRUE, must_work = TRUE)
   } else {

--- a/R/recipe_commit.R
+++ b/R/recipe_commit.R
@@ -60,14 +60,9 @@ recipe_commit <- function(workdir, config) {
   ## Copy the _files_ over, but we'll roll this back if anything fails
   dest <- copy_report(workdir, name, config)
 
-  DBI::dbBegin(con)
   withCallingHandlers(
-    report_data_import(con, workdir, config),
-    error = function(e) {
-      unlink(dest, recursive = TRUE)
-      tryCatch(DBI::dbRollback(con), error = function(e) NULL)
-    })
-  DBI::dbCommit(con)
+    report_db_import(name, id, config),
+    error = function(e) unlink(dest, TRUE))
 
   ## After success we can delete the draft directory
   unlink(workdir, recursive = TRUE)

--- a/R/recipe_run.R
+++ b/R/recipe_run.R
@@ -72,7 +72,7 @@ orderly_run <- function(name, parameters = NULL, envir = NULL,
                         message = NULL) {
   envir <- orderly_environment(envir)
   config <- orderly_config_get(root, locate)
-  check_orderly_archive_version(config)
+  config <- check_orderly_archive_version(config)
 
   info <- recipe_prepare(config, name, id_file, ref, fetch, message)
   on.exit(recipe_current_run_clear())

--- a/R/remote.R
+++ b/R/remote.R
@@ -74,6 +74,7 @@ orderly_pull_dependencies <- function(name, root = NULL, locate = TRUE,
 orderly_pull_archive <- function(name, id = "latest", root = NULL,
                                  locate = TRUE, remote = NULL) {
   config <- orderly_config_get(root, locate)
+  config <- check_orderly_archive_version(config)
   remote <- get_remote(remote, config)
 
   v <- remote_report_versions(name, config, FALSE, remote)

--- a/R/remote.R
+++ b/R/remote.R
@@ -10,6 +10,17 @@
 ##' \code{orderly_pull_archive("reportname")} to pull a copy of
 ##' \code{"reportname"} that has been run on the remote server.
 ##'
+##' Pulling an archive report from a remote also pulls its
+##' dependencies (recursively), and adds all of these to the local
+##' database.  This may require migrating old orderly archives
+##' (\code{\link{orderly_migrate}}).  Note that this migration will
+##' likely fail for remote orderly versions older than 0.6.8 because
+##' the migration needs to read data files on disk that are not
+##' included in the downloaded archive in order to collect all the
+##' information required for the database.  In this case, ask the
+##' administrator of the remote orderly archive to migrate their
+##' archive, and then re-pull.
+##'
 ##' @title Download dependent reports
 ##'
 ##' @param name Name of the report to download dependencies for

--- a/R/remote.R
+++ b/R/remote.R
@@ -89,13 +89,25 @@ orderly_pull_archive <- function(name, id = "latest", root = NULL,
     orderly_log("pull", sprintf("%s already exists, skipping", label))
   } else {
     orderly_log("pull", label)
-    ## TODO (VIMC-2953): it would be might to have the remote pull
-    ## into a temporary directory and handle the copy ourselves for
-    ## easier rollback and less logic.
     path <- file.path(config$root, "archive", name, id)
     withCallingHandlers({
+      ## TODO (VIMC-2953): it would be might to have the remote pull
+      ## into a temporary directory and handle the copy ourselves for
+      ## easier rollback and less logic
       remote$pull(name, id, config$root)
+
+      ## There's an assumption here that the depenency resolution here
+      ## will not be badly affected by migrations.  If a migration
+      ## changes how d$meta$depends is structured (if d$meta$depends
+      ## stops being a data.frame that includes name and id as
+      ## columns) then we'll need to deal with that when checking
+      ## dependencies too.
       orderly_pull_resolve_dependencies(path, remote, config)
+
+      ## Only migrate after dependencies have been resolved because
+      ## some migrations do check dependencies.
+      migrate_single(path, config)
+
       report_db_import(name, id, config)
     }, error = function(e) unlink(path, recursive = TRUE))
   }

--- a/man/orderly_pull_dependencies.Rd
+++ b/man/orderly_pull_dependencies.Rd
@@ -48,6 +48,17 @@ After setting your username up you can run
 \code{"reportname"} can be run, or you can run
 \code{orderly_pull_archive("reportname")} to pull a copy of
 \code{"reportname"} that has been run on the remote server.
+
+Pulling an archive report from a remote also pulls its
+dependencies (recursively), and adds all of these to the local
+database.  This may require migrating old orderly archives
+(\code{\link{orderly_migrate}}).  Note that this migration will
+likely fail for remote orderly versions older than 0.6.8 because
+the migration needs to read data files on disk that are not
+included in the downloaded archive in order to collect all the
+information required for the database.  In this case, ask the
+administrator of the remote orderly archive to migrate their
+archive, and then re-pull.
 }
 \examples{
 # Suppose we have a "remote" orderly repository at some path.

--- a/tests/testthat/test-migrate.R
+++ b/tests/testthat/test-migrate.R
@@ -143,8 +143,9 @@ test_that("migrate_plan default is used", {
   on.exit(options(oo))
 
   path <- unpack_reference("0.3.2")
-  expect_equal(migrate_plan(path), available_migrations())
-  expect_equal(migrate_plan(path, to = "0.0.1"),
+  config <- orderly_config(path)
+  expect_equal(migrate_plan(config$archive_version), available_migrations())
+  expect_equal(migrate_plan(config$archive_version, to = "0.0.1"),
                set_names(character(), character()))
 })
 

--- a/tests/testthat/test-orderly.R
+++ b/tests/testthat/test-orderly.R
@@ -158,21 +158,20 @@ test_that("dependency dir can be used", {
 })
 
 
-test_that("can't commit out of order", {
+test_that("commit out of order", {
   path <- prepare_orderly_example("minimal")
 
   id1 <- orderly_run("example", root = path, echo = FALSE)
   id2 <- orderly_run("example", root = path, echo = FALSE)
 
   orderly_commit(id2, root = path)
-  expect_error(orderly_commit(id1, root = path),
-               "Report id '.+?' is behind existing id '.+?'")
+  expect_error(orderly_commit(id1, root = path), NA)
 
-  expect_equal(dir(file.path(path, "archive", "example")), id2)
-  expect_equal(dir(file.path(path, "draft", "example")), id1)
+  expect_equal(orderly_latest("example", root = path), id2)
 
   id3 <- orderly_run("example", root = path, echo = FALSE)
   expect_error(orderly_commit(id3, root = path), NA)
+  expect_equal(orderly_latest("example", root = path), id3)
 })
 
 

--- a/tests/testthat/test-remote-path.R
+++ b/tests/testthat/test-remote-path.R
@@ -36,6 +36,11 @@ test_that("pull report", {
   d <- orderly_list_archive(path2)
   expect_equal(d$name, "multifile-artefact")
   expect_true(d$id %in% orderly_list_archive(path1)$id)
+
+  ## Pulled report is now in the db:
+  con <- orderly_db("destination", root = path2)
+  on.exit(DBI::dbDisconnect(con))
+  expect_equal(DBI::dbReadTable(con, "report_version")$id, id)
 })
 
 

--- a/tests/testthat/test-remote-path.R
+++ b/tests/testthat/test-remote-path.R
@@ -133,3 +133,27 @@ test_that("pull dependencies", {
   expect_equal(orderly_list_archive(dat$config),
                data_frame(name = "example", id = c(dat$id2, id3)))
 })
+
+
+test_that("pull report with dependencies", {
+  dat <- prepare_orderly_remote_example()
+
+  ## For some reason that I don't understand, we use draft: true for
+  ## the depend report here, so fix that:
+  p <- file.path(dat$path_remote, "src", "depend", "orderly.yml")
+  yml <- grep("^\\s+draft: true", readLines(p), invert = TRUE, value = TRUE)
+  writeLines(yml, p)
+
+  id <- orderly_run("depend", root = dat$path_remote, echo = FALSE)
+  orderly_commit(id, root = dat$path_remote)
+
+  orderly_pull_archive("depend", id,
+                       root = dat$path_local, remote = dat$remote)
+  d <- orderly_list_archive(root = dat$path_local)
+  expect_setequal(d$id, c(dat$id2, id))
+  expect_setequal(d$name, c("example", "depend"))
+
+  con <- orderly_db("destination", root = dat$path_local)
+  on.exit(DBI::dbDisconnect(con))
+  expect_setequal(d$id, DBI::dbReadTable(con, "report_version")$id)
+})

--- a/tests/testthat/test-remote.R
+++ b/tests/testthat/test-remote.R
@@ -68,3 +68,33 @@ test_that("pull_dependencies counts dependencies", {
                               remote = dat$remote),
     "\\[ depends\\s+ \\]  depend has 1 dependency")
 })
+
+
+## These need dealing with properly, but check that they trigger
+## correctly here:
+test_that("pull from old remote", {
+  path_local <- prepare_orderly_example("demo")
+  path_remote <- unpack_reference("0.6.0")
+
+  expect_error(
+    orderly_pull_archive("minimal", root = path_local, remote = path_remote),
+    "Report needs migrating")
+})
+
+
+## These need dealing with properly, but check that they trigger
+## correctly here:
+test_that("pull from new remote", {
+  dat <- prepare_orderly_remote_example()
+
+  p <- path_orderly_run_rds(
+    file.path(dat$path_remote, "archive", "example", dat$id2))
+  d <- readRDS(p)
+  d$archive_version <- numeric_version("100.100.100")
+  saveRDS(d, p)
+
+  expect_error(
+    orderly_pull_archive("example", dat$id2, root = dat$path_local,
+                         remote = dat$remote),
+    "Report was created with orderly more recent than this, upgrade!")
+})


### PR DESCRIPTION
This PR will add reports into the DB as they are pulled, which is required for commiting any reports that that have imported dependencies.  To make that work we now also recursively download reports
