### PR TITLE
VIMC-2929: Remove custom fields from main orderly table

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.4.9
+Version: 1.4.10
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/R/db2.R
+++ b/R/db2.R
@@ -8,7 +8,7 @@
 ## namespace/module feature so that implementation details can be
 ## hidden away a bit further.
 
-orderly_schema_version <- "1.2.39"
+orderly_schema_version <- "1.3.0"
 orderly_schema_table <- "orderly_schema"
 orderly_table_list <- "orderly_schema_tables"
 
@@ -23,14 +23,6 @@ report_db_schema_read <- function(fields = NULL, dialect = "sqlite") {
   }
 
   d <- set_names(lapply(names(d), preprepare), names(d))
-
-  ## Delete with VIMC-2929
-  if (!is.null(fields)) {
-    f <- set_names(Map(function(t, n) list(type = t, nullable = n),
-                       rep("character", nrow(fields)), !fields$required),
-                   fields$name)
-    d[["report_version"]]$columns <- c(d[["report_version"]]$columns, f)
-  }
 
   prepare_table <- function(x) {
     prepare_col <- function(nm) {
@@ -303,10 +295,7 @@ report_data_import <- function(con, dat_rds, config) {
     git_sha = dat_rds$git$sha %||% NA_character_,
     git_branch = dat_rds$git$branch %||% NA_character_,
     git_clean = git_clean)
-  ## TODO: Delete with VIMC-2929
-  if (!is.null(dat_rds$meta$extra_fields)) {
-    report_version <- cbind(report_version, dat_rds$meta$extra_fields)
-  }
+
   DBI::dbWriteTable(con, "report_version", report_version, append = TRUE)
 
   if (!is.null(dat_rds$meta$extra_fields)) {

--- a/inst/database/schema.yml
+++ b/inst/database/schema.yml
@@ -39,8 +39,6 @@ report_version:
     - git_sha: {type: TEXT, nullable: true}
     - git_branch: {type: TEXT, nullable: true}
     - git_clean: {type: BOOLEAN, nullable: true}
-    # NOTE: fields listed in orderly_config.yml will also be
-    # included here.
 
 # Custom fields - all coerced into text.
 report_version_custom_fields:


### PR DESCRIPTION
Comment 2020: This removes the last bit of the pre-proper-schema orderly db - adding custom fields to the report_version table.  The schema version number increases (which triggers a db rebuild) but this should have minimal visibility to users.

This should be tested on uat with montagu pointing at this version to make sure nothing breaks.

Comment 2022: This has to be merged/deployed in lock step with https://github.com/vimc/orderly-web/pull/476 (and waiting for OW master build to be fixed before that build can pass!) Then will need to rebuild `orderly.server`.