### PR TITLE
vimc-3226: Strip leading src/ when running reports

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,8 @@
-# orderly 1.0.2
+# orderly 1.0.3
+
+* `orderly::orderly_run` now strips a leading `src/` if provided, allowing easier tab-completion of report names (VIMC-3226).
+
+# orderly 1.0.2 (CRAN)
 
 * `orderly::orderly_test_check` is no longer case sensitive with paths, preventing issues when used from directories that do not have canonical casing (VIMC-3205)
 

--- a/R/recipe_run.R
+++ b/R/recipe_run.R
@@ -30,7 +30,8 @@
 ##' @title Run a report
 ##'
 ##' @param name Name of the report to run (see
-##'   \code{\link{orderly_list}}).
+##'   \code{\link{orderly_list}}).  A leading \code{src/} will be
+##'   removed if provided, allowing easier use of autocomplete.
 ##'
 ##' @param parameters Parameters passed to the report. A named list of
 ##'   parameters declared in the \code{orderly.yml}.
@@ -90,6 +91,10 @@ orderly_run <- function(name, parameters = NULL, envir = NULL,
   envir <- orderly_environment(envir)
   config <- orderly_config_get(root, locate)
   config <- check_orderly_archive_version(config)
+
+  if (grepl("^src/.+", name)) {
+    name <- sub("^src/", "", name)
+  }
 
   info <- recipe_prepare(config, name, id_file, ref, fetch, message)
 

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -760,3 +760,10 @@ test_that("prevent duplicate filenames", {
     orderly_run("depend", root = path, echo = FALSE),
     "Orderly configuration implies duplicate files:\\s+- previous.rds:")
 })
+
+
+test_that("allow src/ in report name during run", {
+  path <- prepare_orderly_example("minimal")
+  id <- orderly_run("src/example", root = path, echo = FALSE)
+  expect_true(file.exists(file.path(path, "draft", "example", id)))
+})


### PR DESCRIPTION
`orderly::orderly_run` now strips a leading `src/` if provided, allowing easier tab-completion of report names (VIMC-3226).