### PR TITLE
VIMC-2469: refactor the cli interface

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,10 +26,10 @@ Imports:
     R6,
     RSQLite,
     digest,
+    docopt,
     fs,
     ids,
     jsonlite,
-    optparse,
     withr,
     yaml
 Suggests:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,11 +29,11 @@ Imports:
     docopt,
     fs,
     ids,
-    jsonlite,
     withr,
     yaml
 Suggests:
     httr,
+    jsonlite,
     knitr,
     mockery,
     processx,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 0.7.13
+Version: 0.7.14
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# 0.7.14
+
+* The command line interface has been overhauled, in particular the parameter passing interface (VIMC-2469) which now accepts key-value pairs and not json
+
 # 0.7.13
 
 * It is now possible to deduplicate an orderly archive using `orderly::orderly_deduplicate` (VIMC-731).

--- a/R/main.R
+++ b/R/main.R
@@ -1,7 +1,7 @@
 ## Try to make it easy to run things
 main <- function(args = commandArgs(TRUE)) {
   dat <- cli_args_process(args)
-  dat$target(dat$args)
+  dat$target(dat)
 }
 
 

--- a/R/main.R
+++ b/R/main.R
@@ -78,13 +78,15 @@ cli_args_process_run_parameters <- function(parameters) {
   if (length(parameters) == 0L) {
     NULL
   } else {
-    parameters <- strsplit(parameters, "=", fixed = TRUE)
-    n <- lengths(parameters)
-    if (any(n != 2)) {
-      stop("Invalid parameters") # better error messages and coping here
+    p <- strsplit(parameters, "=", fixed = TRUE)
+    err <- lengths(p) != 2
+    if (any(err)) {
+      stop(sprintf(
+        "Invalid parameters %s - all must be in form key=value",
+        paste(squote(parameters[err]), collapse = ", ")))
     }
-    value <- lapply(parameters, function(x) parse_parameter(x[[2L]]))
-    set_names(value, vcapply(parameters, "[[", 1L))
+    value <- lapply(p, function(x) parse_parameter(x[[2L]]))
+    set_names(value, vcapply(p, "[[", 1L))
   }
 }
 

--- a/R/runner.R
+++ b/R/runner.R
@@ -290,10 +290,19 @@ R6_orderly_runner <- R6::R6Class(
       orderly_log("run", sprintf("%s (%s)", key, dat$name))
       self$data$set_state(key, RUNNER_RUNNING)
       id_file <- file.path(self$path_id, key)
+      if (is.na(dat$parameters)) {
+        parameters <- NULL
+      } else {
+        ## In the current system, these come through as json, but we
+        ## might want to tweak this.  I need to follow this back
+        ## through orderly.server next
+        p <- jsonlite::fromJSON(dat$parameters, FALSE)
+        parameters <- sprintf("%s=%s", names(p), vcapply(p, format))
+      }
       args <- c("--root", self$path,
                 "run", dat$name, "--print-log", "--id-file", id_file,
-                if (!is.na(dat$parameters)) c("--parameters", dat$parameters),
-                if (!is.na(dat$ref)) c("--ref", dat$ref))
+                if (!is.na(dat$ref)) c("--ref", dat$ref),
+                parameters)
 
       ## NOTE: sending stdout/stderr to "|" causes a big slowdown (as
       ## in 5-10x longer to run than not going through processx). File

--- a/R/util.R
+++ b/R/util.R
@@ -209,10 +209,6 @@ last <- function(x) {
   x[[length(x)]]
 }
 
-modify_list <- function(a, b) {
-  a[names(b)] <- b
-  a
-}
 
 orderly_env <- function() {
   env <- Sys.getenv()

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,11 +16,11 @@ RUN install2.r \
   RPostgres \
   RSQLite \
   digest \
+  docopt \
   fs \
   ids \
   jsonlite \
   knitr \
-  optparse \
   remotes \
   rmarkdown \
   withr \

--- a/inst/script
+++ b/inst/script
@@ -1,0 +1,6 @@
+tryCatch(
+  orderly:::main(),
+  orderly_cli_error = function(e) {
+    message(paste("orderly:", e$message))
+    q(save = "no", status = 1)
+  })

--- a/tests/testthat/test-main.R
+++ b/tests/testthat/test-main.R
@@ -45,7 +45,6 @@ test_that("run: ref", {
   testthat::skip_on_cran()
   path <- unzip_git_demo()
 
-  pars <- as.character(jsonlite::toJSON(list(nmin = 0), auto_unbox = TRUE))
   args <- c("--root", path, "run", "--ref", "other", "other", "nmin=0")
 
   res <- cli_args_process(args)

--- a/tests/testthat/test-main.R
+++ b/tests/testthat/test-main.R
@@ -398,3 +398,15 @@ test_that("docopt failure gives reasonable error", {
     main(c("--root", path, "list", "unknown")),
     class = "orderly_cli_error")
 })
+
+
+test_that("invalid parameters", {
+  expect_error(
+    cli_args_process_run_parameters("a"),
+    "Invalid parameters 'a' - all must be in form key=value",
+    fixed = TRUE)
+  expect_error(
+    cli_args_process_run_parameters(c("a", "b=2", "c=3=4")),
+    "Invalid parameters 'a', 'c=3=4' - all must be in form key=value",
+    fixed = TRUE)
+})

--- a/tests/testthat/test-main.R
+++ b/tests/testthat/test-main.R
@@ -167,6 +167,7 @@ test_that("latest", {
 
 
 test_that("help", {
+  skip("prevent docopt killing session")
   expect_error(capture.output(cli_args_process("--help")),
                class = "orderly_cli_error")
 

--- a/tests/testthat/test-main.R
+++ b/tests/testthat/test-main.R
@@ -166,18 +166,6 @@ test_that("latest", {
 })
 
 
-test_that("help", {
-  skip("prevent docopt killing session")
-  expect_error(capture.output(cli_args_process("--help")),
-               class = "orderly_cli_error")
-
-  for (cmd in names(cli_commands())) {
-    expect_output(try(cli_args_process(c(cmd, "--help")), silent = TRUE),
-                  sprintf("Usage:\n  orderly %s", cmd))
-  }
-})
-
-
 test_that("list", {
   path <- prepare_orderly_example("minimal")
 

--- a/tests/testthat/test-main.R
+++ b/tests/testthat/test-main.R
@@ -41,6 +41,18 @@ test_that("run: id-file", {
 })
 
 
+test_that("pass parameters", {
+  f <- function(...) {
+    cli_args_process(c("run", "report", ...))$options$parameters
+  }
+  expect_equal(f("a=1"), list(a = 1))
+  expect_equal(f("a=1", "b=value"), list(a = 1, b = "value"))
+  expect_equal(f("a=1", "b=value", "c=TRUE"),
+               list(a = 1, b = "value", c=TRUE))
+  expect_equal(f("a=1+2"), list(a = "1+2"))
+})
+
+
 test_that("run: ref", {
   testthat::skip_on_cran()
   path <- unzip_git_demo()

--- a/tests/testthat/test-main.R
+++ b/tests/testthat/test-main.R
@@ -390,3 +390,11 @@ test_that("main wrapper", {
   path <- prepare_orderly_example("minimal")
   expect_output(main(c("--root", path, "list")), "example")
 })
+
+
+test_that("docopt failure gives reasonable error", {
+  path <- prepare_orderly_example("minimal")
+  expect_error(
+    main(c("--root", path, "list", "unknown")),
+    class = "orderly_cli_error")
+})

--- a/tests/testthat/test-main.R
+++ b/tests/testthat/test-main.R
@@ -381,3 +381,9 @@ test_that("preprocess set root", {
     list(root = "value", list_commands = NULL,
          command = "list", args = character(0)))
 })
+
+
+test_that("main wrapper", {
+  path <- prepare_orderly_example("minimal")
+  expect_output(main(c("--root", path, "list")), "example")
+})

--- a/tests/testthat/test-main.R
+++ b/tests/testthat/test-main.R
@@ -361,3 +361,23 @@ test_that("run: message no changelog",{
                  "but this is not enabled in orderly_config.yml", sep = " ")
   expect_error(capture.output(res$target(res)), error)
 })
+
+
+test_that("preprocess with no options", {
+  expect_equal(
+    cli_args_preprocess(c("run")),
+    list(root = NULL, list_commands = NULL,
+         command = "run", args = character(0)))
+  expect_equal(
+    cli_args_preprocess(c("run", "--option", "other")),
+    list(root = NULL, list_commands = NULL,
+         command = "run", args = c("--option", "other")))
+})
+
+
+test_that("preprocess set root", {
+  expect_equal(
+    cli_args_preprocess(c("--root", "value", "list")),
+    list(root = "value", list_commands = NULL,
+         command = "list", args = character(0)))
+})

--- a/tests/testthat/test-main.R
+++ b/tests/testthat/test-main.R
@@ -104,7 +104,8 @@ test_that("run: pull & ref don't go together", {
   res <- cli_args_process(args)
   expect_error(res$target(res),
                "Can't use --pull with --ref; perhaps you meant --fetch ?",
-               fixed = TRUE)
+               fixed = TRUE,
+               class = "orderly_cli_error")
 })
 
 
@@ -196,7 +197,8 @@ test_that("unknown", {
   path <- tempfile()
   args <- c("--root", path, "foo")
   expect_error(capture.output(cli_args_process(args)),
-               "'foo' is not an orderly command. See orderly --help")
+               "'foo' is not an orderly command. See orderly --help",
+               class = "orderly_cli_error")
 })
 
 

--- a/tests/testthat/test-slack.R
+++ b/tests/testthat/test-slack.R
@@ -1,6 +1,8 @@
 context("slack")
 
 test_that("slack payload is correct", {
+  skip_if_not_installed("httr")
+  skip_if_not_installed("jsonlite")
   server_url <- "https://example.com"
   server_is_primary <- FALSE
   server_name <- "myserver"
@@ -44,6 +46,8 @@ test_that("slack payload is correct", {
 
 
 test_that("git information is collected correctly", {
+  skip_if_not_installed("httr")
+  skip_if_not_installed("jsonlite")
   server_url <- "https://example.com"
   server_is_primary <- FALSE
   server_name <- "myserver"
@@ -149,6 +153,7 @@ test_that("main interface", {
 
 test_that("main interface", {
   skip_if_no_internet()
+  skip_if_not_installed("httr")
 
   path <- prepare_orderly_example("minimal")
   append_lines(c(
@@ -196,6 +201,7 @@ test_that("main interface", {
 
 
 test_that("exit on no httr", {
+  skip_if_not_installed("mockery")
   dat <- list(meta = list(elapsed = 10,
                           id = "20181213-123456-fedcba98",
                           name = "example"))

--- a/tests/testthat/test-z-runner.R
+++ b/tests/testthat/test-z-runner.R
@@ -133,7 +133,7 @@ test_that("run in branch (local)", {
   path <- unzip_git_demo()
   runner <- orderly_runner(path)
 
-  pars <- as.character(jsonlite::toJSON(list(nmin = 0), auto_unbox = TRUE))
+  pars <- '{"nmin":0}'
   key <- runner$queue("other", parameters = pars, ref = "other")
   runner$poll()
   id <- wait_for_id(runner, key)

--- a/tests/testthat/test-z-runner.R
+++ b/tests/testthat/test-z-runner.R
@@ -112,6 +112,24 @@ test_that("run: error", {
 })
 
 
+test_that("run report with parameters", {
+  testthat::skip_on_cran()
+  path <- prepare_orderly_example("demo")
+  runner <- orderly_runner(path)
+  pars <- '{"nmin":0.5}'
+  key <- runner$queue("other", parameters = pars)
+  runner$poll()
+  id <- wait_for_id(runner, key)
+  wait_while_running(runner)
+  d <- orderly_list_archive(path)
+  expect_equal(d$name, "other")
+  expect_equal(d$id, id)
+
+  d <- readRDS(path_orderly_run_rds(file.path(path, "archive", "other", id)))
+  expect_equal(d$meta$parameters, list(nmin = 0.5))
+})
+
+
 test_that("rebuild", {
   path <- prepare_orderly_example("minimal")
   runner <- orderly_runner(path)


### PR DESCRIPTION
This PR will overhaul the cli interface to use docopt rather than optparse. The parameter interface is changed now so that we pass in parameters as simple key-value pairs rather than json, as json was _awful_ to use on a cli.  So now we might write:

```
orderly run other nmin=0.5
```

The actual type inference of parameters might cause some problems but we'll deal with that later...

This slightly affects the orderly.server but not that much because running with parameters is not enabled.  I am going to address this in VIMC-3144 on that package