### PR TITLE
vimc-3515: nicer log printing

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.1.6
+Version: 1.1.7
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/R/logging.R
+++ b/R/logging.R
@@ -114,8 +114,10 @@ orderly_warning <- function(msg) {
 
 
 orderly_log_style <- function(topic) {
-  switch(topic,
+  switch(tolower(topic),
          warning = "alert",
+         error = "alert",
          unexpected = "alert",
+         rollback = "alert",
          "highlight")
 }

--- a/R/logging.R
+++ b/R/logging.R
@@ -84,11 +84,13 @@ orderly_log_off <- function() {
 ##' @export
 orderly_log <- function(topic, value) {
   if (!isTRUE(getOption("orderly.nolog"))) {
+    style <- orderly_style(orderly_log_style(topic))
     n <- length(value) - 1L
     if (n > 0L) {
       topic <- c(topic, rep_len("...", n))
     }
-    str <- trimws(sprintf("[ %-10s ]  %s", topic, value))
+    str <- trimws(sprintf("[ %s ]  %s",
+                          style(format(topic, width = 10)), value))
     if (n > 0L) {
       str <- paste(str, collapse = "\n")
     }
@@ -108,4 +110,12 @@ orderly_warning <- function(msg) {
   } else {
     warning(msg, immediate. = TRUE, call. = FALSE)
   }
+}
+
+
+orderly_log_style <- function(topic) {
+  switch(topic,
+         warning = "alert",
+         unexpected = "alert",
+         "highlight")
 }

--- a/R/util.R
+++ b/R/util.R
@@ -848,3 +848,14 @@ sys_setenv <- function(env) {
     do.call("Sys.setenv", as.list(env))
   }
 }
+
+
+orderly_style <- function(name) {
+  switch(name,
+         highlight = crayon::combine_styles(
+           crayon::bold, crayon::make_style("steelblue3")),
+         alert = crayon::combine_styles(
+           crayon::bold, crayon::make_style("hotpink")),
+         fade = crayon::make_style("grey"),
+         identity)
+}

--- a/tests/testthat/helper-orderly.R
+++ b/tests/testthat/helper-orderly.R
@@ -141,6 +141,14 @@ skip_on_cran_windows <- function() {
 }
 
 
+expect_log_message <- function(expr, ...) {
+  res <- testthat::evaluate_promise(expr)
+  expect_match(
+    crayon::strip_style(res$messages),
+    ..., all = FALSE)
+}
+
+
 if (Sys.getenv("NOT_CRAN") != "true") {
   options(orderly.nogit = TRUE)
 }

--- a/tests/testthat/test-develop.R
+++ b/tests/testthat/test-develop.R
@@ -163,7 +163,7 @@ test_that("orderly_develop_status with changelog", {
 test_that("Can read malformed orderly.yml in develop start", {
   path <- prepare_orderly_example("minimal")
   p <- orderly_new("partial", root = path, quiet = TRUE)
-  expect_message(
+  expect_log_message(
     res <- orderly_develop_start("partial", root = path),
     "[ warning    ]  At least one artefact required",
     fixed = TRUE)

--- a/tests/testthat/test-log.R
+++ b/tests/testthat/test-log.R
@@ -1,7 +1,7 @@
 context("logging")
 
 test_that("on/off", {
-  oo <- options(orderly.nolog = NULL) # default setting to start
+  oo <- options(orderly.nolog = NULL, crayon.enabled = FALSE)
   on.exit(options(oo))
 
   expect_true(orderly_log_on())
@@ -13,4 +13,33 @@ test_that("on/off", {
   expect_true(orderly_log_off())
   expect_false(orderly_log_off())
   expect_silent(orderly_log("subject", "value"))
+})
+
+
+test_that("colour", {
+  res <- withr::with_options(
+    list(crayon.enabled = TRUE),
+    testthat::evaluate_promise(
+      orderly_log("topic", c("a", "a"))))
+  expect_true(crayon::has_style(res$messages))
+
+  s <- strsplit(res$messages, "\n")[[1]]
+  expect_equal(length(s), 2)
+  ## same style
+  expect_equal(sub("...  ", "topic", s[[2]], fixed = TRUE), s[[1]])
+
+  res <- withr::with_options(
+    list(crayon.enabled = FALSE),
+    testthat::evaluate_promise(
+      orderly_log("topic", c("a", "a"))))
+  expect_false(crayon::has_style(res$messages))
+})
+
+
+test_that("warning colourtion", {
+  expect_equal(orderly_log_style("warning"), "alert")
+  expect_equal(orderly_log_style("unexpected"), "alert")
+
+  expect_equal(orderly_log_style("depends"), "highlight")
+  expect_equal(orderly_log_style("anythingelse"), "highlight")
 })

--- a/tests/testthat/test-log.R
+++ b/tests/testthat/test-log.R
@@ -39,6 +39,8 @@ test_that("colour", {
 test_that("warning colourtion", {
   expect_equal(orderly_log_style("warning"), "alert")
   expect_equal(orderly_log_style("unexpected"), "alert")
+  expect_equal(orderly_log_style("ERROR"), "alert")
+  expect_equal(orderly_log_style("rollback"), "alert")
 
   expect_equal(orderly_log_style("depends"), "highlight")
   expect_equal(orderly_log_style("anythingelse"), "highlight")

--- a/tests/testthat/test-migrate.R
+++ b/tests/testthat/test-migrate.R
@@ -165,7 +165,8 @@ test_that("mixed migration", {
   msg <- capture_messages(
     orderly_migrate(path, to = curr))
   expect_true(
-    any(grepl(sprintf("[ ok         ]  example/%s", id), msg, fixed = TRUE)))
+    any(grepl(sprintf("[ ok         ]  example/%s", id),
+              crayon::strip_style(msg), fixed = TRUE)))
 })
 
 

--- a/tests/testthat/test-remote-path.R
+++ b/tests/testthat/test-remote-path.R
@@ -67,11 +67,11 @@ test_that("pull report: already done", {
 
   remote <- orderly_remote_path(path1)
 
-  expect_message(
+  expect_log_message(
     orderly_pull_archive("example", id, path2, remote = remote),
     sprintf("\\[ pull\\s+ \\]  example:%s\\s*$", id))
 
-  expect_message(
+  expect_log_message(
     orderly_pull_archive("example", id, path2, remote = remote),
     sprintf("\\[ pull\\s+ \\]  example:%s already exists", id))
 })
@@ -118,7 +118,7 @@ test_that("set_default", {
 test_that("pull dependencies", {
   dat <- prepare_orderly_remote_example()
 
-  expect_message(
+  expect_log_message(
     orderly_pull_dependencies("depend", root = dat$config,
                               remote = dat$remote),
     "\\[ pull\\s+ \\]  example:")
@@ -128,7 +128,7 @@ test_that("pull dependencies", {
   ## and update
   id3 <- orderly_run("example", root = dat$path_remote, echo = FALSE)
   orderly_commit(id3, root = dat$path_remote)
-  expect_message(
+  expect_log_message(
     orderly_pull_dependencies("depend", root = dat$config,
                               remote = dat$remote),
     "\\[ pull\\s+ \\]  example:")

--- a/tests/testthat/test-remote.R
+++ b/tests/testthat/test-remote.R
@@ -34,7 +34,7 @@ test_that("orderly_pull_archive with wrong version", {
 test_that("pull dependencies", {
   dat <- prepare_orderly_remote_example()
 
-  expect_message(
+  expect_log_message(
     orderly_pull_dependencies("depend", root = dat$config,
                               remote = dat$remote),
     "\\[ pull\\s+ \\]  example:")
@@ -44,7 +44,7 @@ test_that("pull dependencies", {
   ## and update
   id3 <- orderly_run("example", root = dat$path_remote, echo = FALSE)
   orderly_commit(id3, root = dat$path_remote)
-  expect_message(
+  expect_log_message(
     orderly_pull_dependencies("depend", root = dat$config,
                               remote = dat$remote),
     "\\[ pull\\s+ \\]  example:")
@@ -56,14 +56,14 @@ test_that("pull dependencies", {
 test_that("pull_dependencies counts dependencies", {
   dat <- prepare_orderly_remote_example()
 
-  expect_message(
+  expect_log_message(
     orderly_pull_dependencies("example", root = dat$config,
                               remote = dat$remote),
     "\\[ depends\\s+ \\]  example has 0 dependencies")
 
   id <- orderly_run("example", root = dat$path_remote, echo = FALSE)
   orderly_commit(id, root = dat$path_remote)
-  expect_message(
+  expect_log_message(
     orderly_pull_dependencies("depend", root = dat$config,
                               remote = dat$remote),
     "\\[ depends\\s+ \\]  depend has 1 dependency")
@@ -90,7 +90,7 @@ test_that("pull from old remote", {
   DBI::dbDisconnect(db_local)
   DBI::dbDisconnect(db_remote)
 
-  expect_message(
+  expect_log_message(
     orderly_pull_archive("minimal", root = path_local, remote = path_remote),
     "^\\[ migrate")
 

--- a/tests/testthat/test-testing.R
+++ b/tests/testthat/test-testing.R
@@ -1,8 +1,8 @@
 context("testing")
 
-test_that("ordrly_example can be quiet", {
+test_that("orderly_example can be quiet", {
   skip_on_cran_windows()
-  expect_message(
+  expect_log_message(
     orderly_example("minimal", run_demo = TRUE, quiet = FALSE),
     "[ success", fixed = TRUE)
   expect_silent(

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -806,3 +806,17 @@ test_that("don't write with no changes", {
   expect_equal(format_filediff(res), character(0))
   expect_false(file.exists(p))
 })
+
+
+test_that("palette", {
+  withr::with_options(
+    list(crayon.enabled = TRUE), {
+      expect_equal(orderly_style("highlight")("x"),
+                   crayon::bold(crayon::make_style("steelblue3")("x")))
+      expect_equal(orderly_style("alert")("x"),
+                   crayon::bold(crayon::make_style("hotpink")("x")))
+      expect_equal(orderly_style("fade")("x"),
+                   crayon::make_style("grey")("x"))
+      expect_equal(orderly_style("other")("x"), "x")
+   })
+})


### PR DESCRIPTION
This PR adds nicer log printing, by using the crayon package (now that we depend on it).

Just simple at the moment, but I've highlighted cases where the log topic is "warning" and "unexpected" (plus the failure modes in migrations) - we can add more to the list as it seems useful but a little restraint goes a long way...