### PR TITLE
VIMC-3411: Validate parameters early

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.0.8
+Version: 1.0.9
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# orderly 1.0.9
+
+* Enforce parameter types before model run, rather than on commit, and with better messages (VIMC-3411)
+
 # orderly 1.0.8
 
 * Expand how the vault server is defined to allow additional arguments to be directly specified (VIMC-3372)

--- a/R/recipe_run.R
+++ b/R/recipe_run.R
@@ -305,6 +305,23 @@ recipe_parameters <- function(info, parameters) {
       lapply(info$parameters[use_default], "[[", "default")
   }
 
+  ## This somewhat duplicates the checks in db2.R but designed to give
+  ## more sensible errors back to the user.
+  nonscalar <- lengths(parameters) != 1
+  if (any(nonscalar)) {
+    stop(sprintf(
+      "Invalid parameters: %s - must be scalar",
+      pasteq(names(nonscalar[nonscalar]))))
+  }
+
+  err <- !vlapply(parameters, function(x)
+    is.character(x) || is.numeric(x) || is.logical(x))
+  if (any(err)) {
+    stop(sprintf(
+      "Invalid parameters: %s - must be character, numeric or logical",
+      pasteq(names(err[err]))))
+  }
+
   parameters
 }
 

--- a/R/recipe_run.R
+++ b/R/recipe_run.R
@@ -34,7 +34,8 @@
 ##'   removed if provided, allowing easier use of autocomplete.
 ##'
 ##' @param parameters Parameters passed to the report. A named list of
-##'   parameters declared in the \code{orderly.yml}.
+##'   parameters declared in the \code{orderly.yml}.  Each parameter
+##'   must be a scalar character, numeric, integer or logical.
 ##'
 ##' @param envir The parent of the environment that will be used to
 ##'   evaluate the report script; by default a new environment will be

--- a/man/orderly_run.Rd
+++ b/man/orderly_run.Rd
@@ -25,7 +25,8 @@ orderly_run(
 removed if provided, allowing easier use of autocomplete.}
 
 \item{parameters}{Parameters passed to the report. A named list of
-parameters declared in the \code{orderly.yml}.}
+parameters declared in the \code{orderly.yml}.  Each parameter
+must be a scalar character, numeric, integer or logical.}
 
 \item{envir}{The parent of the environment that will be used to
 evaluate the report script; by default a new environment will be

--- a/man/orderly_test_start.Rd
+++ b/man/orderly_test_start.Rd
@@ -34,7 +34,8 @@ orderly_data(
 removed if provided, allowing easier use of autocomplete.}
 
 \item{parameters}{Parameters passed to the report. A named list of
-parameters declared in the \code{orderly.yml}.}
+parameters declared in the \code{orderly.yml}.  Each parameter
+must be a scalar character, numeric, integer or logical.}
 
 \item{envir}{The parent of the environment that will be used to
 evaluate the report script; by default a new environment will be

--- a/tests/testthat/test-db.R
+++ b/tests/testthat/test-db.R
@@ -103,10 +103,6 @@ test_that("avoid unserialisable parameters", {
   skip_on_cran_windows()
   path <- prepare_orderly_example("parameters", testing = TRUE)
   t <- Sys.Date()
-  id <- orderly_run("example", parameters = list(a = t, b = TRUE, c = "one"),
-                    root = path, echo = FALSE)
-  expect_error(orderly_commit(id, root = path),
-               "Unsupported parameter type")
   expect_error(report_db_parameter_type(t), "Unsupported parameter type")
   expect_error(report_db_parameter_serialise(t), "Unsupported parameter type")
 })

--- a/tests/testthat/test-db.R
+++ b/tests/testthat/test-db.R
@@ -100,8 +100,6 @@ test_that("different parameter types are stored correctly", {
 
 
 test_that("avoid unserialisable parameters", {
-  skip_on_cran_windows()
-  path <- prepare_orderly_example("parameters", testing = TRUE)
   t <- Sys.Date()
   expect_error(report_db_parameter_type(t), "Unsupported parameter type")
   expect_error(report_db_parameter_serialise(t), "Unsupported parameter type")

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -826,3 +826,17 @@ test_that("run with different database instance", {
   expect_equal(f(id2), 20)
   expect_equal(f(id3), 10)
 })
+
+
+test_that("Require simple parameters", {
+  path <- prepare_orderly_example("parameters", testing = TRUE)
+
+  expect_error(
+    orderly_run("example", parameters = list(a = Sys.Date(), b = TRUE),
+                root = path, echo = FALSE),
+    "Invalid parameters: 'a' - must be character, numeric or logical")
+  expect_error(
+    orderly_run("example", parameters = list(a = NULL, b = 1:2),
+                root = path, echo = FALSE),
+    "Invalid parameters: 'a', 'b' - must be scalar")
+})


### PR DESCRIPTION
This PR fixes a problem that @sangeetabhatia03 and @imai-n found - if the user provides invalid parameters (from the point of view of orderly's data model) then the error is only thrown when the report is commited, and then with an incomprehensible message.  Here, we validate the parameters before running, and provide better messages that can be actioned