### PR TITLE
Vimc 3512

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.1.12
+Version: 1.1.13
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# orderly 1.1.13
+
+* Enable implicit report name for `orderly::orderly_run` and `orderly::orderly_pull_dependenices` (VIMC-3512, #170)
+
 # orderly 1.1.12
 
 * Introduces a basic query interface for searching for reports that match criteria based on parameters and tags, which can be used directly `orderly::orderly_search` or when declaring dependencies (VIMC-3538)

--- a/R/develop.R
+++ b/R/develop.R
@@ -145,7 +145,7 @@ orderly_develop_location <- function(name, root, locate) {
   }
 
   path <- file.path(path_src(config$root), name)
-  inplace <- same_path(path, getwd())
+  inplace <- file.exists(path) && same_path(path, getwd())
 
   list(config = config, name = name, path = path, inplace = inplace)
 }

--- a/R/recipe_run.R
+++ b/R/recipe_run.R
@@ -39,6 +39,8 @@
 ##' @param name Name of the report to run (see
 ##'   \code{\link{orderly_list}}).  A leading \code{src/} will be
 ##'   removed if provided, allowing easier use of autocomplete.
+##'   Alternatively, the default of \code{NULL} is useful if you have
+##'   already set the working directory to be the source directory.
 ##'
 ##' @param parameters Parameters passed to the report. A named list of
 ##'   parameters declared in the \code{orderly.yml}.  Each parameter
@@ -127,19 +129,16 @@
 ##'
 ##' # These parameters can be used in SQL queries or in the report
 ##' # code.
-orderly_run <- function(name, parameters = NULL, envir = NULL,
+orderly_run <- function(name = NULL, parameters = NULL, envir = NULL,
                         root = NULL, locate = TRUE, echo = TRUE,
                         id_file = NULL, fetch = FALSE, ref = NULL,
                         message = NULL, instance = NULL, use_draft = FALSE,
                         remote = NULL, tags = NULL) {
+  loc <- orderly_develop_location(name, root, locate)
+  name <- loc$name
+  config <- check_orderly_archive_version(loc$config)
+
   envir <- orderly_environment(envir)
-  config <- orderly_config_get(root, locate)
-  config <- check_orderly_archive_version(config)
-
-  if (grepl("^src/.+", name)) {
-    name <- sub("^src/", "", name)
-  }
-
   info <- recipe_prepare(config, name, id_file, ref, fetch, message,
                          use_draft, parameters, remote, tags = tags)
 

--- a/R/recipe_test.R
+++ b/R/recipe_test.R
@@ -26,6 +26,11 @@
 ##' }
 ##'
 ##' @title Prepare a directory for orderly to use
+##'
+##' @param name Name of the report to run (see
+##'   \code{\link{orderly_list}}).  A leading \code{src/} will be
+##'   removed if provided, allowing easier use of autocomplete.
+##'
 ##' @inheritParams orderly_run
 ##' @return The path to the report directory
 ##' @export

--- a/R/remote.R
+++ b/R/remote.R
@@ -27,7 +27,9 @@
 ##'
 ##' @title Download dependent reports
 ##'
-##' @param name Name of the report to download dependencies for
+##' @param name Name of the report to download dependencies for.
+##'   Alternatively, the default of \code{NULL} is useful if you have
+##'   already set the working directory to be the source directory.
 ##'
 ##' @param remote Description of the location.  Typically this is a
 ##'   character string indicating a remote specified in the
@@ -52,9 +54,11 @@
 ##'   remote system in more detail.
 ##'
 ##' @example man-roxygen/example-remote.R
-orderly_pull_dependencies <- function(name, root = NULL, locate = TRUE,
+orderly_pull_dependencies <- function(name = NULL, root = NULL, locate = TRUE,
                                       remote = NULL) {
-  config <- orderly_config_get(root, locate)
+  loc <- orderly_develop_location(name, root, locate)
+  name <- loc$name
+  config <- loc$config
   remote <- get_remote(remote, config)
 
   path <- file.path(path_src(config$root), name)

--- a/man/orderly_pull_dependencies.Rd
+++ b/man/orderly_pull_dependencies.Rd
@@ -5,7 +5,12 @@
 \alias{orderly_pull_archive}
 \title{Download dependent reports}
 \usage{
-orderly_pull_dependencies(name, root = NULL, locate = TRUE, remote = NULL)
+orderly_pull_dependencies(
+  name = NULL,
+  root = NULL,
+  locate = TRUE,
+  remote = NULL
+)
 
 orderly_pull_archive(
   name,
@@ -16,7 +21,9 @@ orderly_pull_archive(
 )
 }
 \arguments{
-\item{name}{Name of the report to download dependencies for}
+\item{name}{Name of the report to download dependencies for.
+Alternatively, the default of \code{NULL} is useful if you have
+already set the working directory to be the source directory.}
 
 \item{root}{The path to an orderly root directory, or \code{NULL}
 (the default) to search for one from the current working

--- a/man/orderly_run.Rd
+++ b/man/orderly_run.Rd
@@ -5,7 +5,7 @@
 \title{Run a report}
 \usage{
 orderly_run(
-  name,
+  name = NULL,
   parameters = NULL,
   envir = NULL,
   root = NULL,
@@ -24,7 +24,9 @@ orderly_run(
 \arguments{
 \item{name}{Name of the report to run (see
 \code{\link{orderly_list}}).  A leading \code{src/} will be
-removed if provided, allowing easier use of autocomplete.}
+removed if provided, allowing easier use of autocomplete.
+Alternatively, the default of \code{NULL} is useful if you have
+already set the working directory to be the source directory.}
 
 \item{parameters}{Parameters passed to the report. A named list of
 parameters declared in the \code{orderly.yml}.  Each parameter

--- a/tests/testthat/test-remote.R
+++ b/tests/testthat/test-remote.R
@@ -53,6 +53,16 @@ test_that("pull dependencies", {
 })
 
 
+test_that("pull dependencies with implied name", {
+  dat <- prepare_orderly_remote_example()
+    expect_equal(nrow(orderly_list_archive(dat$config)), 0)
+  withr::with_dir(
+    file.path(dat$config$root, "src", "depend"),
+    orderly_pull_dependencies(remote = dat$remote))
+  expect_equal(nrow(orderly_list_archive(dat$config)), 1)
+})
+
+
 test_that("pull_dependencies counts dependencies", {
   dat <- prepare_orderly_remote_example()
 

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -977,3 +977,14 @@ test_that("can use environment variables in report", {
     readLines(file.path(path, "draft", "example", id, "env_vars")),
     c(data_path, "example value"))
 })
+
+
+test_that("pick up name from the working directory", {
+  skip_on_cran_windows()
+  path <- prepare_orderly_example("minimal")
+
+  id <- withr::with_dir(
+    file.path(path, "src", "example"),
+    orderly_run(echo = FALSE))
+  expect_true(file.exists(file.path(path, "draft", "example", id)))
+})


### PR DESCRIPTION
This provides nicer default `name` to `orderly_run` and `orderly_pull_dependencies`, as this is becoming now how people interact with orderly

Fixes #170 