### PR TITLE
VIMC-3558: Users can access environment variables specified in orderly.yml

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,7 +43,7 @@ Suggests:
     processx,
     rmarkdown,
     testthat,
-    vaultr (>= 1.0.3)
+    vaultr (>= 1.0.4)
 RoxygenNote: 7.0.2
 VignetteBuilder: knitr
 Language: en-GB

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.1.9
+Version: 1.1.10
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # orderly 1.1.11
 
-* Environment variables can be used in orderly reports (VIMC-3558)
+* Environment variables can be used in orderly reports by using the `environment:` field in `orderly.yml` (VIMC-3558)
 
 # orderly 1.1.10
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# orderly 1.1.10
+
+* Environment variables can be used in orderly reports (VIMC-3558)
+
 # orderly 1.1.9
 
 * Better parsing of parameters passed on the command line, allowing more parameters to be passed through, and coping better with shell quoting (VIMC-3550)

--- a/R/recipe_read.R
+++ b/R/recipe_read.R
@@ -37,7 +37,7 @@ recipe_read <- function(path, config, validate = TRUE, use_draft = FALSE,
                 "global_resources",
                 "tags",
                 "secrets",
-                "environment_variables",
+                "environment",
                 config$fields$name[!config$fields$required])
 
   recipe_read_skip_on_develop(
@@ -128,8 +128,8 @@ recipe_read <- function(path, config, validate = TRUE, use_draft = FALSE,
   
   info$secrets <- recipe_read_check_secrets(info$secrets, config, filename)
   
-  info$environment_variables <- recipe_read_check_env_var(
-    info$environment_variables, filename)
+  info$environment <- recipe_read_check_env_var(
+    info$environment, filename)
 
   info$name <- basename(normalizePath(path))
 
@@ -480,11 +480,11 @@ recipe_read_check_env_var <- function(env_vars, filename) {
     return(NULL)
   }
   assert_named(env_vars, TRUE,
-               name = sprintf("%s:environment_variables", filename))
+               name = sprintf("%s:environment", filename))
   for (name in names(env_vars)) {
     assert_scalar_character(
       env_vars[[name]],
-      sprintf("orderly.yml:environment_variables:%s", name))
+      sprintf("orderly.yml:environment:%s", name))
   }
   env_vars
 }

--- a/R/recipe_read.R
+++ b/R/recipe_read.R
@@ -36,6 +36,7 @@ recipe_read <- function(path, config, validate = TRUE, use_draft = FALSE,
                 "depends",
                 "global_resources",
                 "tags",
+                "environment_variables",
                 config$fields$name[!config$fields$required])
 
   recipe_read_skip_on_develop(
@@ -123,6 +124,9 @@ recipe_read <- function(path, config, validate = TRUE, use_draft = FALSE,
       assert_scalar_character(x, fieldname(el$name))
     }
   }
+  
+  info$environment_variables <- recipe_read_check_env_var(
+    info$environment_variables, filename)
 
   info$name <- basename(normalizePath(path))
 
@@ -436,4 +440,18 @@ recipe_read_check_tags <- function(tags, config, name) {
     }
   }
   tags
+}
+
+recipe_read_check_env_var <- function(env_vars, filename) {
+  if (is.null(env_vars)) {
+    return(NULL)
+  }
+  assert_named(env_vars, TRUE,
+               name = sprintf("%s:environment_variables", filename))
+  for (name in names(env_vars)) {
+    assert_scalar_character(
+      env_vars[[name]],
+      sprintf("orderly.yml:environment_variables:%s", name))
+  }
+  env_vars
 }

--- a/R/recipe_run.R
+++ b/R/recipe_run.R
@@ -387,6 +387,14 @@ recipe_data <- function(config, info, parameters, dest, instance) {
     info <- recipe_substitute(info, parameters)
   }
 
+  if (!is.null(info$environment_variables)) {
+    yml_path <- info$inputs[info$inputs$file_purpose == "orderly_yml",
+                            "filename"]
+    env_vars <- resolve_env(info$environment_variables,
+                            paste0(yml_path, ":environment_variables"))
+    list2env(env_vars, dest)
+  }
+
   ret <- list(dest = dest, parameters = parameters)
 
   if (length(info$data) == 0 && is.null(info$connection)) {

--- a/R/recipe_run.R
+++ b/R/recipe_run.R
@@ -393,10 +393,8 @@ recipe_data <- function(config, info, parameters, dest, instance) {
   }
   
   if (!is.null(info$environment)) {
-    yml_path <- info$inputs[info$inputs$file_purpose == "orderly_yml",
-                            "filename"]
     env_vars <- resolve_env(info$environment,
-                            paste0(yml_path, ":environment"))
+                            "orderly.yml:environment"))
     list2env(env_vars, dest)
   }
 

--- a/R/recipe_run.R
+++ b/R/recipe_run.R
@@ -392,11 +392,11 @@ recipe_data <- function(config, info, parameters, dest, instance) {
     list2env(secrets, dest)
   }
   
-  if (!is.null(info$environment_variables)) {
+  if (!is.null(info$environment)) {
     yml_path <- info$inputs[info$inputs$file_purpose == "orderly_yml",
                             "filename"]
-    env_vars <- resolve_env(info$environment_variables,
-                            paste0(yml_path, ":environment_variables"))
+    env_vars <- resolve_env(info$environment,
+                            paste0(yml_path, ":environment"))
     list2env(env_vars, dest)
   }
 

--- a/R/recipe_run.R
+++ b/R/recipe_run.R
@@ -393,8 +393,11 @@ recipe_data <- function(config, info, parameters, dest, instance) {
   }
   
   if (!is.null(info$environment)) {
-    env_vars <- resolve_env(info$environment,
-                            "orderly.yml:environment"))
+    env_vars <- lapply(names(info$environment), function(name) {
+      Sys_getenv(info$environment[[name]],
+                 sprintf("orderly.yml:environment:%s", name))
+    })
+    names(env_vars) <- names(info$environment)
     list2env(env_vars, dest)
   }
 

--- a/R/util.R
+++ b/R/util.R
@@ -245,10 +245,11 @@ append_text <- function(filename, txt) {
 
 Sys_getenv <- function(x, used_in, error = TRUE, default = NULL) {
   v <- Sys.getenv(x, NA_character_)
-  if (is.na(v)) {
+  if (is.na(v) || grepl("^\\s*$", v)) {
     if (error) {
-      stop(sprintf("Environment variable '%s' is not set\n\t(used in %s)",
-                   x, used_in), call. = FALSE)
+      reason <- if (grepl("^\\s*$", v)) "empty" else "not set"
+      stop(sprintf("Environment variable '%s' is %s\n\t(used in %s)",
+                   x, reason, used_in), call. = FALSE)
     } else {
       v <- default
     }

--- a/R/util.R
+++ b/R/util.R
@@ -245,9 +245,9 @@ append_text <- function(filename, txt) {
 
 Sys_getenv <- function(x, used_in, error = TRUE, default = NULL) {
   v <- Sys.getenv(x, NA_character_)
-  if (is.na(v) || grepl("^\\s*$", v)) {
+  if (is.na(v) || !nzchar(v)) {
     if (error) {
-      reason <- if (grepl("^\\s*$", v)) "empty" else "not set"
+      reason <- if (!nzchar(v)) "empty" else "not set"
       stop(sprintf("Environment variable '%s' is %s\n\t(used in %s)",
                    x, reason, used_in), call. = FALSE)
     } else {

--- a/tests/testthat/test-recipe-read.R
+++ b/tests/testthat/test-recipe-read.R
@@ -698,3 +698,24 @@ test_that("Better error message where tags not enabled", {
     recipe_read(path, config)$tags,
     "Tags are not supported; please edit orderly_config.yml to enable")
 })
+
+test_that("can read env vars from orderly yml", {
+  filename <- "orderly.yml"
+
+  expect_null(recipe_read_check_env_var(NULL, filename))
+  expect_error(
+    recipe_read_check_env_var(list("ENV", "VAR"), filename),
+    "'orderly.yml:environment_variables' must be named")
+  expect_error(
+    recipe_read_check_env_var(list(a = "ENV", a = "VAR"), filename),
+    "'orderly.yml:environment_variables' must have unique names")
+  expect_error(
+    recipe_read_check_env_var(list(a = "ENV", b = 2), filename),
+    "'orderly.yml:environment_variables:b' must be character")
+  expect_error(
+    recipe_read_check_env_var(list(a = list("ENV", "VAR")), filename),
+    "'orderly.yml:environment_variables:a' must be a scalar")
+
+  env_vars <- list(a = "ENV", b = "VAR")
+  expect_equal(recipe_read_check_env_var(env_vars), env_vars)
+})

--- a/tests/testthat/test-recipe-read.R
+++ b/tests/testthat/test-recipe-read.R
@@ -746,16 +746,16 @@ test_that("can read env vars from orderly yml", {
   expect_null(recipe_read_check_env_var(NULL, filename))
   expect_error(
     recipe_read_check_env_var(list("ENV", "VAR"), filename),
-    "'orderly.yml:environment_variables' must be named")
+    "'orderly.yml:environment' must be named")
   expect_error(
     recipe_read_check_env_var(list(a = "ENV", a = "VAR"), filename),
-    "'orderly.yml:environment_variables' must have unique names")
+    "'orderly.yml:environment' must have unique names")
   expect_error(
     recipe_read_check_env_var(list(a = "ENV", b = 2), filename),
-    "'orderly.yml:environment_variables:b' must be character")
+    "'orderly.yml:environment:b' must be character")
   expect_error(
     recipe_read_check_env_var(list(a = list("ENV", "VAR")), filename),
-    "'orderly.yml:environment_variables:a' must be a scalar")
+    "'orderly.yml:environment:a' must be a scalar")
   
   env_vars <- list(a = "ENV", b = "VAR")
   expect_equal(recipe_read_check_env_var(env_vars), env_vars)

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -935,8 +935,8 @@ test_that("can use environment variables in report", {
   
   append_lines(
     c("environment:",
-      paste("  data_path: $EXTRA_DATA_PATH"),
-      paste("  example_var: $EXAMPLE_VAR")),
+      paste("  data_path: EXTRA_DATA_PATH"),
+      paste("  example_var: EXAMPLE_VAR")),
     file.path(path, "src", "example", "orderly.yml"))
   
   append_lines(
@@ -945,7 +945,7 @@ test_that("can use environment variables in report", {
   
   expect_error(orderly_run("example", root = path),
                "Environment variable 'EXTRA_DATA_PATH' is not set
-\t(used in orderly.yml:environment:data_path", fixed = TRUE)
+\t(used in orderly.yml:environment:data_path)", fixed = TRUE)
   
   ## On windows if env variable is empty then windows will return NA from call
   ## to Sys.getenv

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -934,7 +934,7 @@ test_that("can use environment variables in report", {
   path <- prepare_orderly_example("minimal")
   
   append_lines(
-    c("environment_variables:",
+    c("environment:",
       paste("  data_path: $EXTRA_DATA_PATH"),
       paste("  example_var: $EXAMPLE_VAR")),
     file.path(path, "src", "example", "orderly.yml"))
@@ -945,16 +945,16 @@ test_that("can use environment variables in report", {
   
   expect_error(orderly_run("example", root = path),
                "Environment variable 'EXTRA_DATA_PATH' is not set
-\t(used in orderly.yml:environment_variables:data_path", fixed = TRUE)
+\t(used in orderly.yml:environment:data_path", fixed = TRUE)
   
   ## On windows if env variable is empty then windows will return NA from call
   ## to Sys.getenv
   if (is_windows()) {
     expected_err <- "Environment variable 'EXAMPLE_VAR' is not set
-\t(used in orderly.yml:environment_variables:example_var)"
+\t(used in orderly.yml:environment:example_var)"
   } else {
     expected_err <- "Environment variable 'EXAMPLE_VAR' is empty
-\t(used in orderly.yml:environment_variables:example_var)"
+\t(used in orderly.yml:environment:example_var)"
   }
   
   data_path <- tempfile()

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -413,11 +413,20 @@ test_that("Sys_getenv", {
       expect_identical(Sys_getenv("SOME_VAR", "loc", FALSE, NA_character_),
                        NA_character_)
     })
+  
+  ## On windows if env variable is empty then windows will return NA from call
+  ## to Sys.getenv
+  if (is_windows()) {
+    expected_err <- "Environment variable 'SOME_VAR' is not set.*used in loc"
+  } else {
+    expected_err <- "Environment variable 'SOME_VAR' is empty.*used in loc"
+  }
+  
   withr::with_envvar(
     c("SOME_VAR" = ""),
     expect_error(
       Sys_getenv("SOME_VAR", "loc"),
-      "Environment variable 'SOME_VAR' is empty.*used in loc"))
+      expected_err))
   withr::with_envvar(
     c("SOME_VAR" = "x"),
     expect_identical(Sys_getenv("SOME_VAR", "loc"), "x"))

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -414,6 +414,11 @@ test_that("Sys_getenv", {
                        NA_character_)
     })
   withr::with_envvar(
+    c("SOME_VAR" = ""),
+    expect_error(
+      Sys_getenv("SOME_VAR", "loc"),
+      "Environment variable 'SOME_VAR' is empty.*used in loc"))
+  withr::with_envvar(
     c("SOME_VAR" = "x"),
     expect_identical(Sys_getenv("SOME_VAR", "loc"), "x"))
 })

--- a/vignettes/orderly.Rmd
+++ b/vignettes/orderly.Rmd
@@ -722,18 +722,21 @@ orderly::orderly_run(name,
 
 ## Using environment variables
 
-Envirionment variables that are stored in the top-level `orderly_envir.yml` are (since orderly 1.1.6) available as environment variables, via `Sys.getenv()`.  For example, if your `orderly_envir.yml` contains
+Environment variables declared in `orderly.yml` are made available in the report script (since orderly 1.1.10). For example, if your `orderly.yml` contains
 
-```r
-DATA_URL=https://www.example.com/thedata
+```yaml
+environment_variables:
+  external_file: EXTERNAL_FILE_PATH
+  variable_2: ENV_VAR_2
 ```
 
-Then in your script you can use
+Then orderly will evaluate the variables and make them available in your script via the specified name. For example in your script you can use
 
 ```r
-url <- Sys.getenv("DATA_URL")
-download.file(url)
+external_data <- read.csv(external_file)
 ```
+
+The expected use case for this is if you have data which you want to use in a report but do not want to be in the orderly repository (either because it is sensitive or particularly large). You can have the external files somewhere else on your machine and specify the path to them via an environment variable so they can then be accessed from the report script.
 
 ## Developing a report
 

--- a/vignettes/orderly.Rmd
+++ b/vignettes/orderly.Rmd
@@ -725,7 +725,7 @@ orderly::orderly_run(name,
 Environment variables declared in `orderly.yml` are made available in the report script (since orderly 1.1.11). For example, if your `orderly.yml` contains
 
 ```yaml
-environment_variables:
+environment:
   external_file: EXTERNAL_FILE_PATH
   variable_2: ENV_VAR_2
 ```


### PR DESCRIPTION
This PR will
* Allow user to specify named environment variables in their `orderly.yml`
* Which are then made available to report script via the specified name

One note - I changed the default `Sys_getenv` to check for empty vars too. This will change previous behaviour but it did not fail any tests and looks like a sensible default to me? Happy to be told otherwise and can rethink how that check is working.