### PR TITLE
strip out trailing slashes from resource directories

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 0.7.8
+Version: 0.7.10
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/R/recipe_read.R
+++ b/R/recipe_read.R
@@ -217,10 +217,6 @@ recipe_read_check_resources <- function(x, filename, path) {
   trailing <- grepl(pattern = "(\\/)$", x)
   bad_resource <- is_dir & trailing
   if (any(bad_resource)) {
-    warning_msg <- sprintf("Resource %s a traling slash:%s",
-                   ngettext(sum(bad_resource), "directory has",
-                                               "directories have"),
-                   paste(squote(x[bad_resource]), collapse = ", "))
     x[bad_resource] <- sub("(\\/)$", "", x[bad_resource])
   }
 

--- a/R/recipe_read.R
+++ b/R/recipe_read.R
@@ -221,7 +221,6 @@ recipe_read_check_resources <- function(x, filename, path) {
                    ngettext(sum(bad_resource), "directory has",
                                                "directories have"),
                    paste(squote(x[bad_resource]), collapse = ", "))
-    orderly_log("warning", warning_msg)
     x[bad_resource] <- sub("(\\/)$", "", x[bad_resource])
   }
 

--- a/R/recipe_read.R
+++ b/R/recipe_read.R
@@ -210,6 +210,21 @@ recipe_read_check_resources <- function(x, filename, path) {
   if (is.null(x)) {
     return(NULL)
   }
+
+  # make sure that a directory resource does not have a trailing /
+  # There is much more sanitation that could be done here...
+  is_dir <- is_directory(file.path(path, x))
+  trailing <- grepl(pattern = "(\\/)$", x)
+  bad_resource <- is_dir & trailing
+  if (any(bad_resource)) {
+    warning_msg <- sprintf("Resource %s a traling slash:%s",
+                   ngettext(sum(bad_resource), "directory has",
+                                               "directories have"),
+                   paste(squote(x[bad_resource]), collapse = ", "))
+    orderly_log("warning", warning_msg)
+    x[bad_resource] <- sub("(\\/)$", "", x[bad_resource])
+  }
+
   assert_character(x, sprintf("%s:%s", filename, "resouces"))
   assert_file_exists(x, workdir = path, name = "Resource file")
   ## TODO: this is not quite right because the files need to be

--- a/tests/testthat/test-recipe-read.R
+++ b/tests/testthat/test-recipe-read.R
@@ -397,9 +397,15 @@ test_that("trailing slash on resource directory", {
            "requester: ACME"
            )
   writeLines(yml, file.path(yml_path))
-  # make sure we get a warning about this
-  messages <- capture_messages(
-    id <- orderly_run("use_resource", root = path, echo = FALSE))
-  expect_true(any(grep("Resource directory has a traling slash:'meta/'",
-                       messages)))
+  id <- orderly_run("use_resource", root = path, echo = FALSE)
+  p <- file.path(path, "draft", "use_resource", id)
+
+  # make sure the directory has been copied across
+  expect_true(file.exists(file.path(p, "meta")))
+  orderly_commit(id, root = path)
+  con <- orderly_db("destination", root = path)
+  on.exit(DBI::dbDisconnect(con))
+  dat <- DBI::dbReadTable(con, "file_input")
+  # make sure the resource filename does not contain a double slash //
+  expect_true("meta/data.csv" %in% dat$filename)
 })

--- a/tests/testthat/test-recipe-read.R
+++ b/tests/testthat/test-recipe-read.R
@@ -375,3 +375,31 @@ test_that("sources and resources are exclusive", {
     recipe_read(file.path(path, "src", "other"), config),
     "Do not list source files \\(sources\\) as resources:\\s+- functions\\.R")
 })
+
+
+test_that("trailing slash on resource directory", {
+  path <- prepare_orderly_example("demo")
+  ## in report directory create a file called README.md
+  report_path <- file.path(path, "src", "use_resource")
+  #rewrite yml to include extra readme file
+  yml_path <- file.path(report_path, "orderly.yml")
+  yml <- c("data:",
+           "  dat:",
+           "    query: SELECT name, number FROM thing",
+           "script: script.R",
+           "resources:",
+           "  - meta/",
+           "artefacts:",
+           "  staticgraph:",
+           "    description: A graph of things",
+           "    filenames: mygraph.png",
+           "author: Dr Serious",
+           "requester: ACME"
+           )
+  writeLines(yml, file.path(yml_path))
+  # make sure we get a warning about this
+  messages <- capture_messages(
+    id <- orderly_run("use_resource", root = path, echo = FALSE))
+  expect_true(any(grep("Resource directory has a traling slash:'meta/'",
+                       messages)))
+})


### PR DESCRIPTION
If a report has a resource directory specified by
```
resources:
  - data/
```

The report will run correctly with all the contents of data copied correctly.
The files in data will be listed as unexpected artefacts since orderly the files are copied to
```
data/filename.csv
```
but orderly expects the file to be
```
data//filename.csv
```
[This might also cause problems running this report on a windows OS]

This fix removes a trailing slash - we could probably go further sanitizing filenames (and other entries) in the yaml