### PR TITLE
VIMC-3514: Basic support for tags

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.1.4
+Version: 1.1.5
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# orderly 1.1.5
+
+* Introduce the concept of "tags"; these are immutable and exist at the level of a report version.  Currently there is nothing that can be done with tags, but these will become useful in conjuction with [OrderlyWeb](https://github.com/vimc/orderly-web) (VIMC-3514)
+
 # orderly 1.1.4
 
 * Automatic creation of `.gitignore` files with `orderly::orderly_use_gitignore` (VIMC-3513, reported by @jeffeaton)

--- a/R/config.R
+++ b/R/config.R
@@ -13,7 +13,7 @@ orderly_config_read_yaml <- function(filename, root) {
   check_fields(info, filename, character(),
                c("destination", "fields", "minimum_orderly_version",
                  "remote", "vault", "vault_server", "global_resources",
-                 "changelog", "source", "database"))
+                 "changelog", "tags", "source", "database"))
 
   ## There's heaps of really boring validation to do here that I am
   ## going to skip.  The drama that we will have is that there are
@@ -43,6 +43,10 @@ orderly_config_read_yaml <- function(filename, root) {
 
   if (!is.null(info$changelog)) {
     info$changelog <- config_check_changelog(info$changelog, filename)
+  }
+
+  if (!is.null(info$tags)) {
+    assert_character(info$tags, sprintf("%s:tags", filename))
   }
 
   v <- info$minimum_orderly_version

--- a/R/db2.R
+++ b/R/db2.R
@@ -8,7 +8,7 @@
 ## namespace/module feature so that implementation details can be
 ## hidden away a bit further.
 
-ORDERLY_SCHEMA_VERSION <- "0.0.9"
+ORDERLY_SCHEMA_VERSION <- "0.0.10"
 
 ## These will be used in a few places and even though they're not
 ## super likely to change it would be good

--- a/R/db2.R
+++ b/R/db2.R
@@ -143,6 +143,7 @@ report_db_init <- function(con, config, must_create = FALSE, validate = TRUE) {
 report_db_init_create <- function(con, config, dialect) {
   dat <- report_db_schema(config$fields, dialect)
   dat$values$changelog_label <- config$changelog
+  dat$values$tag <- data_frame(id = config$tags)
 
   DBI::dbBegin(con)
   on.exit(DBI::dbRollback(con))
@@ -187,6 +188,14 @@ report_db_open_existing <- function(con, config) {
   if (!ok) {
     stop(
       "changelog labels have changed: rebuild with orderly::orderly_rebuild()",
+      call. = FALSE)
+  }
+
+  tag <- DBI::dbReadTable(con, "tag")$id
+  ok <- setequal(tag, config$tags)
+  if (!ok) {
+    stop(
+      "tags have changed: rebuild with orderly::orderly_rebuild()",
       call. = FALSE)
   }
 }

--- a/R/db2.R
+++ b/R/db2.R
@@ -393,6 +393,13 @@ report_data_import <- function(con, name, id, config) {
     }
   }
 
+  tags <- dat_rds$meta$tags
+  if (!is.null(tags)) {
+    report_version_tag <- data_frame(report_version = id, tag = tags)
+    DBI::dbWriteTable(con, "report_version_tag", report_version_tag,
+                      append = TRUE)
+  }
+
   if (!is.null(dat_rds$meta$parameters)) {
     p <- dat_rds$meta$parameters
     parameters <- data_frame(

--- a/R/recipe_read.R
+++ b/R/recipe_read.R
@@ -35,6 +35,7 @@ recipe_read <- function(path, config, validate = TRUE, use_draft = FALSE,
                 "connection",
                 "depends",
                 "global_resources",
+                "tags",
                 config$fields$name[!config$fields$required])
 
   recipe_read_skip_on_develop(
@@ -78,10 +79,8 @@ recipe_read <- function(path, config, validate = TRUE, use_draft = FALSE,
   }
 
   recipe_read_check_sources(info$sources, info$resources, filename, path)
-  if (!is.null(info$sources)) {
-    assert_character(info$sources, fieldname("sources"))
-    assert_file_exists(file.path(path, info$sources))
-  }
+  info$tags <- recipe_read_check_tags(info$tags, config, filename)
+
   if (!is.null(info$connection)) {
     if (length(config$database) == 0L) {
       stop("No databases are configured - can't use a 'connection' section")
@@ -416,4 +415,22 @@ recipe_read_skip_on_develop <- function(develop, expr) {
   } else {
     force(expr)
   }
+}
+
+
+recipe_read_check_tags <- function(tags, config, filename) {
+  if (!is.null(tags)) {
+    assert_character(tags, sprintf("%s:tags", filename))
+    err <- setdiff(tags, config$tags)
+    if (length(err) > 0L) {
+      stop("Unknown tag: ", paste(squote(err), collapse = ", "),
+           call. = FALSE)
+    }
+    err <- unique(tags[duplicated(tags)])
+    if (length(err) > 0L) {
+      stop("Duplicated tag: ", paste(squote(err), collapse = ", "),
+           call. = FALSE)
+    }
+  }
+  tags
 }

--- a/R/recipe_read.R
+++ b/R/recipe_read.R
@@ -79,7 +79,7 @@ recipe_read <- function(path, config, validate = TRUE, use_draft = FALSE,
   }
 
   recipe_read_check_sources(info$sources, info$resources, filename, path)
-  info$tags <- recipe_read_check_tags(info$tags, config, filename)
+  info$tags <- recipe_read_check_tags(info$tags, config, fieldname("tags"))
 
   if (!is.null(info$connection)) {
     if (length(config$database) == 0L) {
@@ -418,9 +418,12 @@ recipe_read_skip_on_develop <- function(develop, expr) {
 }
 
 
-recipe_read_check_tags <- function(tags, config, filename) {
+recipe_read_check_tags <- function(tags, config, name) {
   if (!is.null(tags)) {
-    assert_character(tags, sprintf("%s:tags", filename))
+    if (is.null(config$tags)) {
+      stop("Tags are not supported; please edit orderly_config.yml to enable")
+    }
+    assert_character(tags, name)
     err <- setdiff(tags, config$tags)
     if (length(err) > 0L) {
       stop("Unknown tag: ", paste(squote(err), collapse = ", "),

--- a/R/recipe_run.R
+++ b/R/recipe_run.R
@@ -83,6 +83,12 @@
 ##'   "remote"} approach will use the latest approach in the
 ##'   \emph{remote} archive (which might be less recent).
 ##'
+##' @param tags Character vector of tags to add to the report.  Tags
+##'   are immutable and cannot be removed once the report is run.
+##'   Tags added here will be \emph{in addition} to any tags listed in
+##'   the \code{tags:} field in \code{orderly.yml} and must be present
+##'   in \code{orderly_config.yml}.
+##'
 ##' @seealso \code{\link{orderly_log}} for controlling display of log
 ##'   messages (not just R output)
 ##'
@@ -119,7 +125,7 @@ orderly_run <- function(name, parameters = NULL, envir = NULL,
                         root = NULL, locate = TRUE, echo = TRUE,
                         id_file = NULL, fetch = FALSE, ref = NULL,
                         message = NULL, instance = NULL, use_draft = FALSE,
-                        remote = NULL) {
+                        remote = NULL, tags = NULL) {
   envir <- orderly_environment(envir)
   config <- orderly_config_get(root, locate)
   config <- check_orderly_archive_version(config)
@@ -129,7 +135,7 @@ orderly_run <- function(name, parameters = NULL, envir = NULL,
   }
 
   info <- recipe_prepare(config, name, id_file, ref, fetch, message,
-                         use_draft, remote)
+                         use_draft, remote, tags = tags)
 
   recipe_current_run_set(info)
   on.exit(recipe_current_run_clear())
@@ -144,7 +150,7 @@ orderly_run <- function(name, parameters = NULL, envir = NULL,
 recipe_prepare <- function(config, name, id_file = NULL, ref = NULL,
                            fetch = FALSE, message = NULL,
                            use_draft = FALSE, remote = NULL,
-                           copy_files = TRUE) {
+                           copy_files = TRUE, tags = NULL) {
   assert_is(config, "orderly_config")
   config <- orderly_config_get(config, FALSE)
 
@@ -159,6 +165,10 @@ recipe_prepare <- function(config, name, id_file = NULL, ref = NULL,
 
   info <- recipe_read(file.path(path_src(config$root), name),
                       config, use_draft = use_draft, remote = remote)
+
+  if (!is.null(tags)) {
+    info$tags <- union(info$tags, recipe_read_check_tags(tags, config, "tags"))
+  }
 
   id <- new_report_id()
   orderly_log("id", id)

--- a/R/recipe_run.R
+++ b/R/recipe_run.R
@@ -270,6 +270,7 @@ recipe_run <- function(info, parameters, envir, config, echo = TRUE,
                depends = depends,
                elapsed = as.numeric(elapsed, "secs"),
                changelog = info$changelog,
+               tags = info$tags,
                git = info$git)
 
   ## All the information about data - it's a little more complicated

--- a/inst/database/schema.yml
+++ b/inst/database/schema.yml
@@ -227,3 +227,13 @@ parameters:
           between integers and floating pointe numbers, instead using
           just "number" for both.  When storing booleans, we store
           lower case "true"/"false", like in JSON, and not like R.
+
+tag:
+  columns:
+    - id: {type: TEXT}
+
+report_version_tag:
+  columns:
+    - id: {type: SERIAL}
+    - report_version: {fk: report_version.id}
+    - tag: {fk: tag.id}

--- a/inst/examples/demo/orderly_config.yml
+++ b/inst/examples/demo/orderly_config.yml
@@ -21,5 +21,9 @@ changelog:
   public:
     public: true
 
+tags:
+  - dataset
+  - plot
+
 global_resources:
   global

--- a/inst/examples/demo/src/interactive/orderly.yml
+++ b/inst/examples/demo/src/interactive/orderly.yml
@@ -12,3 +12,5 @@ artefacts:
 author: Dr Fun
 requester: ACME
 comment: This is a comment about the interactive report
+tags:
+  - plot

--- a/inst/examples/demo/src/other/orderly.yml
+++ b/inst/examples/demo/src/other/orderly.yml
@@ -20,3 +20,5 @@ description: >-
 author: Dr Serious
 requester: ACME
 comment: This is another comment
+tags:
+  - dataset

--- a/man/orderly_run.Rd
+++ b/man/orderly_run.Rd
@@ -17,7 +17,8 @@ orderly_run(
   message = NULL,
   instance = NULL,
   use_draft = FALSE,
-  remote = NULL
+  remote = NULL,
+  tags = NULL
 )
 }
 \arguments{
@@ -80,6 +81,12 @@ with \code{remote = NULL}, as the pull/run approach will use the
 latest report in \emph{your} archive but the \code{remote =
 "remote"} approach will use the latest approach in the
 \emph{remote} archive (which might be less recent).}
+
+\item{tags}{Character vector of tags to add to the report.  Tags
+are immutable and cannot be removed once the report is run.
+Tags added here will be \emph{in addition} to any tags listed in
+the \code{tags:} field in \code{orderly.yml} and must be present
+in \code{orderly_config.yml}.}
 }
 \value{
 The id of the newly created report

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -425,3 +425,22 @@ test_that("default instance from an environmental variable", {
   cfg <- orderly_config(path)
   expect_equal(cfg$database$source$args, list(dbname = "production.sqlite"))
 })
+
+
+test_that("tags can be included in the configuration", {
+  path <- prepare_orderly_example("minimal")
+  expect_null(orderly_config(path)$tags)
+  p <- file.path(path, "orderly_config.yml")
+  append_lines(c("tags:", "  - tag1", "  - tag2"), p)
+  expect_equal(orderly_config(path)$tags, c("tag1", "tag2"))
+})
+
+
+test_that("tags are validated", {
+  path <- prepare_orderly_example("minimal")
+  p <- file.path(path, "orderly_config.yml")
+  append_lines(c("tags:", "  - 1", "  - 2"), p)
+  expect_error(
+    orderly_config(path),
+    "orderly_config.yml:tags' must be character")
+})

--- a/tests/testthat/test-db.R
+++ b/tests/testthat/test-db.R
@@ -390,3 +390,20 @@ test_that("Create and verify tags on startup", {
                data_frame(id = c("tag1", "tag2", "tag3")))
   DBI::dbDisconnect(con)
 })
+
+
+test_that("Add tags to db", {
+  root <- prepare_orderly_example("minimal")
+  append_lines(c("tags:", "  - tag1", "  - tag2"),
+               file.path(root, "orderly_config.yml"))
+  append_lines(c("tags:", "  - tag1"),
+               file.path(root, "src", "example", "orderly.yml"))
+  id <- orderly_run("example", root = root, echo = FALSE)
+  p <- orderly_commit(id, root = root)
+
+  con <- orderly_db("destination", root)
+  on.exit(DBI::dbDisconnect(con))
+  expect_equal(
+    DBI::dbReadTable(con, "report_version_tag"),
+    data_frame(id = 1, report_version = id, tag = "tag1"))
+})

--- a/tests/testthat/test-recipe-read.R
+++ b/tests/testthat/test-recipe-read.R
@@ -684,3 +684,17 @@ test_that("Validate report tag", {
   expect_error(recipe_read(path, config),
                "Duplicated tag: 'tag1'")
 })
+
+
+test_that("Better error message where tags not enabled", {
+  root <- prepare_orderly_example("minimal")
+  config <- orderly_config(root)
+  path <- file.path(root, "src", "example")
+  path_config <- file.path(path, "orderly.yml")
+  txt <- readLines(path_config)
+
+  writeLines(c(txt, "tags: tag1"), path_config)
+  expect_error(
+    recipe_read(path, config)$tags,
+    "Tags are not supported; please edit orderly_config.yml to enable")
+})

--- a/tests/testthat/test-recipe-read.R
+++ b/tests/testthat/test-recipe-read.R
@@ -657,3 +657,30 @@ test_that("Read completely empty orderly.yml", {
     recipe_read(p, config, develop = TRUE),
     "Fields missing from .*: script, artefacts")
 })
+
+
+test_that("Validate report tag", {
+  root <- prepare_orderly_example("minimal")
+  append_lines(c("tags:", "  - tag1", "  - tag2"),
+               file.path(root, "orderly_config.yml"))
+  config <- orderly_config(root)
+  path <- file.path(root, "src", "example")
+  path_config <- file.path(path, "orderly.yml")
+  txt <- readLines(path_config)
+
+  expect_null(recipe_read(path, config)$tags)
+
+  writeLines(c(txt, "tags: tag1"), path_config)
+  expect_equal(recipe_read(path, config)$tags, "tag1")
+
+  writeLines(c(txt, "tags:", "- tag1", "- tag2"), path_config)
+  expect_equal(recipe_read(path, config)$tags, c("tag1", "tag2"))
+
+  writeLines(c(txt, "tags:", "- tag1", "- tag2", "- tag3"), path_config)
+  expect_error(recipe_read(path, config),
+               "Unknown tag: 'tag3'")
+
+  writeLines(c(txt, "tags:", "- tag1", "- tag2", "- tag1"), path_config)
+  expect_error(recipe_read(path, config),
+               "Duplicated tag: 'tag1'")
+})

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -848,3 +848,16 @@ test_that("Require simple parameters", {
                 root = path, echo = FALSE),
     "Invalid parameters: 'a', 'b' - must be scalar")
 })
+
+
+test_that("preserve tags in metadata", {
+  root <- prepare_orderly_example("minimal")
+  append_lines(c("tags:", "  - tag1", "  - tag2"),
+               file.path(root, "orderly_config.yml"))
+  append_lines(c("tags:", "  - tag1"),
+               file.path(root, "src", "example", "orderly.yml"))
+
+  id <- orderly_run("example", root = root, echo = FALSE)
+  d <- readRDS(path_orderly_run_rds(file.path(root, "draft", "example", id)))
+  expect_equal(d$meta$tags, "tag1")
+})

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -861,3 +861,27 @@ test_that("preserve tags in metadata", {
   d <- readRDS(path_orderly_run_rds(file.path(root, "draft", "example", id)))
   expect_equal(d$meta$tags, "tag1")
 })
+
+
+test_that("Pass tags during run", {
+  root <- prepare_orderly_example("minimal")
+  append_lines(c("tags:", "  - tag1", "  - tag2"),
+               file.path(root, "orderly_config.yml"))
+  append_lines(c("tags:", "  - tag1"),
+               file.path(root, "src", "example", "orderly.yml"))
+
+  ## Add new tag
+  id <- orderly_run("example", root = root, echo = FALSE, tags = "tag2")
+  d <- readRDS(path_orderly_run_rds(file.path(root, "draft", "example", id)))
+  expect_equal(d$meta$tags, c("tag1", "tag2"))
+
+  ## Ignore already present tag
+  id <- orderly_run("example", root = root, echo = FALSE, tags = "tag1")
+  d <- readRDS(path_orderly_run_rds(file.path(root, "draft", "example", id)))
+  expect_equal(d$meta$tags, "tag1")
+
+  ## Error on unknown tag
+  expect_error(
+    orderly_run("example", root = root, echo = FALSE, tags = "tag3"),
+    "Unknown tag: 'tag3'")
+})

--- a/tests/testthat/test-z-demo.R
+++ b/tests/testthat/test-z-demo.R
@@ -20,6 +20,7 @@ test_that("orderly_demo", {
 
   ## Ensure that the time manipulation affects the changelog too
   expect_true(nrow(DBI::dbReadTable(con, "changelog")) > 0)
+  expect_true(nrow(DBI::dbReadTable(con, "report_version_tag")) > 0)
 })
 
 


### PR DESCRIPTION
This PR adds very basic support for tags.  At the moment, the main thing it implements is the db structure (new tables `tag` and `report_version_tag`).  Nothing useful can be done with tags within orderly.  The demo data set has tags added to two reports for use in orderlyweb testing.