### PR TITLE
VIMC-2413: Allow default parameter values

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 0.8.0
+Version: 0.8.1
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# 0.8.1
+
+* Parameters now accept defaults in `orderly.yml`, and the format has altered slightly (VIMC-2413, #8).
+
 # 0.8.0
 
 * Deprecated functions `pull_archive`, `pull_dependencies`, `set_default_remote` have been removed (VIMC-2946, deprecated in VIMC-2944 / 0.7.2).

--- a/R/recipe_read.R
+++ b/R/recipe_read.R
@@ -449,7 +449,7 @@ recipe_read_check_parameters <- function(parameters, filename) {
   }
 
   name <- function(p) {
-    sprintf("%s:parameters:%s", p)
+    sprintf("%s:parameters:%s", filename, p)
   }
 
   assert_named(parameters, TRUE, sprintf("%s:parameters", filename))

--- a/R/recipe_read.R
+++ b/R/recipe_read.R
@@ -13,7 +13,7 @@ recipe_read <- function(path, config, validate = TRUE) {
   optional <- c("displayname",
                 "description",
                 "data",
-                "parameters", # character >= 1
+                "parameters",
                 "views",
                 "packages",
                 "sources",
@@ -43,9 +43,7 @@ recipe_read <- function(path, config, validate = TRUE) {
 
   assert_scalar_character(info$script, fieldname("script"))
 
-  if (!is.null(info$parameters)) {
-    assert_character(info$parameters, fieldname("parameters"))
-  }
+  info$parameters <- recipe_read_check_parameters(info$parameters, filename)
   if (!is.null(info$packages)) {
     assert_character(info$packages, fieldname("packages"))
   }
@@ -432,4 +430,32 @@ recipe_read_query <- function(field, info, filename, config) {
     info[[field]] <- d
   }
   info
+}
+
+
+recipe_read_check_parameters <- function(parameters, filename) {
+  if (is.null(parameters) || length(parameters) == 0L) {
+    return(NULL)
+  }
+
+  if (is.character(parameters)) {
+    msg <- c("Use of strings for parameters: is deprecated and will be",
+             "removed in a future orderly version - please use",
+             "'name: ~' for each parameter instead (or add a default).",
+             "See the main package vignette for details")
+    orderly_warning(flow_text(msg))
+    parameters <- set_names(rep(list(NULL), length(parameters)),
+                            parameters)
+  }
+
+  name <- function(p) {
+    sprintf("%s:parameters:%s", p)
+  }
+
+  assert_named(parameters, TRUE, sprintf("%s:parameters", filename))
+  for (p in names(parameters)) {
+    check_fields(parameters[[p]], name(p), NULL, "default")
+  }
+
+  parameters
 }

--- a/inst/examples/demo/src/other/orderly.yml
+++ b/inst/examples/demo/src/other/orderly.yml
@@ -2,7 +2,7 @@ data:
   extract:
     query: SELECT name, number FROM thing WHERE number > ?nmin
 parameters:
-  nmin
+  nmin: ~
 script: script.R
 sources:
   - functions.R

--- a/inst/examples/example/src/example/orderly.yml
+++ b/inst/examples/example/src/example/orderly.yml
@@ -2,7 +2,7 @@ data:
   cars:
     query: SELECT * FROM mtcars WHERE cyl = ?cyl
 parameters:
-  - cyl
+  cyl: ~
 script: script.R
 artefacts:
   - staticgraph:

--- a/inst/examples/interactive/src/count_param/orderly.yml
+++ b/inst/examples/interactive/src/count_param/orderly.yml
@@ -3,8 +3,8 @@ data:
     query: SELECT name, number FROM thing
 script: script.R
 parameters:
-  - time
-  - poll
+  time: ~
+  poll: ~
 artefacts:
   staticgraph:
     description: A graph of things

--- a/inst/examples/other/src/other/orderly.yml
+++ b/inst/examples/other/src/other/orderly.yml
@@ -2,7 +2,7 @@ data:
   extract:
     query: SELECT name, number FROM thing WHERE number > ?nmin
 parameters:
-  nmin
+  nmin: ~
 script: script.R
 artefacts:
   - data:

--- a/inst/examples/parameters/src/example/orderly.yml
+++ b/inst/examples/parameters/src/example/orderly.yml
@@ -1,9 +1,10 @@
 data: ~
 script: script.R
 parameters:
-  - a
-  - b
-  - c
+  a: ~
+  b: ~
+  c:
+    default: 1
 artefacts:
   data:
     description: A graph of things

--- a/inst/orderly_example.yml
+++ b/inst/orderly_example.yml
@@ -63,8 +63,15 @@ artefacts: ~
 # description:
 
 # Optional parameters to the report.  These will be substituted into
-# the SQL queries.  This interface might change at some point.  Must
-# be a string or array of strings.
+# the SQL queries.  For example:
+#
+# parameters:
+#   a:
+#     default: 1
+#   b: ~
+#
+# would declare a parameter called 'a' with a default value of 1, and
+# a parameter of b with no default.
 #
 # parameters:
 

--- a/tests/testthat/example_report.yml
+++ b/tests/testthat/example_report.yml
@@ -18,7 +18,7 @@ data:
         helper.value >= ?minvalue
 
 parameters:
-  - minvalue
+  minvalue: ~
 
 script: script.R
 

--- a/tests/testthat/test-orderly.R
+++ b/tests/testthat/test-orderly.R
@@ -189,3 +189,17 @@ test_that("onload can be rerun", {
   orderly:::.onLoad()
   expect_equal(cache$current_archive_version, v)
 })
+
+
+test_that("default parameter values are used", {
+  path <- prepare_orderly_example("parameters")
+
+  id <- orderly_run("example", list(a = 1, b = 2), root = path, echo = FALSE)
+  d <- readRDS(path_orderly_run_rds(file.path(path, "draft", "example", id)))
+  expect_equal(d$meta$parameters, list(a = 1, b = 2, c = 1))
+
+  id <- orderly_run("example", list(a = 1, b = 2, c = 3),
+                    root = path, echo = FALSE)
+  d <- readRDS(path_orderly_run_rds(file.path(path, "draft", "example", id)))
+  expect_equal(d$meta$parameters, list(a = 1, b = 2, c = 3))
+})

--- a/tests/testthat/test-recipe-read.R
+++ b/tests/testthat/test-recipe-read.R
@@ -426,3 +426,27 @@ test_that("old style global resources deprecated", {
     res$global_resources,
     c(data.csv = "data.csv"))
 })
+
+
+test_that("read parameters", {
+  path <- prepare_orderly_example("parameters")
+  path_example <- file.path(path, "src", "example")
+  info <- recipe_read(path_example, orderly_config(path))
+  expect_equal(info$parameters,
+               list(a = NULL, b = NULL, c = list(default = 1)))
+})
+
+
+test_that("read old-style", {
+  path <- prepare_orderly_example("parameters")
+  path_example <- file.path(path, "src", "example")
+  path_orderly <- file.path(path_example, "orderly.yml")
+  dat <- yaml_read(path_orderly)
+  dat$parameters <- list("a", "b", "c")
+  yaml_write(dat, path_orderly)
+  expect_warning(
+    info <- recipe_read(path_example, orderly_config(path)),
+    "Use of strings for parameters: is deprecated")
+  expect_equal(info$parameters,
+               list(a = NULL, b = NULL, c = NULL))
+})

--- a/tests/testthat/test-recipe-read.R
+++ b/tests/testthat/test-recipe-read.R
@@ -437,7 +437,7 @@ test_that("read parameters", {
 })
 
 
-test_that("read old-style", {
+test_that("read old-style parameters", {
   path <- prepare_orderly_example("parameters")
   path_example <- file.path(path, "src", "example")
   path_orderly <- file.path(path_example, "orderly.yml")
@@ -449,4 +449,20 @@ test_that("read old-style", {
     "Use of strings for parameters: is deprecated")
   expect_equal(info$parameters,
                list(a = NULL, b = NULL, c = NULL))
+})
+
+
+test_that("validate parameters", {
+  path <- prepare_orderly_example("parameters")
+  path_example <- file.path(path, "src", "example")
+  path_orderly <- file.path(path_example, "orderly.yml")
+  config <- orderly_config(path)
+
+  dat <- yaml_read(path_orderly)
+  dat$parameters <- list(a = list(something = 1))
+  yaml_write(dat, path_orderly)
+
+  expect_error(
+    recipe_read(path_example, config),
+    "Unknown fields in .*orderly.yml:parameters:a: something")
 })

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -8,7 +8,7 @@ test_that("minimal", {
   config <- orderly_config(path)
   info <- recipe_read(file.path(path, "src/example"), config)
   data <- recipe_data(config, info, NULL, new.env(parent = .GlobalEnv))
-  expect_is(data$dat, "data.frame")
+  expect_is(data$dest$dat, "data.frame")
 
   expect_error(
     recipe_data(config, info, list(a = 1), new.env(parent = .GlobalEnv)),

--- a/vignettes/orderly.Rmd
+++ b/vignettes/orderly.Rmd
@@ -409,6 +409,36 @@ versions of the same report. Since including the dashes will never
 cause a problem but omitting them might, we advise that they should
 always be included.
 
+## Parameterised reports
+
+Sometimes it can be useful to control how a report runs by a parameter.  This could be the name of a country that an analysis applies to (though we hope to develop a better interface for this soon) through to controlling the number of iterations that an analysis runs for.  Parameters are declared in the `orderly.yml` like:
+
+```yaml
+parameters:
+  a:
+    default: 1
+  b: ~
+```
+
+This would declare that a report takes two parameters `a` (with a default of 1), and `b` (with no default).  Running the report would then look like:
+
+```r
+orderly::orderly_run("reportname", list(a = 10, b = 100))
+```
+
+These parameters are then present in the environment of the report, so the code can use values `a` and `b`.
+
+The parameters will also be interpolated into any SQL queries before they are run, so if the `orderly.yml` contains:
+
+```yaml
+data:
+  cars:
+    query: SELECT * FROM mtcars WHERE cyl > ?a
+```
+
+then this will be evaluated on the SQL server with `a` substituted in where the query says `?a` (this is done with `DBI::sqlInterpolate`).
+
+
 ## Using global resources
 
 There might be files that are used in (almost) every report.  Examples


### PR DESCRIPTION
This PR allows `orderly.yml` to specify parameter values.  This was requested a long time ago in #8

With the new deprecated functionality approach we've used for similar changes this is fairly straightforward to implement, and it will be less painful to do this change before the initial release.