### PR TITLE
Skip git tests in test-util (163,165,167)

### DIFF
--- a/tests/testthat/helper-orderly.R
+++ b/tests/testthat/helper-orderly.R
@@ -5,6 +5,7 @@ with_wd <- function(path, code) {
 }
 
 skip_if_no_git <- function() {
+  testthat::skip_on_cran()
   if (nzchar(Sys.which("git"))) {
     return()
   }

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -146,7 +146,6 @@ test_that("which_max_time", {
 test_that("git", {
   skip_if_no_git()
   skip_on_appveyor() # needs some git work
-  testthat::skip_on_cran()
 
   path <- tempfile()
   code <- system2("git", c("init", path), stdout = FALSE, stderr = FALSE)
@@ -175,7 +174,6 @@ test_that("git", {
 })
 
 test_that("git_info non-cran", {
-  skip_on_cran()
   skip_if_no_git()
 
   path <- unzip_git_demo()

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -146,6 +146,7 @@ test_that("which_max_time", {
 test_that("git", {
   skip_if_no_git()
   skip_on_appveyor() # needs some git work
+  testthat::skip_on_cran()
 
   path <- tempfile()
   code <- system2("git", c("init", path), stdout = FALSE, stderr = FALSE)


### PR DESCRIPTION
We skip_if_no_git() twice - both in test-util.R (in this PR, lines 147, 177).
In both cases, we want to skip on cran - hence I've moved the existing
skip_on_cran() from one of those functions into the top of skip_if_no_git()
(in helper-orderly.R), and now it covers both cases.