### PR TITLE
VIMC-3105: use remote to compute url for slack 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 0.8.1
+Version: 0.8.2
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/R/config.R
+++ b/R/config.R
@@ -159,8 +159,11 @@ config_check_remote <- function(dat, filename) {
 
     ## optionals:
     if (!is.null(remote$url)) {
-      assert_scalar_character(remote$url, field_name("url"))
-      remote$url <- sub("/$", "", remote$url)
+      msg <- c("The 'url' field (used in",
+               sprintf("%s:remote:%s", filename, name),
+               "is deprecated and will be dropped in a future version of",
+               "orderly.  Please remove it from your orderly_config.yml")
+      orderly_warning(flow_text(msg))
     }
     if (!is.null(remote$slack_url)) {
       assert_scalar_character(remote$slack_url, field_name("slack_url"))

--- a/R/remote.R
+++ b/R/remote.R
@@ -318,7 +318,8 @@ implements_remote <- function(x) {
     is.function(x$list_reports) &&
     is.function(x$list_versions) &&
     is.function(x$pull) &&
-    is.function(x$run)
+    is.function(x$run) &&
+    is.function(x$url_report)
 }
 
 

--- a/R/remote_path.R
+++ b/R/remote_path.R
@@ -65,6 +65,6 @@ R6_orderly_remote_path <- R6::R6Class(
     },
 
     url_report = function(name, id) {
-      file.path(self$config$root, name, id, fsep ="/")
+      file.path(self$config$root, name, id, fsep = "/")
     }
   ))

--- a/R/remote_path.R
+++ b/R/remote_path.R
@@ -62,5 +62,9 @@ R6_orderly_remote_path <- R6::R6Class(
 
     run = function(...) {
       stop("'orderly_remote_path' remotes do not run")
+    },
+
+    url_report = function(name, id) {
+      file.path(self$config$root, name, id, fsep ="/")
     }
   ))

--- a/R/slack.R
+++ b/R/slack.R
@@ -2,16 +2,21 @@
 slack_post_success <- function(dat, config) {
   if (!is.null(config$remote_identity)) {
     remote <- config$remote[[config$remote_identity]]
+
     slack_url <- resolve_secrets(remote$slack_url, config)[[1L]]
+
+    driver <- get_remote(config$remote_identity, config)
+    report_url <- driver$url_report(dat$meta$name, dat$meta$id)
+
     if (!is.null(slack_url)) {
-      data <- slack_data(dat, remote$name, remote$url, remote$primary)
+      data <- slack_data(dat, remote$name, report_url, remote$primary)
       do_slack_post_success(slack_url, data)
     }
   }
 }
 
 
-slack_data <- function(dat, remote_name, remote_url, remote_is_primary) {
+slack_data <- function(dat, remote_name, report_url, remote_is_primary) {
   id <- dat$meta$id
   name <- dat$meta$name
   elapsed <- format(as.difftime(dat$meta$elapsed, units = "secs"), digits = 2)
@@ -29,7 +34,6 @@ slack_data <- function(dat, remote_name, remote_url, remote_is_primary) {
     git <- sprintf("%s@%s", branch, sha)
   }
 
-  report_url <- sprintf("%s/reports/%s/%s/", remote_url, name, id)
   title <- sprintf("Ran report '%s'", name)
   text <- sprintf("on server *%s* in %s", remote_name, elapsed)
   fallback <- sprintf("Ran '%s' as '%s'; view at %s", name, id, report_url)

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -258,3 +258,23 @@ test_that("warn when reading old-style db config", {
     list(orderly.nowarnings = TRUE),
     expect_warning(orderly_config(path), NA))
 })
+
+
+test_that("warn when using url in remote definition", {
+  path <- prepare_orderly_example("minimal")
+  append_lines(c(
+    "remote:",
+    "  testing:",
+    "    driver: orderly::orderly_remote_path",
+    "    url: https://example.com",
+    "    args:",
+    sprintf("      path: %s", path),
+    "    slack_url: https://httpbin.org/post"),
+    file.path(path, "orderly_config.yml"))
+  expect_warning(
+    orderly_config(path),
+    "deprecated and will be dropped")
+  withr::with_options(
+    list(orderly.nowarnings = TRUE),
+    expect_warning(orderly_config(path), NA))
+})

--- a/tests/testthat/test-remote-path.R
+++ b/tests/testthat/test-remote-path.R
@@ -157,3 +157,11 @@ test_that("pull report with dependencies", {
   on.exit(DBI::dbDisconnect(con))
   expect_setequal(d$id, DBI::dbReadTable(con, "report_version")$id)
 })
+
+
+test_that("remote_path implements url_report", {
+  path <- prepare_orderly_example("minimal")
+  remote <- orderly_remote_path(path)
+  expect_equal(remote$url_report("name", "id"),
+               file.path(path, "name", "id", fsep = "/"))
+})

--- a/tests/testthat/test-remote-path.R
+++ b/tests/testthat/test-remote-path.R
@@ -163,5 +163,5 @@ test_that("remote_path implements url_report", {
   path <- prepare_orderly_example("minimal")
   remote <- orderly_remote_path(path)
   expect_equal(remote$url_report("name", "id"),
-               file.path(path, "name", "id", fsep = "/"))
+               file.path(remote$config$root, "name", "id", fsep = "/"))
 })

--- a/tests/testthat/test-slack.R
+++ b/tests/testthat/test-slack.R
@@ -10,10 +10,10 @@ test_that("slack payload is correct", {
                           id = "20181213-123456-fedcba98",
                           name = "example"),
               git = NULL)
-  d <- slack_data(dat, server_name, server_url, server_is_primary)
-
   report_url <- sprintf("%s/reports/%s/%s/", server_url,
                         dat$meta$name, dat$meta$id)
+  d <- slack_data(dat, server_name, report_url, server_is_primary)
+
   expect_equal(
     d,
     list(

--- a/tests/testthat/test-slack.R
+++ b/tests/testthat/test-slack.R
@@ -55,7 +55,9 @@ test_that("git information is collected correctly", {
                           id = "20181213-123456-fedcba98",
                           name = "example"),
               git = NULL)
-  d <- slack_data(dat, server_name, server_url, server_is_primary)
+  report_url <- sprintf("%s/reports/%s/%s/", server_url,
+                        dat$meta$name, dat$meta$id)
+  d <- slack_data(dat, server_name, report_url, server_is_primary)
 
   expect_equal(length(d$attachments[[1]]$fields), 1L)
 
@@ -63,7 +65,7 @@ test_that("git information is collected correctly", {
                           id = "20181213-123456-fedcba98",
                           name = "example"),
               git = list(branch = "master", sha_short = "abcdefg"))
-  d <- slack_data(dat, server_name, server_url, server_is_primary)
+  d <- slack_data(dat, server_name, report_url, server_is_primary)
   expect_equal(length(d$attachments[[1]]$fields), 2L)
   expect_equal(d$attachments[[1]]$fields[[2L]],
                list(title = "git", value = "master@abcdefg", short = TRUE))
@@ -73,7 +75,7 @@ test_that("git information is collected correctly", {
                           name = "example"),
               git = list(branch = "master", sha_short = "abcdefg",
                          github_url = "https://github.com/vimc/repo"))
-  d <- slack_data(dat, server_name, server_url, server_is_primary)
+  d <- slack_data(dat, server_name, report_url, server_is_primary)
   expect_equal(
     d$attachments[[1]]$fields[[2]]$value,
     paste0("<https://github.com/vimc/repo/tree/master|master>@",
@@ -91,7 +93,9 @@ test_that("git information works in detached head mode", {
                           name = "example"),
               git = list(branch = NULL, sha_short = "abcdefg",
                          github_url = "https://github.com/vimc/repo"))
-  d <- slack_data(dat, server_name, server_url, server_is_primary)
+  report_url <- sprintf("%s/reports/%s/%s/", server_url,
+                        dat$meta$name, dat$meta$id)
+  d <- slack_data(dat, server_name, report_url, server_is_primary)
   expect_equal(
     d$attachments[[1]]$fields[[2]]$value,
     "(detached)@<https://github.com/vimc/repo/tree/abcdefg|abcdefg>")
@@ -106,8 +110,10 @@ test_that("primary server changes colour", {
                           id = "20181213-123456-fedcba98",
                           name = "example"),
               git = NULL)
-  d1 <- slack_data(dat, server_name, server_url, TRUE)
-  d2 <- slack_data(dat, server_name, server_url, FALSE)
+  report_url <- sprintf("%s/reports/%s/%s/", server_url,
+                        dat$meta$name, dat$meta$id)
+  d1 <- slack_data(dat, server_name, report_url, TRUE)
+  d2 <- slack_data(dat, server_name, report_url, FALSE)
   expect_equal(d1$attachments[[1]]$color, "good")
   expect_equal(d2$attachments[[1]]$color, "warning")
   d2$attachments[[1]]$color <- d1$attachments[[1]]$color
@@ -125,7 +131,9 @@ test_that("sending messages is not a failure", {
                           id = "20181213-123456-fedcba98",
                           name = "example"),
               git = NULL)
-  d <- slack_data(dat, server_name, server_url, server_is_primary)
+  report_url <- sprintf("%s/reports/%s/%s/", server_url,
+                        dat$meta$name, dat$meta$id)
+  d <- slack_data(dat, server_name, report_url, server_is_primary)
 
   slack_url <- "https://httpbin.org/status/403"
   expect_message(do_slack_post_success(slack_url, d),
@@ -173,13 +181,11 @@ test_that("main interface", {
     "    args:",
     sprintf("      path: %s", path),
     "    slack_url: https://httpbin.org/post",
-    "    url: https://example.com",
     "  production:",
     "    driver: orderly::orderly_remote_path",
     "    args:",
     sprintf("      path: %s", path),
     "    slack_url: https://httpbin.org/post",
-    "    url: https://example.com",
     "    primary: true"),
     file.path(path, "orderly_config.yml"))
 
@@ -197,7 +203,7 @@ test_that("main interface", {
   d <- httr::content(r)
   expect_equal(d$json$attachments[[1]]$color, "good") # primary
   expect_equal(d$json$attachments[[1]]$actions[[1]]$url,
-               "https://example.com/reports/example/20181213-123456-fedcba98/")
+               file.path(path, "example", dat$meta$id, fsep = "/"))
 
   config <- withr::with_envvar(
     c("ORDERLY_API_SERVER_IDENTITY" = "testing"),
@@ -237,9 +243,9 @@ test_that("slack payload is correct given actual run data", {
   server_is_primary <- FALSE
   server_name <- "myserver"
 
-  d <- slack_data(dat, server_name, server_url, server_is_primary)
-
-  report_url <- sprintf("%s/reports/%s/%s/", server_url, "minimal", id)
+  report_url <- sprintf("%s/reports/%s/%s/", server_url,
+                        dat$meta$name, dat$meta$id)
+  d <- slack_data(dat, server_name, report_url, server_is_primary)
   git_info <- sprintf("%s@%s", dat$git$branch, dat$git$sha_short)
 
   expect_equal(d$username, "orderly")

--- a/tests/testthat/test-slack.R
+++ b/tests/testthat/test-slack.R
@@ -135,19 +135,29 @@ test_that("sending messages is not a failure", {
 
 test_that("main interface", {
   skip_if_no_internet()
-  dat <- list(meta = list(elapsed = 10,
-                          id = "20181213-123456-fedcba98",
-                          name = "example"),
+  skip_if_not_installed("jsonlite")
+
+  path <- prepare_orderly_example("minimal")
+  id <- "20181213-123456-fedcba98"
+  name <- "example"
+  dat <- list(meta = list(elapsed = 10, id = id, name = name),
               git = NULL)
+
   config <- list(remote_identity = "myserver",
                  remote = list(
                    myserver = list(
+                     driver = c("orderly", "orderly_remote_path"),
+                     args = list(path = path),
                      slack_url = "https://httpbin.org/post",
                      name = "myserver",
                      primary = FALSE,
                      url = "https://example.com")))
   r <- slack_post_success(dat, config)
+
   expect_equal(r$status_code, 200L)
+  res <- jsonlite::fromJSON(httr::content(r)$data, FALSE)
+  expect_equal(res$attachments[[1]]$actions[[1]]$url,
+               orderly_remote_path(path)$url_report(name, id))
 })
 
 


### PR DESCRIPTION
This PR removes the last bit of montagu-specific details (I hope!) from orderly by using the `report_url` method of orderly remotes.

As implemented in orderlyweb via https://github.com/vimc/orderlyweb/pull/5 (VIMC-3168) and in the `orderly_remote_file` remote included in orderly.

Update to montagu-reports is here: https://github.com/vimc/montagu-reports/pull/345
