### PR TITLE
mrc-3467: don't count failed drafts when using dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.0.14
+Version: 1.0.15
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# orderly 1.0.15
+
+* Depending on draft reports, including with `use_draft = "newer"`, no longer pulls in failed drafts (VIMC-3467, reported by @sangeetabhatia03)
+
 # orderly 1.0.14
 
 * Functionality for creating dependency graphs for reports using orderly::orderly_graph (VIMC-2174)

--- a/R/cleanup.R
+++ b/R/cleanup.R
@@ -50,7 +50,8 @@ orderly_cleanup <- function(name = NULL, root = NULL, locate = TRUE,
 
 orderly_cleanup_drafts <- function(config, name = NULL, failed_only = FALSE) {
   assert_is(config, "orderly_config")
-  d <- orderly_list_drafts(config, FALSE)
+
+  d <- orderly_list_drafts(config, FALSE, include_failed = TRUE)
   if (!is.null(name)) {
     assert_character(name)
     d <- d[d$name %in% name, , drop = FALSE]

--- a/R/query.R
+++ b/R/query.R
@@ -46,6 +46,11 @@ orderly_list <- function(root = NULL, locate = TRUE) {
 ##'
 ##' @inheritParams orderly_list
 ##'
+##' @param include_failed Logical, indicating if failed drafts should
+##'   be listed (only has an effect for \code{orderly_list_drafts} as
+##'   no failed run should make it into the archive).  A failed report
+##'   is one that lacks an \code{orderly_run.rds} file.
+##'
 ##' @seealso \code{\link{orderly_list}}, which lists the names of
 ##'   source reports that can be run, and \code{\link{orderly_latest}}
 ##'   which returns the id of the most recent report.
@@ -81,8 +86,9 @@ orderly_list <- function(root = NULL, locate = TRUE) {
 ##'
 ##' # And the second report is in the archive:
 ##' orderly::orderly_list_archive(path)
-orderly_list_drafts <- function(root = NULL, locate = TRUE) {
-  orderly_list2(TRUE, root, locate)
+orderly_list_drafts <- function(root = NULL, locate = TRUE,
+                                include_failed = FALSE) {
+  orderly_list2(TRUE, root, locate, include_failed)
 }
 
 ##' @export
@@ -158,11 +164,13 @@ orderly_latest <- function(name = NULL, root = NULL, locate = TRUE,
 }
 
 
-orderly_list2 <- function(draft, root = NULL, locate = TRUE) {
+orderly_list2 <- function(draft, root = NULL, locate = TRUE,
+                          include_failed = FALSE) {
   config <- orderly_config_get(root, locate)
   path <- if (draft) path_draft else path_archive
   check <- list_dirs(path(config$root))
-  res <- lapply(check, orderly_list_dir, check_run_rds = draft)
+  check_run_rds <- draft && !include_failed
+  res <- lapply(check, orderly_list_dir, check_run_rds = check_run_rds)
   data.frame(name = rep(basename(check), lengths(res)),
              id = as.character(unlist(res)),
              stringsAsFactors = FALSE)

--- a/R/query.R
+++ b/R/query.R
@@ -141,7 +141,7 @@ orderly_latest <- function(name = NULL, root = NULL, locate = TRUE,
   } else {
     path <-
       file.path((if (draft) path_draft else path_archive)(config$root), name)
-    ids <- orderly_list_dir(path)
+    ids <- orderly_list_dir(path, check_run_rds = draft)
   }
 
   if (length(ids) == 0L) {
@@ -162,7 +162,7 @@ orderly_list2 <- function(draft, root = NULL, locate = TRUE) {
   config <- orderly_config_get(root, locate)
   path <- if (draft) path_draft else path_archive
   check <- list_dirs(path(config$root))
-  res <- lapply(check, orderly_list_dir)
+  res <- lapply(check, orderly_list_dir, check_run_rds = draft)
   data.frame(name = rep(basename(check), lengths(res)),
              id = as.character(unlist(res)),
              stringsAsFactors = FALSE)
@@ -286,7 +286,7 @@ latest_id <- function(ids) {
 }
 
 
-orderly_list_dir <- function(path) {
+orderly_list_dir <- function(path, check_run_rds = FALSE) {
   files <- dir(path)
   err <- !grepl(VERSION_ID_RE, files)
   if (any(err)) {
@@ -294,5 +294,11 @@ orderly_list_dir <- function(path) {
                  path, paste(squote(files[err]), collapse = ", ")),
          call. = FALSE)
   }
+
+  if (check_run_rds && length(files) > 0L) {
+    keep <- file.exists(path_orderly_run_rds(file.path(path, files)))
+    files <- files[keep]
+  }
+
   files
 }

--- a/man/orderly_list_drafts.Rd
+++ b/man/orderly_list_drafts.Rd
@@ -5,7 +5,7 @@
 \alias{orderly_list_archive}
 \title{List draft and archived reports}
 \usage{
-orderly_list_drafts(root = NULL, locate = TRUE)
+orderly_list_drafts(root = NULL, locate = TRUE, include_failed = FALSE)
 
 orderly_list_archive(root = NULL, locate = TRUE)
 }
@@ -18,6 +18,11 @@ directory if \code{locate} is \code{TRUE}.}
 searched for.  If \code{TRUE} and \code{config} is not given,
 then orderly looks in the working directory and up through its
 parents until it finds an \code{orderly_config.yml} file.}
+
+\item{include_failed}{Logical, indicating if failed drafts should
+be listed (only has an effect for \code{orderly_list_drafts} as
+no failed run should make it into the archive).  A failed report
+is one that lacks an \code{orderly_run.rds} file.}
 }
 \value{
 A \code{data.frame} with columns \code{name} and

--- a/tests/testthat/test-cleanup.R
+++ b/tests/testthat/test-cleanup.R
@@ -55,11 +55,11 @@ test_that("cleanup failed", {
   id3 <- tryCatch(orderly_run("example", root = path, echo = FALSE),
                   error = function(e) NULL)
   expect_null(id3)
-  d <- orderly_list_drafts("example", root = path)
+  d <- orderly_list_drafts("example", root = path, include_failed = TRUE)
   expect_equal(nrow(d), 3)
 
   orderly_cleanup(root = path, failed_only = TRUE)
-  d <- orderly_list_drafts("example", root = path)
+  d <- orderly_list_drafts("example", root = path, include_failed = TRUE)
   expect_equal(nrow(d), 2)
   expect_true(all(c(id1, id2) %in% d$id))
 })

--- a/tests/testthat/test-query.R
+++ b/tests/testthat/test-query.R
@@ -159,6 +159,25 @@ test_that("Behaviour with rogue files", {
 })
 
 
+test_that("orderly_latest does not find failed drafts", {
+  testthat::skip_on_cran()
+  path <- prepare_orderly_example("minimal")
+  id1 <- orderly_run("example", root = path, echo = FALSE)
+  id2 <- orderly_run("example", root = path, echo = FALSE)
+  file.remove(file.path(path, "draft", "example", id2, "orderly_run.rds"))
+
+  expect_setequal(
+    orderly_list_dir(file.path(path, "draft", "example")),
+    c(id1, id2))
+  expect_setequal(
+    orderly_list_dir(file.path(path, "draft", "example"), TRUE),
+    id1)
+
+  expect_equal(orderly_latest("example", draft = TRUE, root = path), id1)
+  expect_equal(orderly_list_drafts("example", root = path)$id, id1)
+})
+
+
 test_that("orderly_find_report", {
   skip_on_cran_windows()
   path <- prepare_orderly_example("minimal")

--- a/tests/testthat/test-recipe-read.R
+++ b/tests/testthat/test-recipe-read.R
@@ -217,6 +217,30 @@ test_that("dependencies draft, new interface", {
 })
 
 
+test_that("use_draft = newer ignores fails drafts", {
+  path <- prepare_orderly_example("depends", testing = TRUE)
+  id1 <- orderly_run("example", root = path, echo = FALSE)
+  id2 <- orderly_run("example", root = path, echo = FALSE)
+  id3 <- orderly_run("example", root = path, echo = FALSE)
+  orderly_commit(id1, root = path)
+  unlink(file.path(path, "draft", "example", id3, "orderly_run.rds"))
+
+  filename <- file.path(path, "src", "depend", "orderly.yml")
+  dat <- yaml_read(filename)
+  dat$depends$example$draft <- NULL
+  yaml_write(dat, filename)
+
+  config <- orderly_config(path)
+  info <- recipe_read(file.path(path, "src", "depend"), config,
+                      use_draft = "newer")
+  expect_equal(basename(info$depends$path), id2)
+  unlink(file.path(path, "draft", "example", id2, "orderly_run.rds"))
+  info <- recipe_read(file.path(path, "src", "depend"), config,
+                      use_draft = "newer")
+  expect_equal(basename(info$depends$path), id1)
+})
+
+
 test_that("dependencies draft, new interface, throws sensible errors", {
   path <- prepare_orderly_example("depends", testing = TRUE)
 

--- a/tests/testthat/test-z-runner.R
+++ b/tests/testthat/test-z-runner.R
@@ -231,7 +231,9 @@ test_that("cleanup", {
   expect_message(runner$cleanup(), "clean.+draft/example")
   expect_silent(runner$cleanup())
 
-  expect_equal(nrow(orderly_list2(TRUE, root = path)), 0L)
+  expect_equal(
+    nrow(orderly_list2(TRUE, root = path, include_failed = TRUE)),
+    0L)
   expect_equal(orderly_list2(FALSE, root = path)$id, id)
 })
 


### PR DESCRIPTION
This PR fixes a fairly subtle bug found by @sangeetabhatia03 in the ncov project.

When dependencies are allowed to be drafts (e.g., with `use_draft = TRUE`, `use_draft = "newer"` or with `draft: true` in the orderly.yml), then there is a chance that we will pull in a failed version.  This PR modifies the query functions to skip over these most of the time.  Failed reports are detected by the presence of `orderly_run.rds`