### PR TITLE
vimc-3460: add orderly instance to cli runner and to the run rds

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.0.11
+Version: 1.0.12
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# orderly 1.0.12
+
+* The orderly CLI runner gets an `--instance` argument (VIMC-3460)
+* The instance information is saved into the `orderly_run.rds`.  This is not yet reflected in the database and might be tweaked before being added.
+
 # orderly 1.0.11
 
 * More informative error messages when orderly fails to resolve an environment variable, particularly when loading remote configuration (VIMC-3386)

--- a/R/db.R
+++ b/R/db.R
@@ -266,6 +266,9 @@ db_instance_select <- function(instance, config_db) {
                    paste(msg, collapse = ", ")),
            call. = FALSE)
     }
+    for (i in setdiff(names(which(has_instance)), names(instance))) {
+      instance[[i]] <- names(config_db[[i]]$instances)[[1]]
+    }
   }
 
   for (i in names(instance)) {

--- a/R/main.R
+++ b/R/main.R
@@ -102,13 +102,14 @@ usage_run <- "Usage:
   orderly run [options] <name> [<parameter>...]
 
 Options:
-  --no-commit     Do not commit the report
-  --print-log     Print the log (rather than storing it)
-  --id-file=FILE  File to write the id into
-  --ref=REF       Git reference (branch or sha) to use
-  --fetch         Fetch git before updating reference
-  --pull          Pull git before running report
-  --message=TEXT  A message explaining why the report was run
+  --instance=NAME  Database instance to use (if instances are configured)
+  --no-commit      Do not commit the report
+  --print-log      Print the log (rather than storing it)
+  --id-file=FILE   File to write the id into
+  --ref=REF        Git reference (branch or sha) to use
+  --fetch          Fetch git before updating reference
+  --pull           Pull git before running report
+  --message=TEXT   A message explaining why the report was run
 
 Parameters, if given, must be passed through in key=value pairs"
 
@@ -125,6 +126,7 @@ main_do_run <- function(x) {
   config <- orderly_config_get(x$options$root, TRUE)
   name <- x$options$name
   commit <- !x$options$no_commit
+  instance <- x$options$instance
   parameters <- x$options$parameters
   id_file <- x$options$id_file
   parameters <- x$options$parameters
@@ -144,6 +146,7 @@ main_do_run <- function(x) {
       }
     }
     id <- orderly_run(name, parameters, root = config, id_file = id_file,
+                      instance = instance,
                       ref = ref, fetch = fetch, message = message)
     if (commit) {
       orderly_commit(id, name, config)

--- a/R/recipe_run.R
+++ b/R/recipe_run.R
@@ -244,6 +244,7 @@ recipe_run <- function(info, parameters, envir, config, echo = TRUE,
                connection = !is.null(info$connection),
                packages = info$packages,
                random_seed = prep$random_seed,
+               instance = prep$instance,
                file_info_inputs = info$inputs,
                file_info_artefacts = file_info_artefacts,
                global_resources = info$global_resources,
@@ -357,6 +358,7 @@ recipe_data <- function(config, info, parameters, dest, instance) {
 
   con <- orderly_db("source", config, instance = instance)
   on.exit(lapply(con, DBI::dbDisconnect))
+  ret$instance <- lapply(con, attr, "instance", exact = TRUE)
 
   views <- info$views
   for (v in names(views)) {
@@ -543,6 +545,7 @@ orderly_prepare_data <- function(config, info, parameters, envir, instance) {
   }
 
   ret <- list(data = res$data, parameters = res$parameters,
+              instance = res$instance,
               n_dev = n_dev, n_sink = n_sink, random_seed = random_seed())
 
   if (!is.null(info$connection)) {

--- a/tests/testthat/test-db.R
+++ b/tests/testthat/test-db.R
@@ -285,16 +285,18 @@ test_that("db instance select", {
       driver = c("RSQLite", "SQLite"),
       args = list(name = "y")))
 
+  config_db_a <- modifyList(config_db, list(x = list(instance = "a")))
+  config_db_b <- modifyList(config_db, list(x = list(args = list(name = "b"),
+                                                     instance = "b")))
+
   ## The happy paths:
-  expect_identical(db_instance_select(NULL, config_db), config_db)
+  expect_identical(db_instance_select(NULL, config_db), config_db_a)
 
-  expect_equal(db_instance_select("a", config_db), config_db)
-  expect_equal(db_instance_select("b", config_db),
-               modifyList(config_db, list(x = list(args = list(name = "b")))))
+  expect_equal(db_instance_select("a", config_db), config_db_a)
+  expect_equal(db_instance_select("b", config_db), config_db_b)
 
-  expect_equal(db_instance_select(c(x = "a"), config_db), config_db)
-  expect_equal(db_instance_select(c(x = "b"), config_db),
-               modifyList(config_db, list(x = list(args = list(name = "b")))))
+  expect_equal(db_instance_select(c(x = "a"), config_db), config_db_a)
+  expect_equal(db_instance_select(c(x = "b"), config_db), config_db_b)
 
   expect_error(db_instance_select("c", config_db),
                "Invalid instance 'c' for database 'x'")
@@ -320,24 +322,28 @@ test_that("db instance select with two instanced databases", {
         c = list(name = "c"),
         a = list(name = "a"))))
 
-  ## The happy paths:
-  expect_identical(db_instance_select(NULL, config_db), config_db)
+  config_db_aa <- modifyList(config_db,
+                             list(x = list(args = list(name = "a"),
+                                           instance = "a"),
+                                  y = list(args = list(name = "a"),
+                                           instance = "a")))
+  config_db_bc <- modifyList(config_db, list(x = list(instance = "b"),
+                                             y = list(instance = "c")))
+  config_db_ac <- modifyList(config_db,
+                             list(x = list(args = list(name = "a"),
+                                           instance = "a"),
+                                  y = list(args = list(name = "c"),
+                                           instance = "c")))
 
-  expect_equal(
-    db_instance_select("a", config_db),
-    modifyList(config_db, list(x = list(args = list(name = "a")),
-                               y = list(args = list(name = "a")))))
-  expect_equal(
-    db_instance_select(c(x = "a", y = "a"), config_db),
-    modifyList(config_db, list(x = list(args = list(name = "a")),
-                               y = list(args = list(name = "a")))))
-  expect_equal(
-    db_instance_select(c(x = "b", y = "c"), config_db),
-    modifyList(config_db, list(x = list(args = list(name = "b")),
-                               y = list(args = list(name = "c")))))
-  expect_equal(
-    db_instance_select(c(x = "a"), config_db),
-    modifyList(config_db, list(x = list(args = list(name = "a")))))
+  ## The happy paths:
+  expect_identical(db_instance_select(NULL, config_db), config_db_bc)
+
+  expect_equal(db_instance_select("a", config_db), config_db_aa)
+  expect_equal(db_instance_select(c(x = "a", y = "a"), config_db),
+               config_db_aa)
+  expect_equal(db_instance_select(c(x = "b", y = "c"), config_db),
+               config_db_bc)
+  expect_equal(db_instance_select(c(x = "a"), config_db), config_db_ac)
 
   ## Some error paths:
   expect_error(db_instance_select("f", config_db),

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -825,6 +825,14 @@ test_that("run with different database instance", {
   expect_equal(f(id1), 20)
   expect_equal(f(id2), 20)
   expect_equal(f(id3), 10)
+
+  g <- function(id) {
+    d <- readRDS(file.path(path, "draft", "example", id, "orderly_run.rds"))
+    d$meta$instance
+  }
+  expect_equal(g(id1), list(source = "default"))
+  expect_equal(g(id2), list(source = "default"))
+  expect_equal(g(id3), list(source = "alternative"))
 })
 
 


### PR DESCRIPTION
This PR adds an `--instance` switch to the cli. So far so easy.

If we make it easy to change the instance we need to record what was used!  So this makes a quick stab at recording the used instance into the orderly_run.rds.  This does not affect many reports (as in, instances are only a thing since recently) but it would be nice to get this in asap so that we can easily work out what came from where. Later we might lock down instance on production too