### PR TITLE
vimc-3375: Save random seed alongside metadata

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.0.4
+Version: 1.0.5
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# orderly 1.0.5
+
+* The metadata now includes the state of `.Random.seed`, if present (VIMC-3375)
+
 # orderly 1.0.3
 
 * `orderly::orderly_test_start` prints instructions that are pasteable on windows -- previously they may have contained backslashes (VIMC-3251).

--- a/R/recipe_run.R
+++ b/R/recipe_run.R
@@ -221,6 +221,7 @@ recipe_run <- function(info, parameters, envir, config, echo = TRUE) {
                extra_fields = extra_fields,
                connection = !is.null(info$connection),
                packages = info$packages,
+               random_seed = prep$random_seed,
                file_info_inputs = info$inputs,
                file_info_artefacts = file_info_artefacts,
                global_resources = info$global_resources,
@@ -503,7 +504,7 @@ orderly_prepare_data <- function(config, info, parameters, envir) {
   }
 
   ret <- list(data = res$data, parameters = res$parameters,
-              n_dev = n_dev, n_sink = n_sink)
+              n_dev = n_dev, n_sink = n_sink, random_seed = random_seed())
 
   if (!is.null(info$connection)) {
     ## NOTE: this is a copy of exported connections so that we can

--- a/R/util.R
+++ b/R/util.R
@@ -712,3 +712,8 @@ pretty_bytes <- function(bytes) {
 clean_path <- function(path) {
   gsub("\\", "/", path, fixed = TRUE)
 }
+
+
+random_seed <- function(envir = globalenv()) {
+  envir$.Random.seed
+}

--- a/tests/testthat/test-orderly.R
+++ b/tests/testthat/test-orderly.R
@@ -203,3 +203,14 @@ test_that("default parameter values are used", {
   d <- readRDS(path_orderly_run_rds(file.path(path, "draft", "example", id)))
   expect_equal(d$meta$parameters, list(a = 1, b = 2, c = 3))
 })
+
+
+test_that("store random seed", {
+  skip_on_cran_windows()
+  path <- prepare_orderly_example("minimal")
+  set.seed(1)
+  rs <- .Random.seed
+  id <- orderly_run("example", root = path, echo = FALSE)
+  d <- readRDS(path_orderly_run_rds(file.path(path, "draft", "example", id)))
+  expect_true(identical(d$meta$random_seed, rs))
+})

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -630,3 +630,12 @@ test_that("clean_path", {
   expect_equal(clean_path("c:\\My Documents/Projects\\whatever"),
                "c:/My Documents/Projects/whatever")
 })
+
+
+test_that("random_seed", {
+  e1 <- new.env(parent = emptyenv())
+  e2 <- new.env(parent = e1)
+  e1$.Random.seed <- pi
+  expect_equal(random_seed(e1), pi)
+  expect_null(random_seed(e2))
+})


### PR DESCRIPTION
As discussed with the coronavirus group, this would allow some (somewhat) automated workflows for reproducing stochastic analyses, even if `set.seed` is not used.

If we store `.Random.seed` then we can in theory restore the state of the RNG:

```r
> set.seed(1)
> rs <- .Random.seed
> runif(10)
 [1] 0.26550866 0.37212390 0.57285336 0.90820779 0.20168193 0.89838968
 [7] 0.94467527 0.66079779 0.62911404 0.06178627
> .Random.seed <- rs
> runif(10)
 [1] 0.26550866 0.37212390 0.57285336 0.90820779 0.20168193 0.89838968
 [7] 0.94467527 0.66079779 0.62911404 0.06178627
```

There's no support for automatically using this on rerun (and reports where this is important should use the `set.seed()` functionality, which is preferred) but we can look at restoring it when doing VIMC-3378 