### PR TITLE
VIMC-3442: Check orderly version requirements before the fields

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,12 @@ matrix:
   - r: release
     after_success:
     - Rscript -e 'covr::codecov()'
-  - r: release
-    os: osx
-    osx_image: xcode8.3
-    latex: false
+  # This turns out to be very slow and quite unstable. We should
+  # enable it before CRAN releases
+  # - r: release
+  #   os: osx
+  #   osx_image: xcode8.3
+  #   latex: false
 
 r_packages:
   - covr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.1.10
+Version: 1.1.11
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/R/config.R
+++ b/R/config.R
@@ -10,6 +10,14 @@ orderly_config <- function(root) {
 
 orderly_config_read_yaml <- function(filename, root) {
   info <- yaml_read(filename)
+
+  v <- info$minimum_orderly_version
+  if (!is.null(v) && utils::packageVersion("orderly") < v) {
+    stop(sprintf(
+      "Orderly version '%s' is required, but only '%s' installed",
+      v, utils::packageVersion("orderly")))
+  }
+
   check_fields(info, filename, character(),
                c("destination", "fields", "minimum_orderly_version",
                  "remote", "vault", "vault_server", "global_resources",
@@ -47,13 +55,6 @@ orderly_config_read_yaml <- function(filename, root) {
 
   if (!is.null(info$tags)) {
     assert_character(info$tags, sprintf("%s:tags", filename))
-  }
-
-  v <- info$minimum_orderly_version
-  if (!is.null(v) && utils::packageVersion("orderly") < v) {
-    stop(sprintf(
-      "Orderly version '%s' is required, but only '%s' installed",
-      v, utils::packageVersion("orderly")))
   }
 
   info[['vault']] <- config_check_vault(info[['vault']], info[['vault_server']], filename)

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -444,3 +444,16 @@ test_that("tags are validated", {
     orderly_config(path),
     "orderly_config.yml:tags' must be character")
 })
+
+
+## VIMC-3442
+test_that("adding new fields in new versions gives good errors", {
+  path <- prepare_orderly_example("minimal")
+  append_lines(
+    c("new_toplevel_field: value",
+      "minimum_orderly_version: 9.9.9"),
+    file.path(path, "orderly_config.yml"))
+  expect_error(
+    orderly_config(path),
+    "Orderly version '9.9.9' is required, but only '.+' installed")
+})


### PR DESCRIPTION
If a new version of orderly introduces new fields, we should be able to throw the "version requirement" error rather than the unknown fields error.  This PR reorders the configuration checking, and adds a test.  There should be no user-visible effect for already-working configurations