### PR TITLE
VIMC-2968: swap utils::zip for the zip package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,8 @@ Imports:
     jsonlite,
     optparse,
     withr,
-    yaml
+    yaml,
+    zip
 Suggests:
     httr,
     knitr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,7 @@ Imports:
     optparse,
     withr,
     yaml,
-    zip
+    zip (>= 2.0.0)
 Suggests:
     httr,
     knitr,

--- a/R/testing.R
+++ b/R/testing.R
@@ -172,17 +172,6 @@ demo_change_time <- function(id, time, path) {
 }
 
 
-## System call to attrib to unhide a file on windows, in a way
-## that is safely and silently ignored on Linux. Used only
-## in build_git_demo below. The whole line is treated as 
-## a comment in bash, whereas windows will execute the attrib.
-
-unhide_file_windows <- function(file) {
-  if (is_windows()) {
-    system2("attrib", c("-h", file), stdout = NULL)
-  }
-}
-
 ## This version will eventually go into a yml thing but it's a bit
 ## nasty to deal with at the moment.  This means it's not easily
 ## extendable...
@@ -218,12 +207,6 @@ build_git_demo <- function() {
 
   git_checkout_branch("master", root = path)
 
-  # On windows, make ".git" folder non-hidden,
-  # otherwise, it will be ignored by InfoZip (zip.exe 
-  # which utils::zip will likely pick up from the RTools folder)
-  
-  unhide_file_windows(file.path(path, ".git"))
-  
   archive <- zip_dir(path)
   options(orderly.server.demo = archive)
   archive

--- a/R/testing.R
+++ b/R/testing.R
@@ -233,7 +233,7 @@ unzip_git_demo <- function(path = tempfile()) {
   tmp <- tempfile()
   dir.create(tmp, FALSE, TRUE)
   demo <- getOption("orderly.server.demo", build_git_demo())
-  utils::unzip(demo, exdir = tmp)
+  zip::unzip(demo, exdir = tmp)
   dir.create(path, FALSE, TRUE)
   src <- dir(file.path(tmp, "demo"), full.names = TRUE, all.files = TRUE,
              no.. = TRUE)

--- a/R/util.R
+++ b/R/util.R
@@ -401,10 +401,7 @@ sys_which <- function(name) {
 zip_dir <- function(path, dest = paste0(basename(path), ".zip")) {
   owd <- setwd(dirname(path))
   on.exit(setwd(owd))
-  code <- utils::zip(dest, basename(path), extras = "-q")
-  if (code != 0) {
-    stop("error running zip")
-  }
+  zip::zipr(dest, basename(path))
   normalizePath(dest)
 }
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,7 +24,8 @@ RUN install2.r \
   remotes \
   rmarkdown \
   withr \
-  yaml
+  yaml \
+  zip
 
 RUN Rscript -e 'remove.packages("BH")'
 

--- a/tests/testthat/helper-orderly.R
+++ b/tests/testthat/helper-orderly.R
@@ -50,7 +50,7 @@ unpack_reference <- function(version, path = tempfile()) {
       testthat::skip(msg)
     }
   }
-  unzip(src, exdir = path)
+  zip::unzip(src, exdir = path)
   file.path(path, version)
 }
 

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -346,13 +346,6 @@ test_that("sys_which", {
 })
 
 
-test_that("zip_dir", {
-  testthat::skip_on_cran()
-  mockery::stub(zip_dir, "utils::zip", function(...) -1)
-  expect_error(zip_dir(tempfile()), "error running zip")
-})
-
-
 test_that("open_directory: windows", {
   mockery::stub(open_directory, "system2", list)
   mockery::stub(open_directory, "is_windows", TRUE)

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -573,30 +573,3 @@ test_that("pretty_bytes", {
   expect_equal(pretty_bytes(12345678901), "12.35 GB")
   expect_equal(pretty_bytes(123456789012), "123.46 GB")
 })
-
-
-test_that("unhide file windows will call attrib on windows", {
-  mock <- mockery::mock(NULL)
-  mockery::stub(unhide_file_windows, "system2", mock)
-  mockery::stub(unhide_file_windows, "is_windows", TRUE)
-
-  p <- tempfile()
-  expect_null(unhide_file_windows(p))
-  calls <- mockery::mock_calls(mock)
-  expect_equal(length(calls), 1)
-  ## This seems pretty limiting:
-  expect_equal(calls[[1]],
-               quote(system2("attrib", c("-h", file), stdout = NULL)))
-})
-
-
-test_that("unhide file windows call system2 on windows", {
-  mock <- mockery::mock(NULL)
-  mockery::stub(unhide_file_windows, "system2", mock)
-  mockery::stub(unhide_file_windows, "is_windows", FALSE)
-
-  p <- tempfile()
-  expect_null(unhide_file_windows(p))
-  calls <- mockery::mock_calls(mock)
-  expect_equal(length(calls), 0)
-})


### PR DESCRIPTION
This PR will remove `utils::zip` which has proven to be not that reliable, in favour of the `zip` package.  There should be no user-facing changes as a result of this, except that things will be slightly better behaved on windows.

It's possible that this removes the need for the previous rounds of hacking (VIMC-3140 / #127, VIMC-3133 / #125) and perhaps in light of that the net change there could be removed.