### PR TITLE
VIMC-3137: Remove uses of pandoc

### DIFF
--- a/inst/examples/demo/src/html/myreport.Rmd
+++ b/inst/examples/demo/src/html/myreport.Rmd
@@ -1,10 +1,3 @@
----
-title: "An example report"
-author: "orderly"
-date: "20 February 2018"
-output: html_document
----
-
 ## Introduction
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

--- a/inst/examples/demo/src/html/script.R
+++ b/inst/examples/demo/src/html/script.R
@@ -1,1 +1,2 @@
-rmarkdown::render("myreport.Rmd", quiet = TRUE)
+knitr::knit2html("myreport.Rmd", "myreport.html")
+unlink("myreport.md")

--- a/inst/examples/demo/src/html/script.R
+++ b/inst/examples/demo/src/html/script.R
@@ -1,2 +1,2 @@
-knitr::knit2html("myreport.Rmd", "myreport.html")
+knitr::knit2html("myreport.Rmd", "myreport.html", quiet = TRUE)
 unlink("myreport.md")

--- a/inst/examples/knitr/src/example/report.Rmd
+++ b/inst/examples/knitr/src/example/report.Rmd
@@ -1,13 +1,3 @@
----
-title: "An example report"
-author: "Rich"
-date: "August 2017"
-output:
-  html_document: default
-  pdf_document: default
-  word_document: default
----
-
 ``` {r echo=FALSE, results="hide"}
 knitr::opts_chunk$set(error=FALSE)
 ```

--- a/inst/examples/knitr/src/example/script.R
+++ b/inst/examples/knitr/src/example/script.R
@@ -1,2 +1,2 @@
-knitr::knit2html("report.Rmd", "report.html")
+knitr::knit2html("report.Rmd", "report.html", quiet = TRUE)
 unlink("report.md")

--- a/inst/examples/knitr/src/example/script.R
+++ b/inst/examples/knitr/src/example/script.R
@@ -1,2 +1,2 @@
-knitr::knit2html("myreport.Rmd", "myreport.html")
-unlink("myreport.md")
+knitr::knit2html("report.Rmd", "report.html")
+unlink("report.md")

--- a/inst/examples/knitr/src/example/script.R
+++ b/inst/examples/knitr/src/example/script.R
@@ -1,1 +1,2 @@
-rmarkdown::render("report.Rmd", "html_document", quiet = TRUE)
+knitr::knit2html("myreport.Rmd", "myreport.html")
+unlink("myreport.md")

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -329,8 +329,6 @@ test_that("resources", {
 
 
 test_that("markdown", {
-  skip_if_not_installed("rmarkdown")
-  skip_on_appveyor() # See https://github.com/jgm/pandoc/issues/5037
   path <- prepare_orderly_example("knitr")
 
   id <- orderly_run("example", root = path, echo = FALSE)


### PR DESCRIPTION
While `rmarkdown::render` is certainly a nicer way of doing this, it induces an error in the pandoc system package for tests, which will be a problem on CRAN (I believe it does not exist on Solaris, for example).

This PR uses plain knitr for the translation