### PR TITLE
vimc-3377: more flexible draft selection

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.0.6
+Version: 1.0.7
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# orderly 1.0.7
+
+* More flexible control of use of draft reports, using the argument `use_draft` to `orderly_run` and `orderly_test_start`.  This will replace the use of explicitly specifying `draft: true` in the depends section of `orderly.yml` (VIMC-3377).
+
 # orderly 1.0.6
 
 * Database configurations now support the concept of "instances" to allow switching between different versions of a database (e.g., production and staging) without manually altering the configuration or environment variables. Functions `orderly::orderly_run`, `orderly::orderly_db`, `orderly::orderly_test_start` and `orderly::orderly_data` all get an `instance` argument to support this (VIMC-3302).

--- a/R/config.R
+++ b/R/config.R
@@ -237,7 +237,7 @@ config_read_db <- function(name, info, filename) {
       }
       base <- dat$args %||% set_names(list(), character())
       assert_named(base, TRUE, paste0(label, ":args"))
-      instances <- lapply(dat$instances, modifyList, x = base)
+      instances <- lapply(dat$instances, utils::modifyList, x = base)
     } else {
       assert_named(dat$args, TRUE, paste0(label, ":args"))
     }

--- a/R/query.R
+++ b/R/query.R
@@ -195,9 +195,6 @@ orderly_find_name <- function(id, config, locate = FALSE, draft = TRUE,
 ## what we want to achieve is.  This function is not an orderly API
 ## function, and is used only in dependency resolution, so we can
 ## update this later if needed.
-##
-## The draft = TRUE/FALSE bit can eventually be removed if we remove
-## the use of draft: true from within a dependency declaration.
 orderly_find_report <- function(id, name, config, locate = FALSE,
                                 draft = TRUE, must_work = FALSE) {
   config <- orderly_config_get(config, locate)

--- a/R/recipe_read.R
+++ b/R/recipe_read.R
@@ -337,8 +337,17 @@ recipe_read_check_depends <- function(x, filename, config, use_draft,
     ## we come to getting them in the database this is not necessarily
     ## correct!
     if (validate) {
-      draft <- el$draft %||% use_draft
-      el$path <- orderly_find_report(el$id, name, config, draft = draft,
+      if (!is.null(el$draft)) {
+        msg <- c("Using 'draft:' within an ordery.yml is deprecated and",
+                 "will be removed in a future version of orderly.  Please",
+                 "use the 'use_draft' argument to control draft usage.",
+                 "If you want to use a recent version of a report that you",
+                 'are developing simultaneously, use_draft = "newer"',
+                 "will probably do what you want.")
+        orderly_warning(flow_text(msg))
+        use_draft <- el$draft
+      }
+      el$path <- orderly_find_report(el$id, name, config, draft = use_draft,
                                      must_work = TRUE)
       filename_full <- file.path(el$path, el$filename)
 

--- a/R/recipe_read.R
+++ b/R/recipe_read.R
@@ -1,11 +1,17 @@
 ## The bulk of this is validating the yaml; that turns out to be quite
 ## unpleasant unfortunately.
-recipe_read <- function(path, config, validate = TRUE) {
+recipe_read <- function(path, config, validate = TRUE, use_draft = FALSE) {
   assert_is(config, "orderly_config")
   filename <- file.path(path, "orderly.yml")
   assert_file_exists(path, name = "Report working directory")
   assert_file_exists(filename, name = "Orderly configuration")
   info <- yaml_read(filename)
+
+  if (is.logical(use_draft)) {
+    assert_scalar_logical(use_draft)
+  } else {
+    match_value(use_draft, c("always", "newer", "never"))
+  }
 
   required <- c("script", # filename
                 "artefacts",
@@ -39,7 +45,8 @@ recipe_read <- function(path, config, validate = TRUE) {
   info$global_resources <- recipe_read_check_global_resources(
     info$global_resources, filename, config)
   info$depends <-
-    recipe_read_check_depends(info$depends, filename, config, validate)
+    recipe_read_check_depends(info$depends, filename, config, use_draft,
+                              validate)
 
   assert_scalar_character(info$script, fieldname("script"))
 
@@ -285,7 +292,8 @@ recipe_read_check_sources <- function(sources, resources, filename, path) {
 }
 
 
-recipe_read_check_depends <- function(x, filename, config, validate) {
+recipe_read_check_depends <- function(x, filename, config, use_draft,
+                                      validate) {
   ## TODO: this is going to assume that the artefacts are all in place
   ## - that need not actually be the case here - so we need a flag on
   ## this function that indicates that we're actually going to try and
@@ -305,9 +313,8 @@ recipe_read_check_depends <- function(x, filename, config, validate) {
     el$name <- name
 
     assert_character(el$id, sprintf("%s:depends:%s:id", filename, name))
-    if (is.null(el$draft)) {
-      el$draft <- FALSE
-    } else {
+    if (!is.null(el$draft)) {
+      ## TODO: warning here now
       assert_scalar_logical(el$draft,
                             sprintf("%s:depends:%s:draft", filename, name))
     }
@@ -330,7 +337,8 @@ recipe_read_check_depends <- function(x, filename, config, validate) {
     ## we come to getting them in the database this is not necessarily
     ## correct!
     if (validate) {
-      el$path <- orderly_find_report(el$id, name, config, draft = el$draft,
+      draft <- el$draft %||% use_draft
+      el$path <- orderly_find_report(el$id, name, config, draft = draft,
                                      must_work = TRUE)
       filename_full <- file.path(el$path, el$filename)
 

--- a/R/recipe_run.R
+++ b/R/recipe_run.R
@@ -62,6 +62,14 @@
 ##' @param echo Print the result of running the R code to the console
 ##' @param id_file Write the identifier into a file
 ##'
+##' @param use_draft Should draft reports be used for dependencies?
+##'   This should be used only in development.  Valid values are
+##'   logical (\code{TRUE}, \code{FALSE}) or use the string
+##'   \code{newer} to use draft reports where they are newer than
+##'   archive reports.  For consistency, \code{always} and
+##'   \code{never} are equivalent to \code{TRUE} and \code{FALSE},
+##'   respectively.
+##'
 ##' @seealso \code{\link{orderly_log}} for controlling display of log
 ##'   messages (not just R output)
 ##'
@@ -97,7 +105,7 @@
 orderly_run <- function(name, parameters = NULL, envir = NULL,
                         root = NULL, locate = TRUE, echo = TRUE,
                         id_file = NULL, fetch = FALSE, ref = NULL,
-                        message = NULL, instance = NULL) {
+                        message = NULL, instance = NULL, use_draft = FALSE) {
   envir <- orderly_environment(envir)
   config <- orderly_config_get(root, locate)
   config <- check_orderly_archive_version(config)
@@ -106,7 +114,7 @@ orderly_run <- function(name, parameters = NULL, envir = NULL,
     name <- sub("^src/", "", name)
   }
 
-  info <- recipe_prepare(config, name, id_file, ref, fetch, message)
+  info <- recipe_prepare(config, name, id_file, ref, fetch, message, use_draft)
 
   recipe_current_run_set(info)
   on.exit(recipe_current_run_clear())
@@ -119,7 +127,7 @@ orderly_run <- function(name, parameters = NULL, envir = NULL,
 
 
 recipe_prepare <- function(config, name, id_file = NULL, ref = NULL,
-                           fetch = FALSE, message = NULL) {
+                           fetch = FALSE, message = NULL, use_draft = FALSE) {
   assert_is(config, "orderly_config")
   config <- orderly_config_get(config, FALSE)
 
@@ -132,7 +140,8 @@ recipe_prepare <- function(config, name, id_file = NULL, ref = NULL,
     on.exit(git_checkout_branch(prev, TRUE, config$root))
   }
 
-  info <- recipe_read(file.path(path_src(config$root), name), config)
+  info <- recipe_read(file.path(path_src(config$root), name),
+                      config, use_draft = use_draft)
 
   id <- new_report_id()
   orderly_log("id", id)

--- a/R/recipe_test.R
+++ b/R/recipe_test.R
@@ -48,10 +48,11 @@
 ##' # We now confirm that the artefact has been created:
 ##' orderly::orderly_test_check(p)
 orderly_test_start <- function(name, parameters = NULL, envir = parent.frame(),
-                               root = NULL, locate = TRUE, instance = NULL) {
+                               root = NULL, locate = TRUE, instance = NULL,
+                               use_draft = FALSE) {
   config <- orderly_config_get(root, locate)
   info <- recipe_prepare(config, name, id_file = NULL, ref = NULL,
-                         fetch = FALSE, message = NULL)
+                         fetch = FALSE, message = NULL, use_draft = use_draft)
   prep <- withr::with_dir(
     info$workdir,
     orderly_prepare_data(config, info, parameters, envir, instance))

--- a/R/recipe_test.R
+++ b/R/recipe_test.R
@@ -121,7 +121,7 @@ orderly_test_check <- function(path = NULL) {
 ##' env$extract
 orderly_data <- function(name, parameters = NULL, envir = NULL,
                          root = NULL, locate = TRUE, instance = NULL,
-                         use_draft = NULL) {
+                         use_draft = FALSE) {
   config <- orderly_config_get(root, locate)
   info <- recipe_read(file.path(path_src(config$root), name),
                       config, use_draft = use_draft)

--- a/R/recipe_test.R
+++ b/R/recipe_test.R
@@ -120,9 +120,11 @@ orderly_test_check <- function(path = NULL) {
 ##' env$nmin
 ##' env$extract
 orderly_data <- function(name, parameters = NULL, envir = NULL,
-                         root = NULL, locate = TRUE, instance = NULL) {
+                         root = NULL, locate = TRUE, instance = NULL,
+                         use_draft = NULL) {
   config <- orderly_config_get(root, locate)
-  info <- recipe_read(file.path(path_src(config$root), name), config)
+  info <- recipe_read(file.path(path_src(config$root), name),
+                      config, use_draft = use_draft)
   envir <- orderly_environment(envir)
   recipe_data(config, info, parameters, envir, instance)$dest
 }

--- a/inst/init/orderly.yml
+++ b/inst/init/orderly.yml
@@ -122,7 +122,6 @@ artefacts: ~
 #       other_report_name:
 #         id: (identifier, possibly "latest")
 #         use: (mapping of filenames in the format dest: from)
-#         draft: (true, if you want to use a draft report)
 
 # For example, to depend on the latest version of report
 # 'other-report', pulling in 'data.csv' as 'other-data.csv' you might

--- a/man/orderly_run.Rd
+++ b/man/orderly_run.Rd
@@ -15,7 +15,8 @@ orderly_run(
   fetch = FALSE,
   ref = NULL,
   message = NULL,
-  instance = NULL
+  instance = NULL,
+  use_draft = NULL
 )
 }
 \arguments{
@@ -59,6 +60,14 @@ databases where instances are listed in
 \code{orderly_config.yml}, and will be ignored by all database
 where instances are not given.  See the "orderly" vignette for
 further information.}
+
+\item{use_draft}{Should draft reports be used for dependencies?
+This should be used only in development.  Valid values are
+logical (\code{TRUE}, \code{FALSE}) or use the string
+\code{newer} to use draft reports where they are newer than
+archive reports.  For consistency, \code{always} and
+\code{never} are equivalent to \code{TRUE} and \code{FALSE},
+respectively.}
 }
 \value{
 The id of the newly created report

--- a/man/orderly_run.Rd
+++ b/man/orderly_run.Rd
@@ -16,7 +16,7 @@ orderly_run(
   ref = NULL,
   message = NULL,
   instance = NULL,
-  use_draft = NULL
+  use_draft = FALSE
 )
 }
 \arguments{

--- a/man/orderly_test_start.Rd
+++ b/man/orderly_test_start.Rd
@@ -24,7 +24,7 @@ orderly_data(
   root = NULL,
   locate = TRUE,
   instance = NULL,
-  use_draft = NULL
+  use_draft = FALSE
 )
 }
 \arguments{

--- a/man/orderly_test_start.Rd
+++ b/man/orderly_test_start.Rd
@@ -12,7 +12,8 @@ orderly_test_start(
   envir = parent.frame(),
   root = NULL,
   locate = TRUE,
-  instance = NULL
+  instance = NULL,
+  use_draft = FALSE
 )
 
 orderly_test_check(path = NULL)
@@ -57,8 +58,6 @@ databases where instances are listed in
 where instances are not given.  See the "orderly" vignette for
 further information.}
 
-\item{path}{Path to the report that is currently being run}
-
 \item{use_draft}{Should draft reports be used for dependencies?
 This should be used only in development.  Valid values are
 logical (\code{TRUE}, \code{FALSE}) or use the string
@@ -66,6 +65,8 @@ logical (\code{TRUE}, \code{FALSE}) or use the string
 archive reports.  For consistency, \code{always} and
 \code{never} are equivalent to \code{TRUE} and \code{FALSE},
 respectively.}
+
+\item{path}{Path to the report that is currently being run}
 }
 \value{
 The path to the report directory

--- a/man/orderly_test_start.Rd
+++ b/man/orderly_test_start.Rd
@@ -23,7 +23,8 @@ orderly_data(
   envir = NULL,
   root = NULL,
   locate = TRUE,
-  instance = NULL
+  instance = NULL,
+  use_draft = NULL
 )
 }
 \arguments{
@@ -57,6 +58,14 @@ where instances are not given.  See the "orderly" vignette for
 further information.}
 
 \item{path}{Path to the report that is currently being run}
+
+\item{use_draft}{Should draft reports be used for dependencies?
+This should be used only in development.  Valid values are
+logical (\code{TRUE}, \code{FALSE}) or use the string
+\code{newer} to use draft reports where they are newer than
+archive reports.  For consistency, \code{always} and
+\code{never} are equivalent to \code{TRUE} and \code{FALSE},
+respectively.}
 }
 \value{
 The path to the report directory

--- a/tests/testthat/examples/depends/src/depend/orderly.yml
+++ b/tests/testthat/examples/depends/src/depend/orderly.yml
@@ -2,7 +2,6 @@ data: ~
 depends:
   example:
     id: latest
-    draft: true
     use:
       previous.rds: data.rds
 script: script.R

--- a/tests/testthat/examples/depends/src/depend2/orderly.yml
+++ b/tests/testthat/examples/depends/src/depend2/orderly.yml
@@ -2,12 +2,10 @@ data: ~
 depends:
   - example:
       id: latest
-      draft: true
       use:
         previous1.rds: data.rds
   - example:
       id: latest
-      draft: false
       use:
         previous2.rds: data.rds
 script: script.R

--- a/tests/testthat/helper-orderly.R
+++ b/tests/testthat/helper-orderly.R
@@ -76,11 +76,6 @@ prepare_orderly_remote_example <- function(path = tempfile()) {
 
   path_local <- prepare_orderly_example("depends", testing = TRUE)
 
-  ## Patch the report to use non-draft dependencies:
-  p <- file.path(path_local, "src", "depend", "orderly.yml")
-  d <- sub("draft: true", "draft: false", readLines(p))
-  writeLines(d, p)
-
   r <- list(remote = list(
               default = list(
                 driver = "orderly::orderly_remote_path",

--- a/tests/testthat/test-orderly.R
+++ b/tests/testthat/test-orderly.R
@@ -54,6 +54,8 @@ test_that("init - no doc", {
 test_that("orderly_run_info reports on artefacts", {
   path <- prepare_orderly_example("depends", testing = TRUE)
   id1 <- orderly_run("example", root = path, echo = FALSE)
+  orderly_commit(id1, root = path)
+
   id2 <- orderly_run("depend", root = path, echo = FALSE)
 
   d <- readRDS(file.path(path, "draft", "depend", id2, "output.rds"))
@@ -70,6 +72,7 @@ test_that("orderly_run_info errors when not running", {
 test_that("orderly_run_info is usable from test_start", {
   path <- prepare_orderly_example("depends", testing = TRUE)
   id1 <- orderly_run("example", root = path, echo = FALSE)
+  orderly_commit(id1, root = id1)
   p <- orderly_test_start("depend", root = path)
 
   expect_error(
@@ -89,7 +92,7 @@ test_that("orderly_run_info: is_latest detects latest version", {
   id2 <- orderly_run("example", root = path, echo = FALSE)
 
   f <- function() {
-    p <- orderly_test_start("depend", root = path)
+    p <- orderly_test_start("depend", root = path, use_draft = TRUE)
     orderly_run_info(p)
   }
 
@@ -135,7 +138,7 @@ test_that("can't depend on non artefacts", {
   yaml_write(d, path_yml)
 
   expect_error(
-    orderly_run("depend", root = path, echo = FALSE),
+    orderly_run("depend", root = path, echo = FALSE, use_draft = TRUE),
     "Dependency file not an artefact of example/.*:\n- 'script.R'")
 })
 

--- a/tests/testthat/test-orderly.R
+++ b/tests/testthat/test-orderly.R
@@ -72,8 +72,7 @@ test_that("orderly_run_info errors when not running", {
 test_that("orderly_run_info is usable from test_start", {
   path <- prepare_orderly_example("depends", testing = TRUE)
   id1 <- orderly_run("example", root = path, echo = FALSE)
-  orderly_commit(id1, root = id1)
-  p <- orderly_test_start("depend", root = path)
+  p <- orderly_test_start("depend", root = path, use_draft = TRUE)
 
   expect_error(
     orderly_run_info(),

--- a/tests/testthat/test-query.R
+++ b/tests/testthat/test-query.R
@@ -181,5 +181,5 @@ test_that("orderly_find_report", {
   expect_error(
     orderly_find_report(new_report_id(), "example", config = path,
                         must_work = TRUE, draft = FALSE),
-    "Did not find archived report example:")
+    "Did not find archive report example:")
 })

--- a/tests/testthat/test-recipe-read.R
+++ b/tests/testthat/test-recipe-read.R
@@ -242,6 +242,21 @@ test_that("dependencies draft, new interface, throws sensible errors", {
 })
 
 
+test_that("Using draft within a dependency is now a warning", {
+  path <- prepare_orderly_example("depends", testing = TRUE)
+  id1 <- orderly_run("example", root = path, echo = FALSE)
+
+  filename <- file.path(path, "src", "depend", "orderly.yml")
+  dat <- yaml_read(filename)
+  dat$depends$example$draft <- TRUE
+  yaml_write(dat, filename)
+
+  expect_warning(
+    id2 <- orderly_run("depend", root = path, echo = FALSE),
+    "Using 'draft:' within an ordery.yml is deprecated")
+})
+
+
 test_that("data field is optional", {
   path <- prepare_orderly_example("nodata")
   report_path <- file.path(path, "src", "example")

--- a/tests/testthat/test-recipe-read.R
+++ b/tests/testthat/test-recipe-read.R
@@ -182,7 +182,8 @@ test_that("dependencies must exist", {
   dat$depends$example$use$previous.rds <- "unknown.file"
   yaml_write(dat, filename)
 
-  expect_error(orderly_run("depend", root = path, echo = FALSE),
+  expect_error(orderly_run("depend", root = path, echo = FALSE,
+                           use_draft = TRUE),
                "Did not find file unknown.file at")
 })
 

--- a/tests/testthat/test-remote-path.R
+++ b/tests/testthat/test-remote-path.R
@@ -140,12 +140,6 @@ test_that("pull dependencies", {
 test_that("pull report with dependencies", {
   dat <- prepare_orderly_remote_example()
 
-  ## For some reason that I don't understand, we use draft: true for
-  ## the depend report here, so fix that:
-  p <- file.path(dat$path_remote, "src", "depend", "orderly.yml")
-  yml <- grep("^\\s+draft: true", readLines(p), invert = TRUE, value = TRUE)
-  writeLines(yml, p)
-
   id <- orderly_run("depend", root = dat$path_remote, echo = FALSE)
   orderly_commit(id, root = dat$path_remote)
 

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -449,7 +449,14 @@ test_that("use multiple versions of an artefact", {
 
   id1 <- orderly_run("example", root = path, echo = FALSE)
   id2 <- orderly_run("example", root = path, echo = FALSE)
+  orderly_commit(id1, root = path)
   orderly_commit(id2, root = path)
+
+  p <- file.path(path, "src", "depend2", "orderly.yml")
+  dat <- yaml_read(p)
+  dat$depends[[1]]$example$id <- id1
+  dat$depends[[2]]$example$id <- id2
+  yaml_write(dat, p)
 
   id3 <- orderly_run("depend2", root = path, echo = FALSE)
 
@@ -457,8 +464,7 @@ test_that("use multiple versions of an artefact", {
                   c("previous1.rds", "previous2.rds"))
   expect_true(all(file.exists(p1)))
 
-  p2 <- file.path(path, c("draft", "archive"), "example", c(id1, id2),
-                  "data.rds")
+  p2 <- file.path(path, "archive", "example", c(id1, id2), "data.rds")
   expect_equal(hash_files(p1, FALSE),
                hash_files(p2, FALSE))
 })

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -246,9 +246,9 @@ test_that("use artefact", {
 
   data <- orderly_data("depend",
                        envir = new.env(parent = .GlobalEnv),
-                       root = path)
+                       root = path, use_draft = TRUE)
   expect_identical(ls(data), character(0))
-  id2 <- orderly_run("depend", root = path, echo = FALSE)
+  id2 <- orderly_run("depend", root = path, echo = FALSE, use_draft = TRUE)
   path_previous <- file.path(path_draft(path), "depend", id2, "previous.rds")
   expect_true(file.exists(path_previous))
   expect_equal(hash_files(path_previous, FALSE),
@@ -260,7 +260,7 @@ test_that("use artefact", {
 
   ## Then rebuild the original:
   id3 <- orderly_run("example", root = path, echo = FALSE)
-  id4 <- orderly_run("depend", root = path, echo = FALSE)
+  id4 <- orderly_run("depend", root = path, echo = FALSE, use_draft = TRUE)
   path_orig2 <- file.path(path_draft(path), "example", id3, "data.rds")
   path_previous2 <- file.path(path_draft(path), "depend", id4, "previous.rds")
 
@@ -283,7 +283,7 @@ test_that("Can't commit report using nonexistant id", {
   skip_on_cran_windows()
   path <- prepare_orderly_example("depends", testing = TRUE)
   id1 <- orderly_run("example", root = path, echo = FALSE)
-  id2 <- orderly_run("depend", root = path, echo = FALSE)
+  id2 <- orderly_run("depend", root = path, echo = FALSE, use_draft = TRUE)
   unlink(file.path(path, "draft", "example", id1), recursive = TRUE)
   expect_error(orderly_commit(id2, root = path),
                "Report uses nonexistant id")
@@ -399,7 +399,7 @@ test_that("renamed dependencies are expected", {
   path <- prepare_orderly_example("depends", testing = TRUE)
   orderly_run("example", root = path, echo = FALSE)
   messages <- capture_messages(
-    orderly_run("depend", root = path, echo = FALSE))
+    orderly_run("depend", root = path, echo = FALSE, use_draft = TRUE))
   expect_false(any(grep("unexpected", messages)))
 })
 
@@ -780,7 +780,7 @@ test_that("prevent duplicate filenames", {
   file.create(file.path(path, "src", "depend", "previous.rds"))
 
   expect_error(
-    orderly_run("depend", root = path, echo = FALSE),
+    orderly_run("depend", root = path, echo = FALSE, use_draft = TRUE),
     "Orderly configuration implies duplicate files:\\s+- previous.rds:")
 })
 

--- a/vignettes/orderly.Rmd
+++ b/vignettes/orderly.Rmd
@@ -292,16 +292,12 @@ depends:
       id: 20190425-163691-b8451bbf
       use:
         data.rds: huge-data-set.rds
-      draft: false
 ```
 
 This will copy the file the `huge-data-set.rds` from the report
 `big-data-report` with `id` `20190425-163691-b8451bbf` and rename it
 `data.rds`. This file can then be used by the report as if it were in
-the source directory. The field `draft` tells `orderly` to only use
-completed reports in the archive as opposed to drafts. Setting this to
-true allows uncommitted reports in `draft` to be used. This can be
-useful when developing a chain of related reports.
+the source directory.
 
 If we want a report to always use the latest version of a report `big-data-report` we can set the `id` field to `latest`, _e.g._:
 
@@ -311,7 +307,6 @@ depends:
       id: latest
       use:
         data.rds: huge-data-set.rds
-      draft: false
 ```
 
 This will find the most recent version of the report `big-data-report`
@@ -327,7 +322,6 @@ depends:
       use:
         data.rds: huge-data-set.rds
         pop.csv: population_data.csv
-      draft: false
 ```
 
 To use artefacts from multiple reports we add multiple entries to the
@@ -340,12 +334,10 @@ depends:
       use:
         data.rds: huge-data-set.rds
         pop.csv: population_data.csv
-      draft: false
   - report_two:
       id: latest
       use:
         data_b.rds: filename.rds
-      draft: false
 ```
 
 We can also use the same artefact from _different versions_ of the same
@@ -357,12 +349,10 @@ is:
 depends:
   - big-data-report:
       id: 20190425-163691-b8451bbf
-      draft: false
       use:
         data_latest.rds: huge-data-set.rds
   - big-data-report:
       id: 20181225-172991-34c91ef1
-      draft: false
       use:
         data_old: huge-data-set.rds
 ```


### PR DESCRIPTION
This PR is intended to (eventually) replace the `draft: true` trick from orderly.yml's depends, by the ability to change where dependencies come from when running the report. This means that the underlying source does not need updating and we get fewer cases of reports being merged with draft: true sticking around