### PR TITLE
VIMC-3129: Check for sink imbalance

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 0.7.11
+Version: 0.7.12
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# 0.7.12
+
+* `orderly_run` now checks for sink imbalance, in the same way that device imbalances are currently checked for, preventing odd errors when sinks are left open or too many are closed (VIMC-3129)
+
 # 0.7.9
 
 * All README files are copied into destination directory, not just top level (VIMC-3065)

--- a/R/recipe_run.R
+++ b/R/recipe_run.R
@@ -283,6 +283,7 @@ recipe_run <- function(info, parameters, envir, config, echo = TRUE) {
 
   recipe_check_device_stack(prep$n_dev)
   recipe_check_sink_stack(prep$n_sink)
+  recipe_check_connections(info)
   hash_artefacts <- recipe_check_artefacts(info)
 
   hash_data_csv <- con_csv$mset(prep$data)
@@ -856,5 +857,20 @@ recipe_check_unique_inputs <- function(info) {
     stop(sprintf("Orderly configuration implies duplicate files:%s",
                  paste(details, collapse = "")),
          call. = FALSE)
+  }
+}
+
+
+recipe_check_connections <- function(info) {
+  cons <- getAllConnections()
+  cons <- cons[cons > 2] # drop stdin, stdout, stderr
+  if (length(cons) > 0L) {
+    open <- basename(vcapply(cons, function(x)
+      summary.connection(x)$description))
+    ours <- unlist(info$artefacts[, "filenames"], FALSE, FALSE)
+    err <- ours[basename(ours) %in% open]
+    if (any(ours %in% open)) {
+      stop("File left open: ", paste(err, collapse = ", "))
+    }
   }
 }

--- a/inst/migrate/0.7.12.R
+++ b/inst/migrate/0.7.12.R
@@ -1,0 +1,20 @@
+migrate <- function(data, path, config) {
+  info <- data$meta$file_info_artefacts
+  prev <- info$file_hash
+  curr <- hash_files(file.path(path, info$filename), FALSE)
+  err <- prev != curr
+  if (!any(err)) {
+    return(migration_result(FALSE, data))
+  }
+
+  msg <- c(sprintf("Modified %s in %s/%s",
+                   ngettext(sum(err), "artefact", "artefacts"),
+                   data$meta$name,
+                   data$meta$id),
+           paste0("  - ", info$filename[err]))
+  orderly_log("WARNING", msg)
+
+  data$meta$file_info_artefacts$file_hash <- curr
+
+  migration_result(TRUE, data)
+}

--- a/tests/testthat/test-migrate.R
+++ b/tests/testthat/test-migrate.R
@@ -432,3 +432,49 @@ test_that("migrate => 0.6.8", {
   rownames(old_file_input) <- rownames(new_file_input) <- NULL
   expect_equal(old_file_input, new_file_input)
 })
+
+
+test_that("patch modified artefact", {
+  oo <- options(orderly.nowarnings = TRUE)
+  on.exit(options(oo))
+  path <- unpack_reference("0.6.0")
+  orderly_migrate(path, to = "0.6.8")
+
+  sql <- paste("SELECT file_artefact.* from file_artefact",
+               "JOIN report_version_artefact",
+               "  ON report_version_artefact.id = file_artefact.artefact",
+               "WHERE report_version_artefact.report_version = $1")
+
+  list <- orderly_list_archive(path)
+  id <- list$id[list$name == "multi-artefact"]
+
+  con <- orderly_db("destination", path, validate = FALSE)
+  old <- DBI::dbGetQuery(con, sql, id)
+  DBI::dbDisconnect(con)
+
+  path_rds <- file.path(path, "archive", "multi-artefact", id,
+                        "orderly_run.rds")
+
+  ## modify an artefact:
+  p <- file.path(path, "archive", "multi-artefact", id, "subset.csv")
+  h1 <- hash_files(p, FALSE)
+  txt <- readLines(p)
+  writeLines(txt[-length(txt)], p)
+  h2 <- hash_files(p, FALSE)
+
+  ## Preflight check:
+  expect_equal(readRDS(path_rds)$meta$file_info_artefacts$file_hash[[2]], h1)
+  expect_equal(old$file_hash[old$filename == "subset.csv"], h1)
+
+  ## Do the migration
+  orderly_migrate(path, "0.7.12")
+  orderly_rebuild(path)
+
+  ## Confirm we pick up the changes
+  con <- orderly_db("destination", path, validate = FALSE)
+  new <- DBI::dbGetQuery(con, sql, id)
+  DBI::dbDisconnect(con)
+
+  expect_equal(readRDS(path_rds)$meta$file_info_artefacts$file_hash[[2]], h2)
+  expect_equal(new$file_hash[new$filename == "subset.csv"], h2)
+})

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -116,12 +116,14 @@ test_that("sink imbalance", {
       orderly_run("example", root = path, echo = TRUE), logfile),
     "Report left 1 sink open")
 
+  p <- tempfile()
+  sink(p, split = TRUE)
   writeLines(c("sink()", txt), path_script)
   expect_error(
-    suppressWarnings(
-      capture_log(
-        orderly_run("example", root = path, echo = TRUE), logfile),
-      "Report closed 1 more sinks than it opened!"))
+    capture_log(
+      orderly_run("example", root = path, echo = TRUE), logfile),
+    "Report closed 1 more sinks than it opened!")
+  expect_equal(sink.number(), 0)
 })
 
 test_that("included example", {

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -113,16 +113,18 @@ test_that("sink imbalance", {
   logfile <- tempfile()
   expect_error(
     capture_log(
-      orderly_run("example", root = path, echo = TRUE), logfile),
+      orderly_run("example", root = path, echo = FALSE), logfile),
     "Report left 1 sink open")
 
   p <- tempfile()
   sink(p, split = TRUE)
   writeLines(c("sink()", txt), path_script)
-  expect_error(
-    capture_log(
-      orderly_run("example", root = path, echo = TRUE), logfile),
-    "Report closed 1 more sinks than it opened!")
+  withr::with_options(
+    list(orderly.nolog = TRUE),
+    expect_error(
+      capture_log(
+        orderly_run("example", root = path, echo = FALSE), logfile),
+      "Report closed 1 more sinks than it opened!"))
   expect_equal(sink.number(), 0)
 })
 


### PR DESCRIPTION
This PR checks reports for a sink imbalance.  This is particularly important where sinks are used to create artefacts, as seen in VIMC-3128 as this modifies the artefact after creation.

The approach is directly modelled after the device imbalance check