### PR TITLE
VIMC-3589: Fix database instance selection with defaults

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.1.13
+Version: 1.1.14
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# orderly 1.1.14
+
+* Fix bug in instance selection, probably introduced in 1.0.6 (VIMC-3589)
+
 # orderly 1.1.13
 
 * Enable implicit report name for `orderly::orderly_run` and `orderly::orderly_pull_dependenices` (VIMC-3512, #170)

--- a/R/config.R
+++ b/R/config.R
@@ -259,6 +259,9 @@ config_read_db <- function(name, info, filename) {
       args <- dat$args
     } else {
       args <- instances[[dat$default_instance %||% 1L]]
+      v <- c(dat$default_instance,
+             setdiff(names(instances), dat$default_instance))
+      instances <- instances[v]
     }
   } else {
     if (!info$database_old_style) {

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -421,10 +421,30 @@ test_that("default instance from an environmental variable", {
     orderly_config(path))
   expect_equal(cfg$database$source$args, list(dbname = "production.sqlite"))
 
+  cfg <- withr::with_envvar(
+    c("ORDERLY_TEST_DEFAULT_INSTANCE" = "staging"),
+    orderly_config(path))
+  expect_equal(cfg$database$source$args, list(dbname = "staging.sqlite"))
+
+  cfg_db <- withr::with_envvar(
+    c("ORDERLY_TEST_DEFAULT_INSTANCE" = "production"),
+    db_instance_select(NULL, orderly_config(path)$database))
+  expect_equal(cfg_db$source$args, list(dbname = "production.sqlite"))
+
+  cfg_db <- withr::with_envvar(
+    c("ORDERLY_TEST_DEFAULT_INSTANCE" = "staging"),
+    db_instance_select(NULL, orderly_config(path)$database))
+  expect_equal(cfg_db$source$args, list(dbname = "staging.sqlite"))
+
   writeLines("ORDERLY_TEST_DEFAULT_INSTANCE: production",
              file.path(path, "orderly_envir.yml"))
   cfg <- orderly_config(path)
   expect_equal(cfg$database$source$args, list(dbname = "production.sqlite"))
+
+  cfg_db <- withr::with_envvar(
+    c("ORDERLY_TEST_DEFAULT_INSTANCE" = "production"),
+    db_instance_select(NULL, orderly_config(path)$database))
+  expect_equal(cfg_db$source$args, list(dbname = "production.sqlite"))
 })
 
 

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -354,8 +354,8 @@ test_that("multiple database configurations", {
   cfg <- orderly_config(path)
   expect_equal(cfg$database$source$args, list(dbname = "production.sqlite"))
   expect_equal(cfg$database$source$instances,
-               list(staging = list(dbname = "staging.sqlite"),
-                    production = list(dbname = "production.sqlite")))
+               list(production = list(dbname = "production.sqlite"),
+                    staging = list(dbname = "staging.sqlite")))
 })
 
 


### PR DESCRIPTION
This fixes a problem seen on science with the default instance just not working