### PR TITLE
VIMC-3140: alternative approach to the windows unhiding

### DIFF
--- a/R/testing.R
+++ b/R/testing.R
@@ -177,11 +177,10 @@ demo_change_time <- function(id, time, path) {
 ## in build_git_demo below. The whole line is treated as 
 ## a comment in bash, whereas windows will execute the attrib.
 
-unhide_file <- function(file) {
-  script <- paste0(tempfile(), ".bat")
-  writeLines(sprintf("# 2>NUL & attrib -h %s", file), script, sep = "\r\n")
-  system2(script, stdout = NULL)
-  unlink(script)
+unhide_file_windows <- function(file) {
+  if (is_windows()) {
+    system2("attrib", c("-h", file), stdout = NULL)
+  }
 }
 
 ## This version will eventually go into a yml thing but it's a bit
@@ -223,7 +222,7 @@ build_git_demo <- function() {
   # otherwise, it will be ignored by InfoZip (zip.exe 
   # which utils::zip will likely pick up from the RTools folder)
   
-  unhide_file(file.path(path, ".git"))
+  unhide_file_windows(file.path(path, ".git"))
   
   archive <- zip_dir(path)
   options(orderly.server.demo = archive)

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -563,3 +563,30 @@ test_that("backup db", {
   expect_setequal(list_tables(path_db), list_tables(dest))
   expect_setequal(list_tables(path_db), list_tables(dest_prev))
 })
+
+
+test_that("unhide file windows will call attrib on windows", {
+  mock <- mockery::mock(NULL)
+  mockery::stub(unhide_file_windows, "system2", mock)
+  mockery::stub(unhide_file_windows, "is_windows", TRUE)
+
+  p <- tempfile()
+  expect_null(unhide_file_windows(p))
+  calls <- mockery::mock_calls(mock)
+  expect_equal(length(calls), 1)
+  ## This seems pretty limiting:
+  expect_equal(calls[[1]],
+               quote(system2("attrib", c("-h", file), stdout = NULL)))
+})
+
+
+test_that("unhide file windows call system2 on windows", {
+  mock <- mockery::mock(NULL)
+  mockery::stub(unhide_file_windows, "system2", mock)
+  mockery::stub(unhide_file_windows, "is_windows", FALSE)
+
+  p <- tempfile()
+  expect_null(unhide_file_windows(p))
+  calls <- mockery::mock_calls(mock)
+  expect_equal(length(calls), 0)
+})


### PR DESCRIPTION
This PR uses a slightly different hack for the windows file unhiding:

* we only execute `attrib` on windows
* tests use mocks to check that this would not be run on unix and would be run on windows