### PR TITLE
vimc-3373: Update R version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocker/r-ver:3.5.3
+FROM rocker/r-ver:3.6.2
 
 RUN apt-get update && apt-get -y install \
   git \


### PR DESCRIPTION
This is required in order to support the `Hmisc` package which has a dependency `latticeExtra` which depends on R >= 3.6.0 - I think this should be quite safe to upgrade by now