### PR TITLE
VIMC-3130: Exclude potentially sensitive environment variables

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -16,3 +16,4 @@
 ^man-roxygen$
 ^reference$
 ^README\.md\.in$
+^orderly_.*\.tar\.gz$

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ build
 docs
 tests/testthat/montagu-reports
 tests/testthat/reference/*.zip
+orderly_*.tar.gz

--- a/R/util.R
+++ b/R/util.R
@@ -212,7 +212,9 @@ last <- function(x) {
 
 orderly_env <- function() {
   env <- Sys.getenv()
-  as.list(env[grepl("^ORDERLY_", names(env))])
+  nms <- names(env)
+  i <- grepl("^ORDERLY_", nms) & !grepl("(TOKEN|PAT|PASS)", nms)
+  as.list(env[i])
 }
 
 session_info <- function(path = ".") {

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -588,3 +588,27 @@ test_that("pretty_bytes", {
   expect_equal(pretty_bytes(12345678901), "12.35 GB")
   expect_equal(pretty_bytes(123456789012), "123.46 GB")
 })
+
+
+test_that("orderly_env picks up ORDERLY variables", {
+  env <- c("ORDERLY_A" = "a", "ORDERLY_B" = "b")
+  v <- withr::with_envvar(
+    env,
+    orderly_env())
+  expect_true(all(names(env) %in% names(v)))
+  expect_equal(v[names(env)], as.list(env))
+})
+
+
+test_that("orderly_env excludes sensitive data", {
+  env1 <- c("ORDERLY_SERVER_PASSWORD" = "passw0rd",
+           "ORDERLY_SERVER_TOKEN" = "secr7et",
+           "ORDERLY_GITHUB_PAT" = "pat")
+  env2 <- c("ORDERLY_A" = "a", "ORDERLY_B" = "b")
+  v <- withr::with_envvar(
+    c(env1, env2),
+    orderly_env())
+  expect_false(any(names(env1) %in% names(v)))
+  expect_true(all(names(env2) %in% names(v)))
+  expect_equal(v[names(env2)], as.list(env2))
+})


### PR DESCRIPTION
This PR reduces the number of orderly-related environment variables that will be recorded alongside the metadata. Previously we'd grabbed everything starting with `ORDERLY_` but that's a bit much if there are any orderly web related secrets.

I've checked and we're ok on science/uat with this, but it seems worth excluding the most obviously bad cases here for now