### PR TITLE
VIMC-2961: Allow resources in subdirectories (and with different names)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 0.7.14
+Version: 0.7.15
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# 0.7.15
+
+* Global resources can now be renamed on copy, allowing use of subdirectories to structure them.  Using global resources as a set of strings is now deprecated (VIMC-2961).
+
 # 0.7.14
 
 * The command line interface has been overhauled, in particular the parameter passing interface (VIMC-2469) which now accepts key-value pairs and not json

--- a/R/db2.R
+++ b/R/db2.R
@@ -341,6 +341,18 @@ report_data_import <- function(con, name, id, config) {
     stringsAsFactors = FALSE)
   DBI::dbWriteTable(con, "file_input", file_input, append = TRUE)
 
+  if (!is.null(dat_rds$meta$global_resources)) {
+    sql <- c("SELECT id, filename FROM file_input",
+             " WHERE report_version = $1 AND file_purpose = 'global'")
+    tmp <- DBI::dbGetQuery(con, paste(sql, collapse = " "), id)
+    i <- match(names(dat_rds$meta$global_resources), tmp$filename)
+    file_input_global <- data_frame(
+      file_input = tmp$id[i],
+      filename = unname(dat_rds$meta$global_resources))
+    DBI::dbWriteTable(con, "file_input_global", file_input_global,
+                      append = TRUE)
+  }
+
   ## Artefacts:
   report_data_add_files(con, dat_rds$meta$file_info_artefacts)
   report_version_artefact <- cbind(

--- a/R/db2.R
+++ b/R/db2.R
@@ -8,7 +8,7 @@
 ## namespace/module feature so that implementation details can be
 ## hidden away a bit further.
 
-ORDERLY_SCHEMA_VERSION <- "0.0.8"
+ORDERLY_SCHEMA_VERSION <- "0.0.9"
 
 ## These will be used in a few places and even though they're not
 ## super likely to change it would be good

--- a/R/recipe_run.R
+++ b/R/recipe_run.R
@@ -674,10 +674,8 @@ recipe_file_inputs <- function(info) {
     script = file_info(info$script),
     readme = file_info(info$readme),
     source = file_info(info$sources),
-    ## TODO: What we really should do is not have put the sources in
-    ## here in the first place, then this bit would not be necessary.
     resource = file_info(info$resources),
-    global = file_info(info$global_resources))
+    global = file_info(names(info$global_resources)))
 }
 
 
@@ -805,22 +803,13 @@ recipe_copy_resources <- function(info, src) {
 recipe_copy_global <- function(info, config) {
   if (!is.null(info$global_resources)) {
     global_path <- file.path(config$root, config$global_resources)
-    assert_file_exists(
-      info$global_resources, check_case = TRUE, workdir = global_path,
-      name = sprintf("Global resources in '%s'", global_path))
-
-    global_src <- file.path(global_path, info$global_resources)
-    ## See VIMC-2961: the copy here is different to sources and
-    ## resources because we can't rename files as they're copied; we
-    ## don't support directories and we're pretty limited in how
-    ## copying can happen.  I believe the "." that is the destination
-    ## of the copy will strip all leading path fragments (path/to/x
-    ## becoming x).
-    if (any(is_directory(global_src))) {
-      stop("global resources cannot yet be directories")
-    }
-    orderly_log("global", info$global_resources)
-    file_copy(global_src, ".", recursive = TRUE)
+    src <- file.path(global_path, info$global_resources)
+    dest <- names(info$global_resources)
+    dir_create(dirname(dest))
+    file_copy(src, dest)
+    orderly_log("global",
+                sprintf("%s -> %s",
+                        info$global_resources, names(info$global_resources)))
   }
   info
 }

--- a/R/recipe_run.R
+++ b/R/recipe_run.R
@@ -337,6 +337,7 @@ recipe_run <- function(info, parameters, envir, config, echo = TRUE) {
                packages = info$packages,
                file_info_inputs = info$inputs,
                file_info_artefacts = file_info_artefacts,
+               global_resources = info$global_resources,
                artefacts = artefacts,
                depends = depends,
                elapsed = as.numeric(elapsed, "secs"),

--- a/inst/database/schema.yml
+++ b/inst/database/schema.yml
@@ -103,6 +103,14 @@ file_input:
     # This would be great to have but seems overkill
     # - mime: {type: TEXT}
 
+# global files might have been renamed so we track their original
+# names here:
+file_input_global:
+  columns:
+    - id: {type: SERIAL}
+    - file_input: {fk: file_input.id}
+    - filename: {type: TEXT}
+
 # Link views into the report
 report_version_view:
   columns:

--- a/inst/examples/demo/src/global/orderly.yml
+++ b/inst/examples/demo/src/global/orderly.yml
@@ -8,7 +8,7 @@ artefacts:
       description: plot of displacement vs weight
 
 global_resources:
-  - data.csv
+  data.csv: data.csv
 
 author: Researcher McResearcherface
 requester: Funder McFunderface

--- a/inst/examples/global/src/example/orderly.yml
+++ b/inst/examples/global/src/example/orderly.yml
@@ -8,4 +8,4 @@ artefacts:
       description: plot of displacement vs weight
 
 global_resources:
-  - data.csv
+  data.csv: data.csv

--- a/inst/migrate/0.7.15.R
+++ b/inst/migrate/0.7.15.R
@@ -1,0 +1,12 @@
+migrate <- function(data, path, config) {
+  globals <- data$meta$file_info_inputs$filename[
+    data$meta$file_info_inputs$file_purpose == "global"]
+  if (length(globals) > 0 && is.null(data$meta$global_resources)) {
+    ## Before 0.7.15, global resources could not be renamed
+    data$meta$global_resources <- set_names(globals, globals)
+    changed <- TRUE
+  } else {
+    changed <- FALSE
+  }
+  migration_result(changed, data)
+}

--- a/tests/testthat/test-global.R
+++ b/tests/testthat/test-global.R
@@ -62,3 +62,69 @@ test_that("directories of global resources are forbidden", {
     orderly_run("example", root = path),
     "global resources cannot yet be directories")
 })
+
+
+test_that("global resource from a subdir", {
+  path <- prepare_orderly_example("global")
+  dir.create(file.path(path, "global", "dir"))
+  file.rename(file.path(path, "global", "data.csv"),
+              file.path(path, "global", "dir", "data.csv"))
+
+  p_orderly <- file.path(path, "src", "example", "orderly.yml")
+  d <- yaml_read(p_orderly)
+  d$global_resources <- "dir/data.csv"
+  yaml_write(d, p_orderly)
+
+  id <- orderly_run("example", root = path, echo = FALSE)
+  p <- orderly_commit(id, root = path)
+
+  con <- orderly_db("destination", root = path)
+  on.exit(DBI::dbDisconnect(con))
+
+  sql <- c("SELECT file_input.*, file_input_global.filename as orig",
+           "FROM file_input LEFT JOIN file_input_global",
+           "ON file_input.id = file_input_global.file_input")
+  input <- DBI::dbGetQuery(con, paste(sql, collapse = " "))
+
+  expect_equal(nrow(input), 3)
+  i <- input$file_purpose == "global"
+  expect_true(all(is.na(input$orig[!i])))
+  expect_equal(input$orig[i], "dir/data.csv")
+  expect_equal(input$filename[i], "data.csv")
+})
+
+
+test_that("rename global resource on import, into new dir", {
+  path <- prepare_orderly_example("global")
+  dir.create(file.path(path, "global", "dir"))
+  file.rename(file.path(path, "global", "data.csv"),
+              file.path(path, "global", "dir", "globaldata.csv"))
+
+  p_orderly <- file.path(path, "src", "example", "orderly.yml")
+  d <- yaml_read(p_orderly)
+  d$global_resources <- list("my/data.csv" = "dir/globaldata.csv")
+  yaml_write(d, p_orderly)
+
+  p_src <- file.path(path, "src", "example", "script.R")
+  txt <- readLines(p_src)
+  writeLines(sub("data.csv", "my/data.csv", txt, fixed = TRUE), p_src)
+
+  id <- orderly_run("example", root = path, echo = FALSE)
+  p <- orderly_commit(id, root = path)
+
+  expect_true(file.exists(file.path(p, "my", "data.csv")))
+
+  con <- orderly_db("destination", root = path)
+  on.exit(DBI::dbDisconnect(con))
+
+  sql <- c("SELECT file_input.*, file_input_global.filename as orig",
+           "FROM file_input LEFT JOIN file_input_global",
+           "ON file_input.id = file_input_global.file_input")
+  input <- DBI::dbGetQuery(con, paste(sql, collapse = " "))
+
+  expect_equal(nrow(input), 3)
+  i <- input$file_purpose == "global"
+  expect_true(all(is.na(input$orig[!i])))
+  expect_equal(input$orig[i], "dir/globaldata.csv")
+  expect_equal(input$filename[i], "my/data.csv")
+})

--- a/tests/testthat/test-global.R
+++ b/tests/testthat/test-global.R
@@ -55,7 +55,7 @@ test_that("directories of global resources are forbidden", {
 
   p_orderly <- file.path(path, "src", "example", "orderly.yml")
   d <- yaml_read(p_orderly)
-  d$global_resources <- "dir"
+  d$global_resources <- list("dir" = "dir")
   yaml_write(d, p_orderly)
 
   expect_error(
@@ -72,7 +72,7 @@ test_that("global resource from a subdir", {
 
   p_orderly <- file.path(path, "src", "example", "orderly.yml")
   d <- yaml_read(p_orderly)
-  d$global_resources <- "dir/data.csv"
+  d$global_resources <- list("data.csv" = "dir/data.csv")
   yaml_write(d, p_orderly)
 
   id <- orderly_run("example", root = path, echo = FALSE)

--- a/tests/testthat/test-global.R
+++ b/tests/testthat/test-global.R
@@ -16,7 +16,7 @@ test_that("missing global file", {
   path_yaml <- file.path(path_example, "orderly.yml")
   # the final line of the yaml is globa file, so we change that
   config_lines <- readLines(path_yaml)
-  config_lines[11] <- "  - none.csv"
+  config_lines[11] <- "  data.csv: none.csv"
   writeLines(config_lines, path_yaml)
   
   expected_error <- "Global resources in '.+/global' does not exist: 'none.csv'"

--- a/tests/testthat/test-migrate.R
+++ b/tests/testthat/test-migrate.R
@@ -478,3 +478,24 @@ test_that("patch modified artefact", {
   expect_equal(readRDS(path_rds)$meta$file_info_artefacts$file_hash[[2]], h2)
   expect_equal(new$file_hash[new$filename == "subset.csv"], h2)
 })
+
+
+test_that("migrate => 0.6.8", {
+  oo <- options(orderly.nowarnings = TRUE)
+  on.exit(options(oo))
+
+  path <- unpack_reference("0.6.0")
+  orderly_migrate(path, to = "0.7.15")
+  orderly_rebuild(path)
+
+  list <- orderly_list_archive(path)
+  id <- list$id[list$name == "global"]
+
+  d <- readRDS(path_orderly_run_rds(file.path(path, "archive", "global", id)))
+  expect_equal(d$meta$global_resources, c("data.csv" = "data.csv"))
+
+  con <- orderly_db("destination", path, validate = FALSE)
+  on.exit(DBI::dbDisconnect(con))
+  tab <- DBI::dbReadTable(con, "file_input_global")
+  expect_equal(nrow(tab), 1)
+})

--- a/tests/testthat/test-migrate.R
+++ b/tests/testthat/test-migrate.R
@@ -495,7 +495,7 @@ test_that("migrate => 0.7.15", {
   expect_equal(d$meta$global_resources, c("data.csv" = "data.csv"))
 
   con <- orderly_db("destination", path, validate = FALSE)
-  on.exit(DBI::dbDisconnect(con))
+  on.exit(DBI::dbDisconnect(con), add = TRUE)
   tab <- DBI::dbReadTable(con, "file_input_global")
   expect_equal(nrow(tab), 1)
 })

--- a/tests/testthat/test-migrate.R
+++ b/tests/testthat/test-migrate.R
@@ -480,7 +480,7 @@ test_that("patch modified artefact", {
 })
 
 
-test_that("migrate => 0.6.8", {
+test_that("migrate => 0.7.15", {
   oo <- options(orderly.nowarnings = TRUE)
   on.exit(options(oo))
 

--- a/tests/testthat/test-recipe-read.R
+++ b/tests/testthat/test-recipe-read.R
@@ -409,3 +409,20 @@ test_that("trailing slash on resource directory", {
   # make sure the resource filename does not contain a double slash //
   expect_true("meta/data.csv" %in% dat$filename)
 })
+
+
+test_that("old style global resources deprecated", {
+  path <- prepare_orderly_example("global")
+  path_example <- file.path(path, "src", "example")
+  path_yaml <- file.path(path_example, "orderly.yml")
+  config_lines <- readLines(path_yaml)
+  config_lines[[11]] <- "  data.csv"
+  writeLines(config_lines, path_yaml)
+
+  expect_warning(
+    res <- recipe_read(path_example, orderly_config(path)),
+    "Use of strings for global_resources: is deprecated")
+  expect_equal(
+    res$global_resources,
+    c(data.csv = "data.csv"))
+})

--- a/vignettes/orderly.Rmd
+++ b/vignettes/orderly.Rmd
@@ -489,9 +489,9 @@ Then to use any file in `your_global_dir` in your report add a
 
 ```yaml
 global_resources:
-  - org_logo.jpg
-  - org_latex_class.cls
-  - org_styles.css
+  logo.jpg: org_logo.jpg
+  latex_class.cls: org_latex_class.cls
+  styles.css: org_styles.css
 ```
 
 Currently code _i.e._ R source code cannot be sourced from the global


### PR DESCRIPTION
This PR will allow global resources to be organised into subdirectories.  Previously this was not really possible as it was ambiguous what

```
global_resources:
  - path/file.csv
```

should do - should it copy to the current report as `path/file.csv` or as `file.csv` (this ambiguity does not exist for ordinary resources as this is just a declaration that they exist).

To solve this we take the same approach as dependencies where files can be renamed:

```
global_resources:
  file.csv: path/file.csv
```

The lhs is the destination - that is the order used in the dependencies.  This approach allows arbitrary renaming, which is quite nice.

There are changes to the schema as a result of this - a new table exists to map the original names.

I do not believe that any report currently uses global resources so this should have minimal effect at the moment.  A migration is included to be on the safe side though.