### PR TITLE
vimc-3536: access to secrets from an orderly report

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.1.9
+Version: 1.1.10
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# orderly 1.1.10
+
+* Secrets can be read from the vault and used in orderly reports (VIMC-3536)
+
 # orderly 1.1.9
 
 * Better parsing of parameters passed on the command line, allowing more parameters to be passed through, and coping better with shell quoting (VIMC-3550)

--- a/R/recipe_run.R
+++ b/R/recipe_run.R
@@ -387,6 +387,11 @@ recipe_data <- function(config, info, parameters, dest, instance) {
     info <- recipe_substitute(info, parameters)
   }
 
+  if (!is.null(info$secrets)) {
+    secrets <- resolve_secrets(info$secrets, config)
+    list2env(secrets, dest)
+  }
+
   ret <- list(dest = dest, parameters = parameters)
 
   if (length(info$data) == 0 && is.null(info$connection)) {

--- a/tests/testthat/test-recipe-read.R
+++ b/tests/testthat/test-recipe-read.R
@@ -698,3 +698,45 @@ test_that("Better error message where tags not enabled", {
     recipe_read(path, config)$tags,
     "Tags are not supported; please edit orderly_config.yml to enable")
 })
+
+
+test_that("read secrets", {
+  config <- list(root = tempfile(),
+                 vault = list(addr = "https://example.com/vault"))
+  filename <- "orderly.yml"
+
+  expect_null(recipe_read_check_secrets(NULL, NULL, filename))
+  expect_error(
+    recipe_read_check_secrets(list(a = "path"), NULL, filename),
+    "Vault not enabled in orderly_config.yml")
+
+  expect_equal(
+    recipe_read_check_secrets(list(a = "first:one"), config, filename),
+    list(a = "VAULT:first:one"))
+  expect_equal(
+    recipe_read_check_secrets(list(a = "first:one", b = "second:other"),
+                              config, filename),
+    list(a = "VAULT:first:one",
+         b = "VAULT:second:other"))
+
+  expect_error(
+    recipe_read_check_secrets(list("path", "other"), config, filename),
+    "'orderly.yml:secrets' must be named")
+  expect_error(
+    recipe_read_check_secrets(list(a = "path", a = "other"), config, filename),
+    "'orderly.yml:secrets' must have unique names")
+  expect_error(
+    recipe_read_check_secrets(list(a = "path", b = 2), config, filename),
+    "'orderly.yml:secrets:b' must be character")
+  expect_error(
+    recipe_read_check_secrets(list(a = "path"), config, filename),
+    "Misformatted secret path: 'path' for 'a'")
+  expect_error(
+    recipe_read_check_secrets(list(a = "path", b = "other:field:what"),
+                              config, filename),
+    "Misformatted secret path: 'path' for 'a', 'other:field:what' for 'b'")
+  expect_error(
+    recipe_read_check_secrets(list(a = "first:path", b = "other:field:what"),
+                              config, filename),
+    "Misformatted secret path: 'other:field:what' for 'b'")
+})

--- a/vignettes/orderly.Rmd
+++ b/vignettes/orderly.Rmd
@@ -720,7 +720,7 @@ orderly::orderly_run(name,
                       instance = c(source = "production", extra = "staging"))
 ```
 
-## Using environment variables
+## Using environment variables and secrets
 
 Envirionment variables that are stored in the top-level `orderly_envir.yml` are (since orderly 1.1.6) available as environment variables, via `Sys.getenv()`.  For example, if your `orderly_envir.yml` contains
 
@@ -734,6 +734,15 @@ Then in your script you can use
 url <- Sys.getenv("DATA_URL")
 download.file(url)
 ```
+
+If the values are sensitive, then this is not ideal, as you will store your values in plain text in the `orderly_envir.yml`.  Instead, if using vault, you can use a `secrets:` section in `orderly.yml`, like:
+
+```yaml
+secrets:
+  password: /secret/myproject/login:value
+```
+
+and then an R variable `password` will be available to all the code in your report, containing the result of looking up `/secret/myproject/login` in your vault and getting the `value` field.
 
 ## Developing a report
 


### PR DESCRIPTION
This PR builds on #181 in spirit, though with a different approach.

We allow a `secrets:` section in orderly.yml, in which the user includes values that should be recovered from the vault.  These come through as R variables, named in the yaml map.