### PR TITLE
vimc-3530: Use orderly_envir.yml environment variables during report run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ matrix:
   - r: release
     after_success:
     - Rscript -e 'covr::codecov()'
+  - r: release
+    os: osx
+    osx_image: xcode8.3
+    latex: false
 
 r_packages:
   - covr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.1.5
+Version: 1.1.6
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# orderly 1.1.6
+
+* Environment variables in `orderly_envir.yml` are available during report run (#180, VIMC-3530)
+
 # orderly 1.1.5
 
 * Introduce the concept of "tags"; these are immutable and exist at the level of a report version.  Currently there is nothing that can be done with tags, but these will become useful in conjuction with [OrderlyWeb](https://github.com/vimc/orderly-web) (VIMC-3514)

--- a/R/develop.R
+++ b/R/develop.R
@@ -32,8 +32,9 @@
 ##' it will re-run through the setup steps, but beware that sourcing
 ##' functions is additive and never subtractive.  If you delete (or
 ##' rename) a function within a source file, it will not be removed
-##' from your global environment.  When in doubt, restart your R
-##' session.
+##' from your global environment.  Similarly, environment variables
+##' will be loaded each time you call this, but no deletions will
+##' happen.  When in doubt, restart your R session.
 ##'
 ##' Note that these functions are much more permissive as to the state
 ##' of your \code{orderly.yml} than \code{\link{orderly_run}} - in

--- a/R/develop.R
+++ b/R/develop.R
@@ -95,6 +95,8 @@ orderly_develop_start <- function(name = NULL, parameters = NULL,
     orderly_prepare_data(loc$config, info, parameters, envir, instance)
   })
 
+  sys_setenv(orderly_envir_read(loc$config$root))
+
   invisible(loc$path)
 }
 

--- a/R/recipe_run.R
+++ b/R/recipe_run.R
@@ -31,7 +31,8 @@
 ##' Environment variables that are created in \code{orderly_envir.yml}
 ##' will be available while the report runs.  Those that begin with
 ##' \code{ORDERLY_} will be saved into the \code{orderly_run.rds}
-##' within the \code{$env} section.
+##' within the \code{$env} section (except for any that match the
+##' patterns "TOKEN", "PAT" or "PASS").
 ##'
 ##' @title Run a report
 ##'

--- a/R/recipe_run.R
+++ b/R/recipe_run.R
@@ -28,6 +28,11 @@
 ##' default are omitted, and it is an error if unknown parameters are
 ##' provided.
 ##'
+##' Environment variables that are created in \code{orderly_envir.yml}
+##' will be available while the report runs.  Those that begin with
+##' \code{ORDERLY_} will be saved into the \code{orderly_run.rds}
+##' within the \code{$env} section.
+##'
 ##' @title Run a report
 ##'
 ##' @param name Name of the report to run (see

--- a/R/recipe_run.R
+++ b/R/recipe_run.R
@@ -140,8 +140,10 @@ orderly_run <- function(name, parameters = NULL, envir = NULL,
   recipe_current_run_set(info)
   on.exit(recipe_current_run_clear())
 
-  info <- recipe_run(info, parameters, envir, config, echo = echo,
-                     instance = instance)
+  info <- withr::with_envvar(
+    orderly_envir_read(config$root),
+    recipe_run(info, parameters, envir, config, echo = echo,
+               instance = instance))
 
   info$id
 }

--- a/R/util.R
+++ b/R/util.R
@@ -841,3 +841,10 @@ format_filediff <- function(x, ..., context = 2L, colour = NULL) {
   }
   paste(sprintf("%s | %s\n", line, text), collapse = "")
 }
+
+
+sys_setenv <- function(env) {
+  if (length(env) > 0L) {
+    do.call("Sys.setenv", as.list(env))
+  }
+}

--- a/man/orderly_develop_start.Rd
+++ b/man/orderly_develop_start.Rd
@@ -112,8 +112,9 @@ Repeately running \code{orderly_develop_start} is "safe", in that
 it will re-run through the setup steps, but beware that sourcing
 functions is additive and never subtractive.  If you delete (or
 rename) a function within a source file, it will not be removed
-from your global environment.  When in doubt, restart your R
-session.
+from your global environment.  Similarly, environment variables
+will be loaded each time you call this, but no deletions will
+happen.  When in doubt, restart your R session.
 
 Note that these functions are much more permissive as to the state
 of your \code{orderly.yml} than \code{\link{orderly_run}} - in

--- a/man/orderly_run.Rd
+++ b/man/orderly_run.Rd
@@ -122,6 +122,11 @@ id <- orderly::orderly_run("other", list(nmin = 0.2), root = path)
 \code{orderly.yml}.  It is an error if parameters without a
 default are omitted, and it is an error if unknown parameters are
 provided.
+
+Environment variables that are created in \code{orderly_envir.yml}
+will be available while the report runs.  Those that begin with
+\code{ORDERLY_} will be saved into the \code{orderly_run.rds}
+within the \code{$env} section.
 }
 \examples{
 path <- orderly::orderly_example("demo")

--- a/man/orderly_run.Rd
+++ b/man/orderly_run.Rd
@@ -126,7 +126,8 @@ provided.
 Environment variables that are created in \code{orderly_envir.yml}
 will be available while the report runs.  Those that begin with
 \code{ORDERLY_} will be saved into the \code{orderly_run.rds}
-within the \code{$env} section.
+within the \code{$env} section (except for any that match the
+patterns "TOKEN", "PAT" or "PASS").
 }
 \examples{
 path <- orderly::orderly_example("demo")

--- a/tests/testthat/test-develop.R
+++ b/tests/testthat/test-develop.R
@@ -181,3 +181,14 @@ test_that("Can read malformed orderly.yml in develop start", {
     orderly_develop_clean("partial", root = path),
     NA) # (no error)
 })
+
+
+test_that("can load environment variables during develop", {
+  path <- prepare_orderly_example("minimal")
+  p <- file.path(path, "src", "example")
+  writeLines(c("MY_A: a", "ORDERLY_B: b"), file.path(path, "orderly_envir.yml"))
+  on.exit(Sys.unsetenv(c("MY_A", "ORDERLY_B")))
+  orderly_develop_start("example", root = path)
+  expect_equal(Sys.getenv("MY_A"), "a")
+  expect_equal(Sys.getenv("ORDERLY_B"), "b")
+})

--- a/tests/testthat/test-recipe-read.R
+++ b/tests/testthat/test-recipe-read.R
@@ -587,7 +587,7 @@ test_that("resolve_dependencies_remote", {
   config <- orderly_config(dat$path_local)
   remote <- get_remote("default", config)
 
-  p <- file.path(dat$path_local, "archive", "example")
+  p <- file.path(normalizePath(dat$path_local), "archive", "example")
 
   expect_equal(
     resolve_dependencies_remote("latest", "example", config, remote),

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -885,3 +885,18 @@ test_that("Pass tags during run", {
     orderly_run("example", root = root, echo = FALSE, tags = "tag3"),
     "Unknown tag: 'tag3'")
 })
+
+
+test_that("orderly_envir is available during run", {
+  path <- prepare_orderly_example("minimal")
+  p <- file.path(path, "src", "example")
+  writeLines(c("MY_A: a", "ORDERLY_B: b"), file.path(path, "orderly_envir.yml"))
+  append_lines('writeLines(Sys.getenv("MY_A"), "env")',
+               file.path(p, "script.R"))
+  id <- orderly_run("example", root = path, echo = FALSE)
+
+  p <- file.path(path, "draft", "example", id)
+  expect_equal(readLines(file.path(p, "env")), "a")
+  expect_equal(readRDS(path_orderly_run_rds(p))$env,
+               list(ORDERLY_B = "b"))
+})

--- a/vignettes/orderly.Rmd
+++ b/vignettes/orderly.Rmd
@@ -720,6 +720,21 @@ orderly::orderly_run(name,
                       instance = c(source = "production", extra = "staging"))
 ```
 
+## Using environment variables
+
+Envirionment variables that are stored in the top-level `orderly_envir.yml` are (since orderly 1.1.6) available as environment variables, via `Sys.getenv()`.  For example, if your `orderly_envir.yml` contains
+
+```r
+DATA_URL=https://www.example.com/thedata
+```
+
+Then in your script you can use
+
+```r
+url <- Sys.getenv("DATA_URL")
+download.file(url)
+```
+
 ## Developing a report
 
 Because orderly works in a directory that is not the same as the source directory (e.g., `draft/myreport/YYYYMMDD-HHMMSS-abcdefgh`), because global resources and dependencies etc are copied in just as it is used, and because `orderly` takes control of things like parameters and `source()`-ing files, it may not seem straightforward to develop a report as you would ordinarily.


### PR DESCRIPTION
This PR loads the environment variables in orderly_envir.yml and makes them available as ordinary environment variables (`Sys.getenv()`) during a report build. As requested by @jeffeaton in #180 

Better handling of secrets will be done in a subsequent PR as that's a bit more tricky, but see vimc-3536 as I have a good idea for this