### PR TITLE
VIMC-3372: Expanded vault configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
 r_packages:
   - covr
 r_github_packages:
-  - vimc/vaultr@vimc-3397
+  - vimc/vaultr
 before_script:
   - Rscript -e 'vaultr::vault_test_server_install()'
   - cp -r reference tests/testthat

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ matrix:
 
 r_packages:
   - covr
+r_github_packages:
+  - vimc/vaultr@vimc-3397
 before_script:
   - Rscript -e 'vaultr::vault_test_server_install()'
   - cp -r reference tests/testthat

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,7 +42,7 @@ Suggests:
     processx,
     rmarkdown,
     testthat,
-    vaultr (>= 1.0.0)
+    vaultr (>= 1.0.3)
 RoxygenNote: 7.0.0
 VignetteBuilder: knitr
 Language: en-GB

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.0.6
+Version: 1.0.7
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# orderly 1.0.7
+
+* Expand how the vault server is defined to allow additional arguments to be directly specified
+
 # orderly 1.0.6
 
 * Database configurations now support the concept of "instances" to allow switching between different versions of a database (e.g., production and staging) without manually altering the configuration or environment variables. Functions `orderly::orderly_run`, `orderly::orderly_db`, `orderly::orderly_test_start` and `orderly::orderly_data` all get an `instance` argument to support this (VIMC-3302).

--- a/R/config.R
+++ b/R/config.R
@@ -286,11 +286,7 @@ config_check_vault <- function(vault, vault_server, filename) {
     vault <- list(addr = vault_server)
   }
   if (!is.null(vault)) {
-    check_fields(vault, sprintf("%s:vault", filename), "addr", "auth")
-    assert_scalar_character(vault$addr, sprintf("%s:vault:addr", filename))
-    if (!is.null(vault$auth)) {
-      assert_named(vault$auth, name = sprintf("%s:vault:auth", filename))
-    }
+    assert_named(vault, TRUE, sprintf("%s:vault", filename))
   }
 
   vault

--- a/R/config.R
+++ b/R/config.R
@@ -276,7 +276,8 @@ config_read_db <- function(name, info, filename) {
 config_check_vault <- function(vault, vault_server, filename) {
   if (!is.null(vault_server)) {
     if (!is.null(vault)) {
-      stop("Can't specify both 'vault' and 'vault_server'")
+      stop(sprintf("Can't specify both 'vault' and 'vault_server' in %s",
+                   filename))
     }
     msg <- c("Use of 'vault_server' is deprecated and will be removed in a",
              "future orderly version.  Please use the new 'vault' server",

--- a/R/vault.R
+++ b/R/vault.R
@@ -1,9 +1,9 @@
 resolve_secrets <- function(x, config) {
-  if (is.null(config$vault_server)) {
+  if (is.null(config$vault)) {
     return(x)
   }
   loadNamespace("vaultr")
   withr::with_envvar(
     orderly_envir_read(config$root),
-    vaultr::vault_resolve_secrets(x, addr = config$vault_server))
+    vaultr::vault_resolve_secrets(x, vault_args = resolve_env(config$vault)))
 }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,6 +30,7 @@ before_test:
 
 build_script:
   - travis-tool.sh install_deps
+  - travis-tool.sh install_github vimc/vaultr@vimc-3397
 
 test_script:
   - travis-tool.sh run_tests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,7 @@ before_test:
 
 build_script:
   - travis-tool.sh install_deps
-  - travis-tool.sh install_github vimc/vaultr@vimc-3397
+  - travis-tool.sh install_github vimc/vaultr
 
 test_script:
   - travis-tool.sh run_tests

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -198,21 +198,14 @@ test_that("vault configuration validation for typical use", {
 
 
 test_that("vault configuration requires string for url", {
-  expect_error(config_check_vault(list(addr = TRUE), NULL, "orderly.yml"),
-               "'orderly.yml:vault:addr' must be character")
+  oo <- options(orderly.nowarnings = TRUE)
+  on.exit(options(oo))
+  expect_error(config_check_vault(NULL, TRUE, "orderly.yml"),
+               "'orderly.yml:vault_server' must be character")
   expect_error(
-    config_check_vault(list(addr = c("a", "b")), NULL, "orderly.yml"),
-    "'orderly.yml:vault:addr' must be a scalar")
-  expect_error(
-    config_check_vault(list(addr = NULL), NULL, "orderly.yml"),
-    "'orderly.yml:vault:addr' must be a scalar")
-})
-
-
-test_that("vault auth must be named", {
-  vault <- list(addr = "https://vault.example.com", auth = TRUE)
-  expect_error(config_check_vault(vault, NULL, "orderly.yml"),
-               "'orderly.yml:vault:auth' must be named")
+    config_check_vault(NULL, c("a", "b"), "orderly.yml"),
+    "'orderly.yml:vault_server' must be a scalar")
+  expect_null(config_check_vault(NULL, NULL, "orderly.yml"))
 })
 
 
@@ -230,16 +223,11 @@ test_that("vault configuration", {
   path_config <- file.path(path, "orderly_config.yml")
   text <- readLines(path_config)
 
-  expect_null(orderly_config(root = path)$vault_server)
+  expect_null(orderly_config(root = path)$vault)
 
   url <- "https://vault.example.com"
-  writeLines(c(text, sprintf("vault_server: %s", url)), path_config)
-  expect_equal(orderly_config(root = path)$vault_server, url)
-
-  writeLines(c(text, sprintf("vault_server: %s", TRUE)), path_config)
-  expect_error(orderly_config(root = path),
-               "orderly_config.yml:vault_server' must be character",
-               fixed = TRUE)
+  writeLines(c(text, sprintf("vault:\n  addr: %s", url)), path_config)
+  expect_equal(orderly_config(root = path)$vault, list(addr = url))
 })
 
 

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -182,6 +182,49 @@ test_that("no global folder", {
 })
 
 
+test_that("vault configuration validation when absent", {
+  expect_null(config_check_vault(NULL, NULL, "orderly.yml"))
+})
+
+
+test_that("vault configuration validation for typical use", {
+  vault <- list(addr = "https://vault.example.com")
+  expect_identical(config_check_vault(vault, NULL, "orderly.yml"), vault)
+
+  vault <- list(addr = "https://vault.example.com",
+                auth = list(method = "github"))
+  expect_identical(config_check_vault(vault, NULL, "orderly.yml"), vault)
+})
+
+
+test_that("vault configuration requires string for url", {
+  expect_error(config_check_vault(list(addr = TRUE), NULL, "orderly.yml"),
+               "'orderly.yml:vault:addr' must be character")
+  expect_error(
+    config_check_vault(list(addr = c("a", "b")), NULL, "orderly.yml"),
+    "'orderly.yml:vault:addr' must be a scalar")
+  expect_error(
+    config_check_vault(list(addr = NULL), NULL, "orderly.yml"),
+    "'orderly.yml:vault:addr' must be a scalar")
+})
+
+
+test_that("vault auth must be named", {
+  vault <- list(addr = "https://vault.example.com", auth = TRUE)
+  expect_error(config_check_vault(vault, NULL, "orderly.yml"),
+               "'orderly.yml:vault:auth' must be named")
+})
+
+
+test_that("previous configuration is transformed with warning", {
+  addr <- "https://vault.example.com"
+  expect_warning(
+    res <- config_check_vault(NULL, addr, "orderly.yml")  ,
+    "Use of 'vault_server' is deprecated")
+  expect_equal(res, list(addr = addr))
+})
+
+
 test_that("vault configuration", {
   path <- prepare_orderly_example("minimal")
   path_config <- file.path(path, "orderly_config.yml")

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -218,6 +218,14 @@ test_that("previous configuration is transformed with warning", {
 })
 
 
+test_that("Can't use both new and old vault configurations", {
+  expect_error(config_check_vault(list(login = "token"),
+                                  "https://vault.example.com",
+                                  "orderly.yml"),
+               "Can't specify both 'vault' and 'vault_server' in orderly.yml")
+})
+
+
 test_that("vault configuration", {
   path <- prepare_orderly_example("minimal")
   path_config <- file.path(path, "orderly_config.yml")

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -138,16 +138,16 @@ test_that("resolve secret env", {
   cl$write("/secret/users/bob", list(password = "BOB"))
 
   config <- list(root = tempfile(),
-                 vault_server = srv$addr)
+                 vault = list(addr = srv$addr,
+                              login = "token",
+                              token = srv$token))
 
   x <- list(user = "$ORDERLY_USER",
             password = "$ORDERLY_PASSWORD",
             other = "string")
 
   vars <- c("ORDERLY_PASSWORD" = "VAULT:/secret/users/alice:password",
-            "ORDERLY_USER" = "alice",
-            "VAULTR_AUTH_METHOD" = "token",
-            "VAULT_TOKEN" = srv$token)
+            "ORDERLY_USER" = "alice")
 
   res <- withr::with_envvar(vars, resolve_driver_config(x, config))
   expect_equal(res,

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -90,7 +90,7 @@ test_that("secrets", {
   cl$write("/secret/users/bob", list(password = "BOB"))
 
   config <- list(root = tempfile(),
-                 vault_server = srv$addr)
+                 vault = list(addr = srv$addr))
 
   x <- list(name = "alice",
             password = "VAULT:/secret/users/alice:password")
@@ -112,6 +112,23 @@ test_that("secrets", {
     expect_equal(resolve_secrets(unlist(x), config),
                  list(name = "alice", password = "ALICE"))
   })
+})
+
+test_that("secets and expanded vault definition", {
+  srv <- vaultr::vault_test_server()
+  cl <- srv$client()
+  cl$write("/secret/users/alice", list(password = "ALICE"))
+  cl$write("/secret/users/bob", list(password = "BOB"))
+
+  config <- list(root = tempfile(),
+                 vault = list(
+                   addr = srv$addr,
+                   login = "token",
+                   token = srv$token))
+  x <- list(name = "alice",
+            password = "VAULT:/secret/users/alice:password")
+  expect_equal(resolve_secrets(x, config),
+               list(name = "alice", password = "ALICE"))
 })
 
 test_that("resolve secret env", {

--- a/vignettes/orderly.Rmd
+++ b/vignettes/orderly.Rmd
@@ -572,6 +572,37 @@ would look up the field `password` at the path
 `orderly_config.yml`, in the contents of an environment variable or
 in `orderly_envir.yml` (currently this only uses the vault [version 1 key-value storage](https://www.vaultproject.io/docs/secrets/kv/kv-v1.html))
 
+If you need to control how the vault server is accessed, then you can pass additional arguments within an `args` block:
+
+```yaml
+vault:
+  addr: https://example.com:8200
+  login: userpass
+  username: alice
+  password: secret
+  mount: userpass
+```
+
+This is equivalent to connecting to the vault, using `vaultr` as
+
+```r
+vaultr::vault_client(addr = "https://example.com:8200", login = "userpass",
+                     username = "alice", password = "secret",
+                     mount = "userpass")
+```
+
+Environment variables here will be respected so you could write:
+
+```yaml
+vault:
+  addr: https://example.com:8200
+  login: userpass
+  username: $VAULT_USER
+  password: $VAULT_PASSWORD
+```
+
+and the username and password will be found from environment variables (the actual secret resolution uses `vaultr::vault_resolve_secrets` - see the documentation in vaultr for further details).
+
 ### Advanced database configuration
 
 _In general, you can ignore this section if you only use one global database._

--- a/vignettes/orderly.Rmd
+++ b/vignettes/orderly.Rmd
@@ -556,7 +556,8 @@ retrieve them.
 To do this, you should include the address of your vault server in the `orderly_config.yml` as
 
 ```yaml
-vault_server: https://example.com:8200
+vault:
+  addr: https://example.com:8200
 ```
 
 Then, for values that you want to retrieve from the vault, set the value of the field to `VAULT:<path>:<field>`, where `<path>` is the name of a vault


### PR DESCRIPTION
Now allows all connection options to be set in the orderly configuration, not just the vault address.  This will make the eventual vimc -> mrc-ide vault a lot easier because we can use a different github mount for the authentication.  

Requires https://github.com/vimc/vaultr/pull/26 to be merged and references to vimc-3397 to be removed from the .travis.yml and appveyor.yml