### PR TITLE
vimc-3550: better command line parsing

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.1.8
+Version: 1.1.9
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# orderly 1.1.8
+# orderly 1.1.9
 
 * Better parsing of parameters passed on the command line, allowing more parameters to be passed through, and coping better with shell quoting (VIMC-3550)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# orderly 1.1.8
+
+* Better parsing of parameters passed on the command line, allowing more parameters to be passed through, and coping better with shell quoting (VIMC-3550)
+
 # orderly 1.1.6
 
 * Environment variables in `orderly_envir.yml` are available during report run (#180, VIMC-3530)

--- a/R/main.R
+++ b/R/main.R
@@ -361,9 +361,11 @@ cli_commands <- function() {
 
 
 parse_parameter <- function(x) {
-  value <- parse(text = x)[[1]]
+  value <- tryCatch(parse(text = x)[[1]], error = function(e) x)
   if (is.logical(value) || is.numeric(value)) {
     value
+  } else if (is.character(x) && grepl('^(".*"|\'.*\')$', x)) {
+    x <- substr(x, 2, nchar(x) - 1L)
   } else {
     x
   }

--- a/R/main.R
+++ b/R/main.R
@@ -365,7 +365,7 @@ parse_parameter <- function(x) {
   if (is.logical(value) || is.numeric(value)) {
     value
   } else if (is.character(x) && grepl('^(".*"|\'.*\')$', x)) {
-    x <- substr(x, 2, nchar(x) - 1L)
+    substr(x, 2, nchar(x) - 1L)
   } else {
     x
   }

--- a/tests/testthat/test-main.R
+++ b/tests/testthat/test-main.R
@@ -97,6 +97,7 @@ test_that("pass parameters", {
   expect_equal(f("a=1", "b=value", "c=TRUE"),
                list(a = 1, b = "value", c=TRUE))
   expect_equal(f("a=1+2"), list(a = "1+2"))
+  expect_equal(f("a='quoted string'"), list(a = "quoted string"))
 })
 
 
@@ -506,4 +507,12 @@ test_that("invalid parameters", {
     cli_args_process_run_parameters(c("a", "b=2", "c=3=4")),
     "Invalid parameters 'a', 'c=3=4' - all must be in form key=value",
     fixed = TRUE)
+})
+
+
+test_that("parameter type conversion", {
+  expect_equal(parse_parameter("abc"), "abc")
+  expect_equal(parse_parameter("123abc"), "123abc")
+  expect_equal(parse_parameter("123"), 123)
+  expect_equal(parse_parameter("TRUE"), TRUE)
 })

--- a/tests/testthat/test-main.R
+++ b/tests/testthat/test-main.R
@@ -515,4 +515,7 @@ test_that("parameter type conversion", {
   expect_equal(parse_parameter("123abc"), "123abc")
   expect_equal(parse_parameter("123"), 123)
   expect_equal(parse_parameter("TRUE"), TRUE)
+
+  expect_equal(parse_parameter("'quoted string'"), "quoted string")
+  expect_equal(parse_parameter('"quoted string"'), "quoted string")
 })


### PR DESCRIPTION
Catch the error when parsing - we're only doing this to detect numbers properly.  If we are passed in a quoted string (e.g., to escape this conversion, or with spaces), then remove the quotes too