### PR TITLE
vimc-3386: more informative resolution of environment variables

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.0.10
+Version: 1.0.11
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # orderly 1.0.11
 
-* More informative informative error messages when orderly fails to resolve an environment variable, particularly when loading vault configuration (VIMC-3386)
+* More informative informative error messages when orderly fails to resolve an environment variable, particularly when loading remote configuration (VIMC-3386)
 
 # orderly 1.0.10
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # orderly 1.0.11
 
-* More informative informative error messages when orderly fails to resolve an environment variable, particularly when loading remote configuration (VIMC-3386)
+* More informative error messages when orderly fails to resolve an environment variable, particularly when loading remote configuration (VIMC-3386)
 
 # orderly 1.0.10
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# orderly 1.0.11
+
+* More informative informative error messages when orderly fails to resolve an environment variable, particularly when loading vault configuration (VIMC-3386)
+
 # orderly 1.0.10
 
 * Fix regression running reports - vault autocompletes to vault_server

--- a/R/config.R
+++ b/R/config.R
@@ -125,8 +125,6 @@ config_check_remote <- function(dat, filename) {
     }
     assert_scalar_character(remote$driver, field_name("driver"))
     assert_named(remote$args, name = field_name("args"))
-    remote <- resolve_env(remote, error = FALSE)
-    remote$args <- resolve_env(remote$args, error = FALSE, default = NULL)
 
     ## optionals:
     if (!is.null(remote$url)) {
@@ -135,9 +133,6 @@ config_check_remote <- function(dat, filename) {
                "is deprecated and will be dropped in a future version of",
                "orderly.  Please remove it from your orderly_config.yml")
       orderly_warning(flow_text(msg))
-    }
-    if (!is.null(remote$slack_url)) {
-      assert_scalar_character(remote$slack_url, field_name("slack_url"))
     }
     if (is.null(remote$primary)) {
       remote$primary <- FALSE

--- a/R/config.R
+++ b/R/config.R
@@ -241,7 +241,8 @@ config_read_db <- function(name, info, filename) {
         stop(flow_text(msg), call. = FALSE)
       }
       dat["default_instance"] <-
-        resolve_env(dat["default_instance"], error = FALSE, default = NULL)
+        resolve_env(dat["default_instance"], "default_instance",
+                    error = FALSE, default = NULL)
       if (!is.null(dat$default_instance)) {
         match_value(dat$default_instance, names(instances),
                     paste0(label, ":default_instance"))

--- a/R/remote.R
+++ b/R/remote.R
@@ -302,7 +302,13 @@ load_remote <- function(name, config) {
   hash <- hash_object(remote)
   if (is.null(cache$remotes[[hash]])) {
     driver <- getExportedValue(remote$driver[[1L]], remote$driver[[2L]])
-    args <- resolve_secrets(remote$args, config)
+    base <- "orderly_config.yml:remote"
+    remote <- resolve_secrets(
+      resolve_env(remote, name = sprintf("%s:%s", base, name)),
+      config)
+    args <- resolve_secrets(
+      resolve_env(remote$args, name = sprintf("%s:%s:args", base, name)),
+      config)
     cache$remotes[[hash]] <- do.call(driver, args)
   }
   cache$remotes[[hash]]

--- a/R/remote.R
+++ b/R/remote.R
@@ -304,10 +304,10 @@ load_remote <- function(name, config) {
     driver <- getExportedValue(remote$driver[[1L]], remote$driver[[2L]])
     base <- "orderly_config.yml:remote"
     remote <- resolve_secrets(
-      resolve_env(remote, name = sprintf("%s:%s", base, name)),
+      resolve_env(remote, sprintf("%s:%s", base, name)),
       config)
     args <- resolve_secrets(
-      resolve_env(remote$args, name = sprintf("%s:%s:args", base, name)),
+      resolve_env(remote$args, sprintf("%s:%s:args", base, name)),
       config)
     cache$remotes[[hash]] <- do.call(driver, args)
   }

--- a/R/slack.R
+++ b/R/slack.R
@@ -1,14 +1,14 @@
 ## Send slack messages!
+
 slack_post_success <- function(dat, config) {
   if (!is.null(config$remote_identity)) {
     remote <- config$remote[[config$remote_identity]]
-
-    slack_url <- resolve_secrets(remote$slack_url, config)[[1L]]
-
     driver <- get_remote(config$remote_identity, config)
     report_url <- driver$url_report(dat$meta$name, dat$meta$id)
+    slack_url <- remote$slack_url
 
     if (!is.null(slack_url)) {
+      assert_scalar_character(slack_url, "slack_url")
       data <- slack_data(dat, remote$name, report_url, remote$primary)
       do_slack_post_success(slack_url, data)
     }

--- a/R/util.R
+++ b/R/util.R
@@ -243,12 +243,12 @@ append_text <- function(filename, txt) {
   writeLines(c(orig, txt), filename)
 }
 
-Sys_getenv <- function(x, error = TRUE, default = NULL, name = NULL) {
+Sys_getenv <- function(x, used_in, error = TRUE, default = NULL) {
   v <- Sys.getenv(x, NA_character_)
   if (is.na(v)) {
     if (error) {
       stop(sprintf("Environment variable '%s' is not set\n\t(used in %s)",
-                   x, name))
+                   x, used_in))
     } else {
       v <- default
     }
@@ -320,20 +320,17 @@ indent <- function(x, n) {
 }
 
 resolve_driver_config <- function(args, config, name = NULL) {
-  resolve_secrets(resolve_env(args, name = name), config)
+  resolve_secrets(resolve_env(args, name), config)
 }
 
-resolve_env <- function(x, error = TRUE, default = NULL, name = NULL) {
+resolve_env <- function(x, used_in, error = TRUE, default = NULL) {
   f <- function(nm, x) {
     if (length(x) == 1L && is.character(x) && grepl("^\\$[0-9A-Z_]+$", x)) {
-      Sys_getenv(substr(x, 2, nchar(x)), error = error, default = NULL,
-                 name = join_name(name, nm))
+      Sys_getenv(substr(x, 2, nchar(x)), sprintf("%s:%s", used_in, nm),
+                 error = error, default = NULL)
     } else {
       x
     }
-  }
-  join_name <- function(a, b) {
-    if (is.null(a)) b else sprintf("%s:%s", a, b)
   }
   assert_named(x)
   Map(f, names(x), x)

--- a/R/util.R
+++ b/R/util.R
@@ -248,7 +248,7 @@ Sys_getenv <- function(x, used_in, error = TRUE, default = NULL) {
   if (is.na(v)) {
     if (error) {
       stop(sprintf("Environment variable '%s' is not set\n\t(used in %s)",
-                   x, used_in))
+                   x, used_in), call. = FALSE)
     } else {
       v <- default
     }

--- a/R/vault.R
+++ b/R/vault.R
@@ -3,9 +3,8 @@ resolve_secrets <- function(x, config) {
     return(x)
   }
   loadNamespace("vaultr")
-  name <- "orderly_config.yml:vault"
   withr::with_envvar(orderly_envir_read(config$root), {
-    vault_args <- resolve_env(config[["vault"]], name = name)
+    vault_args <- resolve_env(config[["vault"]], "orderly_config.yml:vault")
     vaultr::vault_resolve_secrets(x, vault_args = vault_args)
   })
 }

--- a/R/vault.R
+++ b/R/vault.R
@@ -3,7 +3,9 @@ resolve_secrets <- function(x, config) {
     return(x)
   }
   loadNamespace("vaultr")
-  withr::with_envvar(
-    orderly_envir_read(config$root),
-    vaultr::vault_resolve_secrets(x, vault_args = resolve_env(config[['vault']])))
+  name <- "orderly_config.yml:vault"
+  withr::with_envvar(orderly_envir_read(config$root), {
+    vault_args <- resolve_env(config[["vault"]], name = name)
+    vaultr::vault_resolve_secrets(x, vault_args = vault_args)
+  })
 }

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -8,7 +8,7 @@ test_that("read", {
   expect_equal(cfg$destination$driver, c("RSQLite", "SQLite"))
   expect_equal(cfg$destination$args, list(dbname = "orderly.sqlite"))
 
-  dat <- orderly_db_args(cfg$destination, cfg)
+  dat <- orderly_db_args(cfg$destination, cfg, "loc")
   expect_identical(dat$driver, RSQLite::SQLite)
   expect_identical(dat$args$dbname, file.path(cfg$root, "orderly.sqlite"))
 })
@@ -30,12 +30,13 @@ test_that("environment variables", {
 
   cfg <- orderly_config(path)
 
-  expect_error(orderly_db_args(cfg$database$source, cfg),
-               "Environment variable 'OURPASSWORD' is not set")
+  expect_error(
+    orderly_db_args(cfg$database$source, cfg, "loc"),
+    "Environment variable 'OURPASSWORD' is not set.*used in loc:password")
 
   dat <- withr::with_envvar(
     c(OURPASSWORD = "foo"),
-    orderly_db_args(cfg$database$source, cfg))
+    orderly_db_args(cfg$database$source, cfg, "loc"))
   expect_equal(dat$args$password, "foo")
   expect_equal(dat$args$host, "OURHOST")
 })

--- a/tests/testthat/test-envir.R
+++ b/tests/testthat/test-envir.R
@@ -12,7 +12,7 @@ test_that("set env", {
 
   config <- orderly_config(path)
 
-  expect_error(orderly_db_args(config$database$source, config),
+  expect_error(orderly_db_args(config$database$source, config, "loc"),
                "Environment variable 'MY_USER' is not set")
 
   writeLines(c("MY_USER: foo"), path_orderly_envir_yml(path))

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -60,7 +60,7 @@ test_that("resolve_env skips non-scalars", {
   set.seed(1)
   v <- paste(sample(c(LETTERS, 0:9, "_"), 20, replace = TRUE), collapse = "")
   vv <- paste0("$", v)
-  expect_identical(resolve_env(c(x = v)), list(x = v))
+  expect_identical(resolve_env(c(x = v), "loc"), list(x = v))
 
   env <- setNames("value", v)
   expect_identical(


### PR DESCRIPTION
This solves a problem where (say) a remote is configured like:

```
remote:
  main:
    driver: orderlyweb::orderlyweb_remote
    args:
      host: orderly.example.com
      port: 443
      token: $VAULT_AUTH_GITHUB_TOKEN
```

and the environment variable is not set.  At present the user just gets an error saying

```
> orderly_pull_dependencies("explore_delays", remote = "testing")
Error: 'token' must be a scalar
> traceback()
15: stop(sprintf("'%s' must be a scalar", name), call. = FALSE)
14: assert_scalar(x, name)
13: assert_scalar_character(token)
12: orderlyweb_token_constant(token)
11: .subset2(public_bind_env, "initialize")(...)
10: R6_orderlyweb_api_client$new(host, port, token, name = name, 
        https = https, prefix = prefix, api_version = api_version, 
        insecure = insecure, verbose = verbose)
9: orderlyweb_api_client(...)
8: orderlyweb(host = host, port = port, token = token, https = https, 
       prefix = prefix, name = name)
7: .subset2(public_bind_env, "initialize")(...)
6: R6_orderlyweb_remote$new(host, port, token, https, prefix, name)
5: (function (host, port, token, https = TRUE, prefix = NULL, name = NULL) 
   {
       R6_orderlyweb_remote$new(host, port, token, https, prefix, 
           name)
   })(host = "ncov.dide.ic.ac.uk", port = 1443L, token = NULL, name = "testing")
4: do.call(driver, args)
3: load_remote(remote, config)
2: get_remote(remote, config)
1: orderly_pull_dependencies("explore_delays", remote = "testing")
```

which is not helpful and not actionable.  Now the error would look like:

```
> orderly_pull_dependencies("explore_delays", remote = "testing")
Error: Environment variable 'VAULT_AUTH_GITHUB_TOKEN' is not set
	(used in orderly_config.yml:remote:testing:args:token)
```

which points much more effectively to the error!  This is added to all environment variables that are resolved from the configuration.

