### PR TITLE
vimc-3543: Try and fix environment variable resolution with remotes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.1.7
+Version: 1.1.8
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/R/slack.R
+++ b/R/slack.R
@@ -1,14 +1,19 @@
 ## Send slack messages!
 
 slack_post_success <- function(dat, config) {
+  urls <- slack_urls(config)
   if (!is.null(config$remote_identity)) {
-    remote <- config$remote[[config$remote_identity]]
-    driver <- get_remote(config$remote_identity, config)
-    report_url <- driver$url_report(dat$meta$name, dat$meta$id)
-    slack_url <- remote$slack_url
+    remote <- get_remote(config$remote_identity, config, FALSE)
+
+    ## TODO(VIMC-3544): This moves into the object itself, using some
+    ## sort of data field, so we might use remote$data$slack_url and
+    ## remote$data$primary
+    slack_url <- attr(remote, "slack_url")
+    primary <- attr(remote, "primary")
+    assert_scalar_character(slack_url, "slack_url")
 
     if (!is.null(slack_url)) {
-      assert_scalar_character(slack_url, "slack_url")
+      report_url <- remote$url_report(dat$meta$name, dat$meta$id)
       data <- slack_data(dat, remote$name, report_url, remote$primary)
       do_slack_post_success(slack_url, data)
     }

--- a/R/slack.R
+++ b/R/slack.R
@@ -2,7 +2,7 @@
 
 slack_post_success <- function(dat, config) {
   if (!is.null(config$remote_identity)) {
-    remote <- get_remote(config$remote_identity, config, FALSE)
+    remote <- get_remote(config$remote_identity, config)
 
     ## TODO(VIMC-3544): This moves into the object itself, using some
     ## sort of data field, so we might use remote$data$slack_url and
@@ -13,7 +13,7 @@ slack_post_success <- function(dat, config) {
 
     if (!is.null(slack_url)) {
       report_url <- remote$url_report(dat$meta$name, dat$meta$id)
-      data <- slack_data(dat, remote$name, report_url, remote$primary)
+      data <- slack_data(dat, remote$name, report_url, primary)
       do_slack_post_success(slack_url, data)
     }
   }

--- a/R/slack.R
+++ b/R/slack.R
@@ -1,7 +1,6 @@
 ## Send slack messages!
 
 slack_post_success <- function(dat, config) {
-  urls <- slack_urls(config)
   if (!is.null(config$remote_identity)) {
     remote <- get_remote(config$remote_identity, config, FALSE)
 


### PR DESCRIPTION
This is a stopgap fix, really; it allows SLACK_URL to be missing (required on user machines). The other half is fixed via https://github.com/vimc/montagu-orderly-web/pull/11 which solves the problems that we saw together