### PR TITLE
VIMC-3511: Better error messages when artefacts are provided as string array

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.1.1
+Version: 1.1.2
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# orderly 1.1.2
+
+* Improved error message with misformatted artefacts (VIMC-3511, reported by @jeffeaton)
+
 # orderly 1.1.1
 
 * Dependencies can be resolved as if they were to be run on a remote (including appropriate selection of "latest" dependencies).  This is to support future decentralised workflows (VIMC-3473)

--- a/R/recipe_read.R
+++ b/R/recipe_read.R
@@ -162,6 +162,23 @@ recipe_read_check_artefacts <- function(x, filename, path) {
     stop("At least one artefact required")
   }
 
+  if (is.character(x)) {
+    msg <- c("Your artefacts are misformatted.  You must provide a 'type'",
+             "and a description for each, and each logical artefact may",
+             "contain multiple files.  For example, you might use",
+             "",
+             "artefacts:",
+             "  - data:",
+             "      description: These are data for x, y, z",
+             "      filenames:",
+             sprintf("        - %s", x),
+             "",
+             sprintf("other alternatives to 'data' are %s",
+                     paste(squote(setdiff(valid_formats(), "data")),
+                           collapse = ", ")))
+    stop(paste(msg, collapse = "\n"), call. = FALSE)
+  }
+
   ## There are two valid options here:
   ##
   ## artefacts:


### PR DESCRIPTION
As reported by @jeffeaton in VIMC-3503/#174, this PR adds a more human friendly check.  If artefacts are provided like:

```
artefacts:
  - survey_individuals.csv
```

the error message now says:

```
Error: Your artefacts are misformatted.  You must provide a 'type'
and a description for each, and each logical artefact may
contain multiple files.  For example, you might use

artefacts:
  - data:
      description: These are data for x, y, z
      filenames:
        - survey_individuals.csv

other alternatives to 'data' are 'staticgraph', 'interactivegraph', 'report', 'interactivehtml'
```

It *always* proposes `data` as an artefact type, as everything is kind of data.

Fixes #168