### PR TITLE
Vimc 3424 - possible autocompletion of vault to vault_server

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.0.9
+Version: 1.0.10
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# orderly 1.0.10
+
+* Fix regression running reports - vault autocompletes to vault_server
+
 # orderly 1.0.9
 
 * Enforce parameter types before model run, rather than on commit, and with better messages (VIMC-3411)

--- a/R/config.R
+++ b/R/config.R
@@ -52,7 +52,7 @@ orderly_config_read_yaml <- function(filename, root) {
       v, utils::packageVersion("orderly")))
   }
 
-  info$vault <- config_check_vault(info$vault, info$vault_server, filename)
+  info$vault <- config_check_vault(info[['vault']], info[['vault_server']], filename)
   info$remote <- config_check_remote(info$remote, filename)
 
   info$root <- normalizePath(root, mustWork = TRUE)

--- a/R/config.R
+++ b/R/config.R
@@ -52,7 +52,7 @@ orderly_config_read_yaml <- function(filename, root) {
       v, utils::packageVersion("orderly")))
   }
 
-  info$vault <- config_check_vault(info[['vault']], info[['vault_server']], filename)
+  info[['vault']] <- config_check_vault(info[['vault']], info[['vault_server']], filename)
   info$remote <- config_check_remote(info$remote, filename)
 
   info$root <- normalizePath(root, mustWork = TRUE)

--- a/R/vault.R
+++ b/R/vault.R
@@ -1,9 +1,9 @@
 resolve_secrets <- function(x, config) {
-  if (is.null(config$vault)) {
+  if (is.null(config[['vault']])) {
     return(x)
   }
   loadNamespace("vaultr")
   withr::with_envvar(
     orderly_envir_read(config$root),
-    vaultr::vault_resolve_secrets(x, vault_args = resolve_env(config$vault)))
+    vaultr::vault_resolve_secrets(x, vault_args = resolve_env(config[['vault']])))
 }

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -217,6 +217,22 @@ test_that("previous configuration is transformed with warning", {
   expect_equal(res, list(addr = addr))
 })
 
+test_that("vault_server (not vault) in configuration yaml", {
+
+  # 1.0.10 - this fails if config.R:55 uses $vault instead of [['vault']]
+
+  path <- prepare_orderly_example("minimal")
+  path_config <- file.path(path, "orderly_config.yml")
+  text <- readLines(path_config)
+
+  expect_null(orderly_config(root = path)$vault)
+
+  url <- "https://vault.example.com"
+  writeLines(c(text, sprintf("vault_server: %s", url)), path_config)
+  expect_warning(res <- orderly_config(root = path)$vault,
+                 "Use of 'vault_server' is deprecated")
+  expect_equal(res, list(addr = url))
+})
 
 test_that("Can't use both new and old vault configurations", {
   expect_error(config_check_vault(list(login = "token"),


### PR DESCRIPTION
All $vault and $vault_server are now [['vault']] and [['vault_server']].

One added test - which is somewhat water under the bridge - but will fail if the above change on config.R:55 is rolled back.