### PR TITLE
vimc-3466: expose the dependency pull on the CLI

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.0.12
+Version: 1.0.13
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# orderly 1.0.13
+
+* The orderly CLI runner gets a `pull` sub command for pulling dependencies from remote orderly servers (VIMC-3466)
+
 # orderly 1.0.12
 
 * The orderly CLI runner gets an `--instance` argument (VIMC-3460)

--- a/R/main.R
+++ b/R/main.R
@@ -43,6 +43,7 @@ Commands:
   commit       Commit a report
   list         List reports
   latest       Find the most recent report
+  pull         Pull reports from remote servers
   cleanup      Remove drafts and dangling data
   rebuild      Rebuild the database
   migrate      Migrate the archive"
@@ -266,6 +267,34 @@ main_do_latest <- function(x) {
 }
 
 
+usage_pull <- "Usage:
+  orderly pull [options] <name>...
+Options:
+  --dependencies  Pull *dependencies* of the report, not the report itself
+  --id=ID         The id to use when pulling a single report (default: latest)
+  --remote=NAME   Name of the remote to pull from"
+
+
+main_do_pull <- function(x) {
+  root <- x$options$root
+  name <- x$options$name
+  id <- x$options$id
+  remote <- x$options$remote
+  dependencies <- x$options$dependencies
+
+  if (dependencies) {
+    if (!is.null(id)) {
+      stop("Do not provide --id with --dependencies", call. = FALSE)
+    }
+    orderly_pull_dependencies(name, remote = remote,
+                              root = root, locate = TRUE)
+  } else {
+    orderly_pull_archive(name, id, remote = remote,
+                         root = root, locate = TRUE)
+  }
+}
+
+
 ## 8. migrate
 usage_migrate <- "Usage:
   orderly migrate [options]
@@ -316,6 +345,9 @@ cli_commands <- function() {
        latest = list(name = "find most recent report",
                      usage = usage_latest,
                      target = main_do_latest),
+       pull = list(name = "pull reports from remote servers",
+                   usage = usage_pull,
+                   target = main_do_pull),
        cleanup = list(name = "remove drafts and dangling data",
                       usage = usage_cleanup,
                       target = main_do_cleanup),

--- a/tests/testthat/test-main.R
+++ b/tests/testthat/test-main.R
@@ -215,6 +215,50 @@ test_that("latest", {
 })
 
 
+test_that("pull dependencies", {
+  skip_on_cran_windows()
+
+  dat <- prepare_orderly_remote_example()
+
+  args <- c("--root", dat$path_local, "pull", "--dependencies", "depend",
+            "--remote", "default")
+  res <- cli_args_process(args)
+
+  expect_equal(res$command, "pull")
+  expect_equal(res$options$name, "depend")
+  expect_true(res$options$dependencies)
+  expect_equal(res$options$remote, "default")
+  expect_null(res$options$id)
+  expect_identical(res$target, main_do_pull)
+
+  res$target(res)
+  expect_equal(orderly_list_archive(dat$config),
+               data_frame(name = "example", id = dat$id2))
+})
+
+
+test_that("pull archive", {
+  skip_on_cran_windows()
+
+  dat <- prepare_orderly_remote_example()
+
+  args <- c("--root", dat$path_local, "pull", "example",
+            "--remote", "default", "--id", dat$id1)
+  res <- cli_args_process(args)
+
+  expect_equal(res$command, "pull")
+  expect_equal(res$options$name, "example")
+  expect_false(res$options$dependencies)
+  expect_equal(res$options$remote, "default")
+  expect_equal(res$options$id, dat$id1)
+  expect_identical(res$target, main_do_pull)
+
+  res$target(res)
+  expect_equal(orderly_list_archive(dat$config),
+               data_frame(name = "example", id = dat$id1))
+})
+
+
 test_that("list", {
   skip_on_cran_windows()
   path <- prepare_orderly_example("minimal")

--- a/tests/testthat/test-main.R
+++ b/tests/testthat/test-main.R
@@ -259,6 +259,16 @@ test_that("pull archive", {
 })
 
 
+test_that("pull --dependencies and --id are incompatible", {
+  args <- c("pull", "example", "--id", "myid", "--dependencies")
+  res <- cli_args_process(args)
+  expect_error(
+    res$target(res),
+    "Do not provide --id with --dependencies",
+    fixed = TRUE)
+})
+
+
 test_that("list", {
   skip_on_cran_windows()
   path <- prepare_orderly_example("minimal")


### PR DESCRIPTION
This adds a `pull` sub command that allows pulling a report or a dependency.  This might come in useful if we use that larger cluster node for running some reports.