### PR TITLE
VIMC-3205: Don't check case in orderly_test_check

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.0.1
+Version: 1.0.2
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# orderly 1.0.2
+
+* `orderly::orderly_test_check` is no longer case sensitive with paths, preventing issues when used from directories that do not have canonical casing (VIMC-3205)
+
 # orderly 1.0.1
 
 * In orderly to comply with CRAN policies, the functionality of `orderly::orderly_test_start` and related functions has been severely reduced.  Functions `orderly::orderly_test_end` and `orderly::orderly_test_restart` have been removed and `orderly::orderly_test_start` no longer directly provides a useable environment for testing reports (VIMC-3178).

--- a/R/recipe_test.R
+++ b/R/recipe_test.R
@@ -92,7 +92,7 @@ orderly_test_start <- function(name, parameters = NULL, envir = parent.frame(),
 ##' @param path Path to the report that is currently being run
 orderly_test_check <- function(path = NULL) {
   path <- path %||% getwd()
-  assert_is_directory(path)
+  assert_is_directory(path, FALSE)
   info <- cache$test[[normalizePath(path)]]
   if (is.null(info)) {
     stop(sprintf("Not running in test mode (for path %s)", path))

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -350,7 +350,10 @@ test_that("test mode artefacts", {
 
 
 test_that("orderly_test_check requires test mode", {
-  expect_error(orderly_test_check(), "Not running in test mode")
+  p <- tempfile()
+  dir.create(p)
+  on.exit(unlink(p, recursive = TRUE))
+  expect_error(orderly_test_check(p), "Not running in test mode")
 })
 
 


### PR DESCRIPTION
This PR is in response to a CRAN request:

> Dear package maintainer,
> 
> your package orderly_1.0.1.tar.gz did *not* pass 'R CMD check' on
> Windows and will be omitted from the corresponding CRAN directory.
> Please check the attached log-file and submit a version
> with increased version number that passes R CMD check on Windows.
>
> R version 3.6.1 (2019-07-05)

```
* checking for unstated dependencies in 'tests' ... OK
* checking tests ... [173s] ERROR
  Running 'testthat.R' [172s]
Running the tests in 'tests/testthat.R' failed.
Complete output:
  > library(testthat)
  > library(orderly)
  > 
  > test_check("orderly")
  -- 1. Failure: orderly_test_check requires test mode (@test-run.R#353)  --------
  `orderly_test_check()` threw an error with unexpected message.
  Expected match: "Not running in test mode"
  Actual message: "File does not exist: 'd:/Rcompile/CRANpkg/local/3.6/orderly.Rcheck/tests/testthat' (should be 'd:/RCompile/CRANpkg/local/3.6/orderly.Rcheck/tests/testthat')"
  
  == testthat results  ===========================================================
  [ OK: 792 | SKIPPED: 82 | WARNINGS: 0 | FAILED: 1 ]
  1. Failure: orderly_test_check requires test mode (@test-run.R#353) 
  
  Error: testthat unit tests failed
  Execution halted
* checking for unstated dependencies in vignettes ... OK
* checking package vignettes in 'inst/doc' ... OK
* checking re-building of vignette outputs ... [10s] OK
* checking PDF version of manual ... OK
* DONE
```
