### PR TITLE
VIMC-3057: Better error message when changelog labels have changed

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 0.7.7
+Version: 0.7.8
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/R/db2.R
+++ b/R/db2.R
@@ -185,8 +185,9 @@ report_db_open_existing <- function(con, config) {
     identical(label$public[match(label$id, config$changelog$id)],
               config$changelog$public %||% logical(0))
   if (!ok) {
-    stop("changelog labels have changed: rebuild with orderly::orderly_rebuild",
-         call. = FALSE)
+    stop(
+      "changelog labels have changed: rebuild with orderly::orderly_rebuild()",
+      call. = FALSE)
   }
 }
 

--- a/tests/testthat/test-changelog.R
+++ b/tests/testthat/test-changelog.R
@@ -237,7 +237,8 @@ test_that("label change requires rebuild", {
   id2 <- orderly_run("example", root = path, echo = FALSE)
   expect_error(
     orderly_commit(id2, root = path),
-    "changelog labels have changed: rebuild with orderly::orderly_rebuild")
+    "changelog labels have changed: rebuild with orderly::orderly_rebuild()",
+    fixed = TRUE)
 
   orderly_rebuild(root = path)
   p2 <- orderly_commit(id2, root = path)


### PR DESCRIPTION
This PR will improve the error message when changelog labels have changed, requiring a db rebuild by making it clearer that one must run the function

As reported by @Imai-N