### PR TITLE
VIMC-3157: support cleaning up old migration files

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 0.7.15
+Version: 0.7.16
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# 0.7.16
+
+* `orderly_migrate` can now clean up old migration backup files.  These should generally be quite safe to delete, but it would be better to do this directly from orderly (VIMC-3157)
+
 # 0.7.15
 
 * Global resources can now be renamed on copy, allowing use of subdirectories to structure them.  Using global resources as a set of strings is now deprecated (VIMC-2961).

--- a/R/main.R
+++ b/R/main.R
@@ -269,14 +269,16 @@ usage_migrate <- "Usage:
 
 Options:
   --to=VERSION  Version to migrate to
-  --dry-run     Test run the migration only"
+  --dry-run     Test run the migration only
+  --clean       Clean migration backup files"
 
 
 main_do_migrate <- function(x) {
   root <- x$options$root
   dry_run <- x$options$dry_run
   to <- x$options$to
-  orderly_migrate(root, to = to, dry_run = dry_run)
+  clean <- x$options$clean
+  orderly_migrate(root, to = to, dry_run = dry_run, clean = clean)
 }
 
 

--- a/R/migrate.R
+++ b/R/migrate.R
@@ -266,6 +266,7 @@ migrate_clean <- function(config, dry_run) {
               sprintf("%d backup files to delete (%s)", length(files), size))
   if (!dry_run) {
     file.remove(files)
+    orderly_log("clean", "...files deleted")
   }
   invisible()
 }

--- a/man/orderly_migrate.Rd
+++ b/man/orderly_migrate.Rd
@@ -5,7 +5,7 @@
 \title{Migrate an orderly archive}
 \usage{
 orderly_migrate(root = NULL, locate = TRUE, to = NULL,
-  dry_run = FALSE, skip_failed = FALSE)
+  dry_run = FALSE, skip_failed = FALSE, clean = FALSE)
 }
 \arguments{
 \item{root}{The path to an orderly root directory, or \code{NULL}
@@ -31,6 +31,11 @@ useful on local archives only because it violates the
 append-only nature of orderly.  However, if a local archive
 contains unusual copies of orderly archives that can't be
 migrated this might come in helpful.}
+
+\item{clean}{Logical, where \code{TRUE} (and where the migration
+was successful and \code{dry_run} is \code{FALSE}) orderly will
+clean up all migration backup files.  Use this periodically to
+clean up the archive.}
 }
 \description{
 Migrate an orderly archive.  This is needed periodically when the

--- a/tests/testthat/test-main.R
+++ b/tests/testthat/test-main.R
@@ -226,6 +226,7 @@ test_that("migrate", {
   res <- cli_args_process(args)
   expect_equal(res$command, "migrate")
   expect_false(res$options$dry_run)
+  expect_false(res$options$clean)
   expect_null(res$options$to)
   expect_identical(res$target, main_do_migrate)
 
@@ -237,10 +238,11 @@ test_that("migrate", {
 
 test_that("migrate: args", {
   path <- prepare_orderly_example("minimal")
-  args <- c("--root", path, "migrate", "--to", "0.3.3", "--dry-run")
+  args <- c("--root", path, "migrate", "--to", "0.3.3", "--dry-run", "--clean")
   res <- cli_args_process(args)
   expect_equal(res$command, "migrate")
   expect_true(res$options$dry_run)
+  expect_true(res$options$clean)
   expect_equal(res$options$to, "0.3.3")
   expect_identical(res$target, main_do_migrate)
 })

--- a/tests/testthat/test-migrate.R
+++ b/tests/testthat/test-migrate.R
@@ -499,3 +499,28 @@ test_that("migrate => 0.7.15", {
   tab <- DBI::dbReadTable(con, "file_input_global")
   expect_equal(nrow(tab), 1)
 })
+
+
+test_that("clean up migrations", {
+  oo <- options(orderly.nowarnings = TRUE)
+  on.exit(options(oo))
+
+  path <- unpack_reference("0.6.0")
+  files <- list.files(path, "^orderly_run_([0-9]+\\.){3}rds",
+                      recursive = TRUE, full.names = TRUE)
+  expect_true(length(files) == 0)
+  orderly_migrate(path, to = "0.7.15", clean = FALSE)
+  files <- list.files(path, "^orderly_run_([0-9]+\\.){3}rds",
+                      recursive = TRUE, full.names = TRUE)
+  expect_true(length(files) > 0)
+
+  orderly_migrate(path, to = "0.7.15", clean = TRUE, dry_run = TRUE)
+  expect_true(all(file.exists(files)))
+
+  orderly_migrate(path, to = "0.7.15", clean = TRUE)
+  expect_false(any(file.exists(files)))
+
+  files <- list.files(path, "^orderly_run_([0-9]+\\.){3}rds",
+                      recursive = TRUE, full.names = TRUE)
+  expect_equal(files, character(0))
+})


### PR DESCRIPTION
This PR will add an option to `orderly_migrate` (and the cli) to clean up old migration backup files (like `orderly_run_0.6.0.rds`). These clutter up the downloaded zips and should be safe to delete eventually