### PR TITLE
vimc-3593: refactor orderly's configuration

### DIFF
--- a/R/changelog.R
+++ b/R/changelog.R
@@ -1,5 +1,6 @@
 changelog_load <- function(path, message, info, config) {
   changelog <- changelog_read(path)
+
   if (!is.null(message)) {
     changelog <- rbind(
       changelog_message_parse(message),

--- a/R/changelog.R
+++ b/R/changelog.R
@@ -1,6 +1,5 @@
 changelog_load <- function(path, message, info, config) {
   changelog <- changelog_read(path)
-
   if (!is.null(message)) {
     changelog <- rbind(
       changelog_message_parse(message),

--- a/R/config.R
+++ b/R/config.R
@@ -181,10 +181,6 @@ config_validate_destination <- function(destination, filename) {
   }
   label <- sprintf("%s:destination", filename)
 
-  if (!any(c("args", "instances") %in% names(destination))) {
-    stop("old style db")
-  }
-
   check_fields(destination, label, c("driver", "args"), character())
   destination$driver <-
     check_symbol_from_str(destination$driver, paste0(label, ":driver"))

--- a/R/config.R
+++ b/R/config.R
@@ -93,8 +93,7 @@ config_migrate <- function(data, filename) {
              "future orderly version.  Please use the new 'vault' server",
              "field, which offers more flexibility")
     orderly_warning(flow_text(msg))
-    assert_scalar_character(vault_server, sprintf("%s:vault_server", filename))
-    data$vault <- list(addr = vault_server)
+    data$vault <- list(addr = data[["vault_server"]])
     data$vault_server <- NULL
   }
 
@@ -116,7 +115,7 @@ config_migrate <- function(data, filename) {
 
   for (i in seq_along(data[["database"]])) {
     x <- data[["database"]][[i]]
-    if (!any(c("instance", "args") %in% names(x))) {
+    if (!any(c("instances", "args") %in% names(x))) {
       label <- sprintf("orderly_config.yml:database:%s", names(x)[[i]])
       msg <- c("Please move your database arguments within an 'args'",
                "block, as detecting them will be deprecated in a future",

--- a/R/config.R
+++ b/R/config.R
@@ -59,7 +59,7 @@ orderly_config <- R6::R6Class(
     },
 
     migrate = function() {
-      self$data <- config_migrate(self$data)
+      self$data <- config_migrate(self$data, "orderly_config.yml")
     },
 
     validate = function() {
@@ -93,6 +93,8 @@ config_migrate <- function(data, filename) {
              "future orderly version.  Please use the new 'vault' server",
              "field, which offers more flexibility")
     orderly_warning(flow_text(msg))
+    assert_scalar_character(data[["vault_server"]],
+                            "orderly_config.yml:vault_server")
     data$vault <- list(addr = data[["vault_server"]])
     data$vault_server <- NULL
   }

--- a/R/config.R
+++ b/R/config.R
@@ -1,96 +1,153 @@
-orderly_config <- function(root) {
-  filename <- path_orderly_config_yml(root)
-  if (!file.exists(filename)) {
-    stop("Did not find file 'orderly_config.yml' at path ", root)
+orderly_locate_config <- function() {
+  root <- find_file_descend("orderly_config.yml")
+  if (is.null(root)) {
+    stop("Reached root without finding 'orderly_config.yml'")
   }
-  withr::with_envvar(
-    orderly_envir_read(root),
-    orderly_config_read_yaml(filename, root))
+  orderly_config$new(root)
 }
 
-orderly_config_read_yaml <- function(filename, root) {
-  info <- yaml_read(filename)
 
-  v <- info$minimum_orderly_version
-  if (!is.null(v) && utils::packageVersion("orderly") < v) {
-    stop(sprintf(
-      "Orderly version '%s' is required, but only '%s' installed",
-      v, utils::packageVersion("orderly")))
+orderly_config_get <- function(x, locate = FALSE) {
+  if (inherits(x, "orderly_config")) {
+    x
+  } else if (is.null(x) && locate) {
+    orderly_locate_config()
+  } else if (is.character(x)) {
+    orderly_config$new(x)
+  } else {
+    stop("Invalid input")
   }
+}
 
-  check_fields(info, filename, character(),
-               c("destination", "fields", "minimum_orderly_version",
+
+orderly_config <- R6::R6Class(
+  "orderly_config",
+
+  public = list(
+    ## The core data will remain available as top-level keys, but
+    ## we'll make this extensible when we do the plugins.
+    root = NULL,
+    data = NULL,
+    destination = NULL,
+    fields = NULL,
+    remote = NULL,
+    vault = NULL,
+    global_resources = NULL,
+    changelog = NULL,
+    tags = NULL,
+    database = NULL,
+    archive_version = NULL,
+
+    initialize = function(root, validate = TRUE) {
+      assert_is_directory(root)
+      self$root <- normalizePath(root, mustWork = TRUE)
+      filename <- path_orderly_config_yml(self$root)
+      assert_file_exists(basename(filename), workdir = self$root,
+                         name = "Orderly configuration")
+      self$data <- yaml_read(filename)
+
+      v <- self$data$minimum_orderly_version
+      if (!is.null(v) && utils::packageVersion("orderly") < v) {
+        stop(sprintf(
+          "Orderly version '%s' is required, but only '%s' installed",
+          v, utils::packageVersion("orderly")))
+      }
+
+      if (validate) {
+        self$validate()
+      }
+    },
+
+    validate = function() {
+      withr::with_dir(
+        self$root,
+        withr::with_envvar(
+          orderly_envir_read("."),
+          config_validate(self, "orderly_config.yml")))
+    },
+
+    server_options = function() {
+      i <- vlapply(self$remote, function(x) isTRUE(x$identity))
+      if (!any(i)) {
+        return(NULL)
+      }
+      ## TODO(VIMC-3590): Let's move these all under options at some point
+      ret <- self$remote[[which(i)]]
+      ret[setdiff(names(ret), c("identity", "driver", "args", "name"))]
+    }
+  ))
+
+
+config_validate <- function(self, filename) {
+  ## There are no required fields, and soon we will let the optional
+  ## fields grow as the plugin interface develops; that will require
+  ## looking in some plugins field fairly early?
+
+  ## An important concept here is that none of the configuration
+  ## fields depend on each other - we just plough through and read
+  ## them one after another.  That makes things considerably easier to
+  ## reason about (note that none of these gets the fill structure and
+  ## the only two that get anything else are the old-style-handlers)
+
+  ## Write a small 'migration' layer here, I think.  Then things get a
+  ## lot easier.
+  data <- self$data
+
+  check_fields(data, filename, character(),
+               c("minimum_orderly_version", "destination", "fields",
                  "remote", "vault", "vault_server", "global_resources",
                  "changelog", "tags", "source", "database"))
 
-  ## There's heaps of really boring validation to do here that I am
-  ## going to skip.  The drama that we will have is that there are
-  ## things that should be interpreted relative to different
-  ## directories; things like the sqlite path.  And I want to be able
-  ## to encrypt and decrypt things like passwords.  So we probably
-  ## cannot be totally opaque when reading information in.
-  info$fields <- config_check_fields(info$fields, filename)
-  if (!is.null(info$source)) {
-    if (!is.null(info$database)) {
-      stop("Both 'database' and 'source' fields may not be used")
-    }
-    msg <- c("Use of 'source' is deprecated and will be removed in a",
-             "future orderly version - please use 'database' instead.",
-             "See the main package vignette for details.")
-    orderly_warning(flow_text(msg))
-    info$database_old_style <- TRUE
-    info$database <- list(source = config_read_db("source", info, filename))
-  } else if (!is.null(info$database)) {
-    assert_named(info$database, unique = TRUE)
-    info$database_old_style <- FALSE
-    for (nm in names(info$database)) {
-      info$database[[nm]] <- config_read_db(c("database", nm), info, filename)
-    }
-  }
-  info$destination <- config_read_db("destination", info, filename)
+  self$destination <- config_validate_destination(
+    data[["destination"]], filename)
+  self$fields <- config_validate_fields(
+    data[["fields"]], filename)
+  self$remote <- config_validate_remote(
+    data[["remote"]], filename)
+  self$vault <- config_validate_vault(
+    data[["vault"]], data[["vault_server"]], filename)
+  self$global_resources <- config_validate_global_resources(
+    data[["global_resources"]], filename)
+  self$changelog <- config_validate_changelog(
+    data[["changelog"]], filename)
+  self$tags <- config_validate_tags(
+    data[["tags"]], filename)
+  self$database <- config_validate_database(
+    data[["database"]], data[["source"]], filename)
 
-  if (!is.null(info$changelog)) {
-    info$changelog <- config_check_changelog(info$changelog, filename)
-  }
+  self$archive_version <- read_orderly_archive_version(".")
 
-  if (!is.null(info$tags)) {
-    assert_character(info$tags, sprintf("%s:tags", filename))
-  }
-
-  info[["vault"]] <-
-    config_check_vault(info[["vault"]], info[["vault_server"]], filename)
-  info$remote <- config_check_remote(info$remote, filename)
-
-  info$root <- normalizePath(root, mustWork = TRUE)
-
-  remote_identity <- Sys.getenv("ORDERLY_API_SERVER_IDENTITY", "")
-  if (nzchar(remote_identity)) {
-    info$remote_identity <-
-      match_value(remote_identity, names(info$remote))
-    excl <- c("driver", "args", "name")
-    server_options <- info$remote[[remote_identity]]
-    info$server_options <- server_options[setdiff(names(server_options), excl)]
-  }
-
-  if (!is.null(info$global_resources)) {
-    assert_is_directory(info$global_resources, name = "global resource",
-                        workdir = root)
-  }
-
-  info$archive_version <- read_orderly_archive_version(root)
-
-  class(info) <- "orderly_config"
-  info
+  invisible(self)
 }
 
-config_check_fields <- function(x, filename) {
-  if (is.null(x)) {
+
+config_validate_destination <- function(destination, filename) {
+  if (is.null(destination)) {
+    destination <- list(driver = "RSQLite::SQLite",
+                        args = list(dbname = "orderly.sqlite"))
+  }
+  label <- sprintf("%s:destination", filename)
+
+  if (!any(c("args", "instances") %in% names(destination))) {
+    stop("old style db")
+  }
+
+  check_fields(destination, label, c("driver", "args"), character())
+  destination$driver <-
+    check_symbol_from_str(destination$driver, paste0(label, ":driver"))
+  assert_named(destination$args, TRUE, paste0(label, ":args"))
+  destination
+}
+
+
+config_validate_fields <- function(fields, filename) {
+  if (is.null(fields)) {
     return(data.frame(name = character(0), required = logical(0),
                       stringsAsFactors = FALSE))
   }
-  assert_named(x, TRUE, sprintf("%s:fields", filename))
+  assert_named(fields, TRUE, sprintf("%s:fields", filename))
   check1 <- function(nm) {
-    d <- x[[nm]]
+    d <- fields[[nm]]
     ## TODO: See VIMC-2930; "type" can be removed once the reports are
     ## updated, but it's best to do that in a staged way (deploy
     ## VIMC-2768, remove entries from the montagu-reports, then remove
@@ -107,57 +164,56 @@ config_check_fields <- function(x, filename) {
     }
     d
   }
-  dat <- lapply(names(x), check1)
-  data.frame(name = names(x),
+  dat <- lapply(names(fields), check1)
+  data_frame(name = names(fields),
              required = vlapply(dat, "[[", "required"),
-             description = vcapply(dat, "[[", "description"),
-             stringsAsFactors = FALSE)
+             description = vcapply(dat, "[[", "description"))
 }
 
 
-config_check_remote <- function(dat, filename) {
-  if (is.null(dat)) {
+config_validate_remote <- function(remote, filename) {
+  if (is.null(remote)) {
     return(NULL)
   }
-  assert_named(dat, unique = TRUE)
+  assert_named(remote, unique = TRUE)
 
   check1 <- function(name) {
-    remote <- dat[[name]]
-    check_fields(remote, sprintf("%s:remote:%s", filename, name),
+    d <- remote[[name]]
+    check_fields(d, sprintf("%s:remote:%s", filename, name),
                  c("driver", "args"),
                  c("url", "slack_url", "primary", "master_only"))
     field_name <- function(nm) {
       sprintf("%s:remote:%s:%s", filename, name, nm)
     }
-    assert_scalar_character(remote$driver, field_name("driver"))
-    assert_named(remote$args, name = field_name("args"))
+    assert_scalar_character(d$driver, field_name("driver"))
+    assert_named(d$args, name = field_name("args"))
 
     ## optionals:
-    if (!is.null(remote$url)) {
+    if (!is.null(d$url)) {
       msg <- c("The 'url' field (used in",
                sprintf("%s:remote:%s", filename, name),
                "is deprecated and will be dropped in a future version of",
                "orderly.  Please remove it from your orderly_config.yml")
       orderly_warning(flow_text(msg))
     }
-    if (is.null(remote$primary)) {
-      remote$primary <- FALSE
+    if (is.null(d$primary)) {
+      d$primary <- FALSE
     } else {
-      assert_scalar_logical(remote$primary, field_name("primary"))
+      assert_scalar_logical(d$primary, field_name("primary"))
     }
-    if (is.null(remote$master_only)) {
-      remote$master_only <- FALSE
+    if (is.null(d$master_only)) {
+      d$master_only <- FALSE
     } else {
-      assert_scalar_logical(remote$master_only, field_name("master_only"))
+      assert_scalar_logical(d$master_only, field_name("master_only"))
     }
 
-    remote$driver <- check_symbol_from_str(remote$driver, field_name("driver"))
-    remote$args <- c(remote$args, list(name = name))
-    remote$name <- name
-    remote
+    d$driver <- check_symbol_from_str(d$driver, field_name("driver"))
+    d$args <- c(d$args, list(name = name))
+    d$name <- name
+    d
   }
 
-  ret <- set_names(lapply(names(dat), check1), names(dat))
+  ret <- set_names(lapply(names(remote), check1), names(remote))
   primary <- vlapply(ret, "[[", "primary")
   if (sum(primary) > 1L) {
     stop(sprintf(
@@ -165,120 +221,18 @@ config_check_remote <- function(dat, filename) {
       sum(primary), paste(squote(names(which(primary))), collapse = ", ")),
       call. = FALSE)
   }
+
+  identity <- Sys.getenv("ORDERLY_API_SERVER_IDENTITY", "")
+  if (nzchar(identity)) {
+    match_value(identity, names(ret))
+    ret[[identity]]$identity <- TRUE
+  }
+
   ret
 }
 
-config_check_changelog <- function(x, filename) {
-  assert_named(x, unique = TRUE, sprintf("%s:changelog", filename))
-  for (i in names(x)) {
-    assert_scalar_logical(
-      x[[i]]$public,
-      sprintf("%s:changelog:%s:public", filename, i))
-  }
 
-  data_frame(id = names(x),
-             public = vlapply(x, function(x) x$public, USE.NAMES = FALSE))
-}
-
-
-orderly_locate_config <- function() {
-  root <- find_file_descend("orderly_config.yml")
-  if (is.null(root)) {
-    stop("Reached root without finding 'orderly_config.yml'")
-  }
-  orderly_config(root)
-}
-
-
-orderly_config_get <- function(x, locate = FALSE) {
-  if (inherits(x, "orderly_config")) {
-    x
-  } else if (is.null(x) && locate) {
-    orderly_locate_config()
-  } else if (is.character(x)) {
-    orderly_config(x)
-  } else {
-    stop("Invalid input")
-  }
-}
-
-
-config_read_db <- function(name, info, filename) {
-  if (identical(name, "destination") && is.null(info[[name]])) {
-    dat <- list(driver = "RSQLite::SQLite",
-                args = list(dbname = "orderly.sqlite"))
-  } else {
-    dat <- info[[name]]
-  }
-  label <- sprintf("%s:%s:driver", filename, paste(name, collapse = ":"))
-  driver <- check_symbol_from_str(dat$driver, label)
-  instances <- NULL
-
-  ## There's a bit of faff required here now - this would be simpler
-  ## if we dropped old-style databases (vimc-3315) but that's
-  ## awkward in its own right because it affects the configuration
-  ## during migration tests.
-  if (any(c("args", "instances") %in% names(dat))) {
-    if (identical(name, "destination")) {
-      optional <- "args"
-    } else {
-      optional <- c("args", "instances", "default_instance")
-    }
-    label <- sprintf("%s:%s", filename, paste(name, collapse = ":"))
-    check_fields(dat, label, "driver", optional)
-
-    if (!is.null(dat$instances)) {
-      assert_named(dat$instances, TRUE, paste0(label, ":instances"))
-      for (i in names(dat$instances)) {
-        assert_named(dat$instances[[i]], TRUE, paste0(label, ":instances:", i))
-      }
-      base <- dat$args %||% set_names(list(), character())
-      assert_named(base, TRUE, paste0(label, ":args"))
-      instances <- lapply(dat$instances, utils::modifyList, x = base)
-    } else {
-      assert_named(dat$args, TRUE, paste0(label, ":args"))
-    }
-
-    if (!is.null(dat$default_instance)) {
-      if (is.null(instances)) {
-        msg <- c(
-          "Can't specify 'default_instance' with no defined instances in",
-          label)
-        stop(flow_text(msg), call. = FALSE)
-      }
-      dat["default_instance"] <-
-        resolve_env(dat["default_instance"], "default_instance",
-                    error = FALSE, default = NULL)
-      if (!is.null(dat$default_instance)) {
-        match_value(dat$default_instance, names(instances),
-                    paste0(label, ":default_instance"))
-      }
-    }
-
-    if (is.null(instances)) {
-      args <- dat$args
-    } else {
-      args <- instances[[dat$default_instance %||% 1L]]
-      v <- c(dat$default_instance,
-             setdiff(names(instances), dat$default_instance))
-      instances <- instances[v]
-    }
-  } else {
-    if (!info$database_old_style) {
-      msg <- c("Please move your database arguments within an 'args'",
-               "block, as detecting them will be deprecated in a future",
-               "orderly version.  See the main package vignette for",
-               "details.  Reported for: ", label)
-      orderly_warning(flow_text(msg))
-    }
-    args <- dat[setdiff(names(dat), "driver")]
-  }
-
-  list(driver = driver, args = args, instances = instances)
-}
-
-
-config_check_vault <- function(vault, vault_server, filename) {
+config_validate_vault <- function(vault, vault_server, filename) {
   if (!is.null(vault_server)) {
     if (!is.null(vault)) {
       stop(sprintf("Can't specify both 'vault' and 'vault_server' in %s",
@@ -296,4 +250,123 @@ config_check_vault <- function(vault, vault_server, filename) {
   }
 
   vault
+}
+
+
+config_validate_global_resources <- function(global_resources, filename) {
+  if (!is.null(global_resources)) {
+    assert_is_directory(global_resources, name = "Global resource directory")
+    global_resources
+  }
+}
+
+
+config_validate_changelog <- function(changelog, filename) {
+  if (is.null(changelog)) {
+    return(NULL)
+  }
+
+  assert_named(changelog, unique = TRUE, sprintf("%s:changelog", filename))
+  for (i in names(changelog)) {
+    assert_scalar_logical(
+      changelog[[i]]$public,
+      sprintf("%s:changelog:%s:public", filename, i))
+  }
+
+  data_frame(
+    id = names(changelog),
+    public = vlapply(changelog, "[[", "public", USE.NAMES = FALSE))
+}
+
+
+config_validate_tags <- function(tags, filename) {
+  if (is.null(tags)) {
+    return(NULL)
+  }
+
+  assert_character(tags, sprintf("%s:tags", filename))
+  tags
+}
+
+
+config_validate_database <- function(database, source, filename) {
+  if (is.null(database) && is.null(source)) {
+    return(NULL)
+  }
+  database_old_style <- !is.null(source)
+  if (database_old_style) {
+    if (!is.null(database)) {
+      stop("Both 'database' and 'source' fields may not be used")
+    }
+    msg <- c("Use of 'source' is deprecated and will be removed in a",
+             "future orderly version - please use 'database' instead.",
+             "See the main package vignette for details.")
+    orderly_warning(flow_text(msg))
+    browser()
+    ## This bit needs work
+
+    prefix <- sprintf("%s:source", filename)
+    database <- list(source = config_validate_database1(source, prefix))
+  }
+
+  assert_named(database, unique = TRUE, sprintf("%s:database", filename))
+  for (nm in names(database)) {
+    prefix <- sprintf("%s:database:%s", filename, nm)
+    database[[nm]] <- config_validate_database1(database[[nm]], prefix)
+  }
+
+  database
+}
+
+
+config_validate_database1 <- function(db, prefix) {
+  ## TODO: dropping support here for old-style db entries, which
+  ## breaks migrations.  Might support a separate code-path for
+  ## old-style reading, but let's keep this clean.  Alternatively, we
+  ## might just rewrite the migrations before running.
+  optional <- c("args", "instances", "default_instance")
+  check_fields(db, prefix, "driver", optional)
+
+  driver <- check_symbol_from_str(db$driver, paste0(prefix, ":driver"))
+  instances <- NULL
+
+  if (!is.null(db$args)) {
+    assert_named(db$args, TRUE, paste0(prefix, ":args"))
+  }
+
+  if (!is.null(db$instances)) {
+    assert_named(db$instances, TRUE, paste0(prefix, ":instances"))
+    for (i in names(db$instances)) {
+      assert_named(db$instances[[i]], TRUE, paste0(prefix, ":instances:", i))
+    }
+    base <- db$args %||% set_names(list(), character())
+    instances <- lapply(db$instances, utils::modifyList, x = base)
+  }
+
+  if (!is.null(db$default_instance)) {
+    if (is.null(instances)) {
+      msg <- c(
+        "Can't specify 'default_instance' with no defined instances in",
+        prefix)
+      stop(flow_text(msg), call. = FALSE)
+    }
+    db["default_instance"] <-
+      resolve_env(db["default_instance"], "default_instance",
+                  error = FALSE, default = NULL)
+    if (!is.null(db$default_instance)) {
+      match_value(db$default_instance, names(instances),
+                  paste0(prefix, ":default_instance"))
+    }
+  }
+
+  if (is.null(instances)) {
+    args <- db$args
+  } else {
+    args <- instances[[db$default_instance %||% 1L]]
+    v <- c(db$default_instance,
+           setdiff(names(instances), db$default_instance))
+    instances <- instances[v]
+  }
+
+  list(driver = driver, args = args, instances = instances)
 }

--- a/R/recipe_read.R
+++ b/R/recipe_read.R
@@ -88,14 +88,12 @@ recipe_read <- function(path, config, validate = TRUE, use_draft = FALSE,
       stop("No databases are configured - can't use a 'connection' section")
     }
     if (is.character(info$connection)) {
-      if (!config$database_old_style) {
-        ## TODO: Better message?
-        msg <- c("Use of strings for connection: is deprecated and will be",
-                 "removed in a future orderly version - please use",
-                 "connection: <object>: <dbname> instead.  See the main",
-                 "package vignette for details")
-        orderly_warning(flow_text(msg))
-      }
+      ## TODO: Better message?
+      msg <- c("Use of strings for connection: is deprecated and will be",
+               "removed in a future orderly version - please use",
+               "connection: <object>: <dbname> instead.  See the main",
+               "package vignette for details")
+      orderly_warning(flow_text(msg))
       if (length(config$database) > 1L) {
         msg <- paste("More than one database configured; update 'connection'",
                      sprintf("from '%s' to '%s: <dbname>' in '%s'",
@@ -351,13 +349,11 @@ recipe_read_query <- function(field, info, filename, config) {
       name <- sprintf("%s:%s:%s", filename, field, nm)
       d <- d[[nm]]
       if (is.character(d)) {
-        if (!config$database_old_style) {
-          msg <- c("Use of strings for queries is deprecated and will be",
-                   "removed in a future orderly version - please use",
-                   "query: <yourstring> instead.  See the main package",
-                   "vignette for details")
-          orderly_warning(flow_text(msg))
-        }
+        msg <- c("Use of strings for queries is deprecated and will be",
+                 "removed in a future orderly version - please use",
+                 "query: <yourstring> instead.  See the main package",
+                 "vignette for details")
+        orderly_warning(flow_text(msg))
         d <- string_or_filename(d, path, name)
       } else {
         check_fields(d, name, "query", "database")

--- a/R/remote_path.R
+++ b/R/remote_path.R
@@ -41,7 +41,7 @@ orderly_remote_path_ <- R6::R6Class(
       if (!file.exists(path_orderly_config_yml(path))) {
         stop("Does not look like an orderly repository: ", squote(path))
       }
-      self$config <- orderly_config(path)
+      self$config <- orderly_config$new(path)
       self$name <- name %||% self$config$root
       lockBinding(quote(config), self)
       lockBinding(quote(name), self)

--- a/R/runner.R
+++ b/R/runner.R
@@ -419,7 +419,7 @@ runner_allow_ref <- function(has_git, allow_ref, config) {
     allow_ref <- FALSE
   }
   if (is.null(allow_ref)) {
-    allow_ref <- !(config$server_options$master_only %||% FALSE)
+    allow_ref <- !(config$server_options()$master_only %||% FALSE)
   }
   if (allow_ref) {
     res <- git_run(c("rev-parse", "HEAD"), root = config$root, check = FALSE)

--- a/R/slack.R
+++ b/R/slack.R
@@ -1,21 +1,20 @@
 ## Send slack messages!
 
 slack_post_success <- function(dat, config) {
-  stop("FIXME")
-  # instead need to go through server_options
-  if (!is.null(config$remote_identity)) {
-    remote <- get_remote(config$remote_identity, config)
+  opts <- config$server_options()
+
+  if (!is.null(opts)) {
+    remote <- get_remote(opts$name, config)
 
     ## TODO(VIMC-3544): This moves into the object itself, using some
     ## sort of data field, so we might use remote$data$slack_url and
     ## remote$data$primary
-    slack_url <- attr(remote, "slack_url")
-    primary <- attr(remote, "primary")
-    assert_scalar_character(slack_url, "slack_url")
+    slack_url <- opts$slack_url
 
     if (!is.null(slack_url)) {
+      assert_scalar_character(slack_url, "slack_url")
       report_url <- remote$url_report(dat$meta$name, dat$meta$id)
-      data <- slack_data(dat, remote$name, report_url, primary)
+      data <- slack_data(dat, remote$name, report_url, opts$primary)
       do_slack_post_success(slack_url, data)
     }
   }

--- a/R/slack.R
+++ b/R/slack.R
@@ -1,6 +1,8 @@
 ## Send slack messages!
 
 slack_post_success <- function(dat, config) {
+  stop("FIXME")
+  # instead need to go through server_options
   if (!is.null(config$remote_identity)) {
     remote <- get_remote(config$remote_identity, config)
 

--- a/tests/testthat/helper-orderly.R
+++ b/tests/testthat/helper-orderly.R
@@ -86,7 +86,7 @@ prepare_orderly_remote_example <- function(path = tempfile()) {
                 args = list(path = path_remote))))
   append_lines(yaml::as.yaml(r), file.path(path_local, "orderly_config.yml"))
 
-  config <- orderly_config(path_local)
+  config <- orderly_config$new(path_local)
   remote <- get_remote(NULL, config)
 
   list(path_remote = path_remote,

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -1,7 +1,7 @@
 context("config")
 
 test_that("read", {
-  cfg <- orderly_config("example")
+  cfg <- orderly_config$new("example")
   expect_is(cfg, "orderly_config")
 
   ## default destination database:
@@ -28,7 +28,7 @@ test_that("environment variables", {
                               password = "$OURPASSWORD"))))
   writeLines(yaml::as.yaml(dat), path_orderly_config_yml(path))
 
-  cfg <- orderly_config(path)
+  cfg <- orderly_config$new(path)
 
   expect_error(
     orderly_db_args(cfg$database$source, cfg, "loc"),
@@ -42,8 +42,10 @@ test_that("environment variables", {
 })
 
 test_that("not found", {
-  expect_error(orderly_config(tempfile()),
-               "Did not find file 'orderly_config.yml' at path")
+  path <- tempfile()
+  dir.create(path)
+  expect_error(orderly_config$new(path),
+               "Orderly configuration does not exist: 'orderly_config.yml'")
 })
 
 test_that("get: invalid config", {
@@ -64,7 +66,7 @@ test_that("minimum orderly version is enforced", {
   dat <- list(minimum_orderly_version = "9.9.9")
   writeLines(yaml::as.yaml(dat), path_orderly_config_yml(path))
 
-  expect_error(orderly_config(path),
+  expect_error(orderly_config$new(path),
                "Orderly version '9.9.9' is required, but only",
                fixed = TRUE)
 })
@@ -76,9 +78,9 @@ test_that("minimum version is a less than relationship", {
 
   dat <- list(minimum_orderly_version = as.character(packageVersion("orderly")))
   writeLines(yaml::as.yaml(dat), path_orderly_config_yml(path))
-  cfg <- orderly_config(path)
+  cfg <- orderly_config$new(path)
   expect_is(cfg, "orderly_config")
-  expect_equal(cfg$minimum_orderly_version, dat$minimum_orderly_version)
+  expect_equal(cfg$data$minimum_orderly_version, dat$minimum_orderly_version)
 })
 
 
@@ -95,7 +97,7 @@ test_that("support declaring api server", {
                   driver = "orderly::orderly_remote_path",
                   args = list(root = path))))
   writeLines(yaml::as.yaml(dat), path_orderly_config_yml(path))
-  cfg <- orderly_config(path)
+  cfg <- orderly_config$new(path)
 
   expect_is(cfg$remote, "list")
   expect_equal(cfg$remote$main$args,
@@ -103,29 +105,34 @@ test_that("support declaring api server", {
 
   cfg <- withr::with_envvar(
     c("ORDERLY_API_SERVER_IDENTITY" = "main"),
-    orderly_config(path))
-  expect_equal(cfg$remote_identity, "main")
-  expect_true(cfg$server_options$primary)
-  expect_true(cfg$server_options$master_only)
+    orderly_config$new(path))
+  expect_true(cfg$remote$main$identity)
+  expect_null(cfg$remote$other$identity)
+  expect_equal(
+    cfg$server_options(),
+    list(primary = TRUE, master_only = TRUE))
 
   cfg <- withr::with_envvar(
     c("ORDERLY_API_SERVER_IDENTITY" = "other"),
-    orderly_config(path))
-  expect_equal(cfg$remote_identity, "other")
-  expect_false(cfg$server_options$primary)
-  expect_false(cfg$server_options$master_only)
+    orderly_config$new(path))
+  expect_null(cfg$remote$main$identity)
+  expect_true(cfg$remote$other$identity)
+  expect_equal(
+    cfg$server_options(),
+    list(primary = FALSE, master_only = FALSE))
 
   cfg <- withr::with_envvar(
     c("ORDERLY_API_SERVER_IDENTITY" = NA),
-    orderly_config(path))
-  expect_null(cfg$remote_identity)
-  expect_null(cfg$server_options)
+    orderly_config$new(path))
+  expect_null(cfg$remote$main$identity)
+  expect_null(cfg$remote$other$identity)
+  expect_null(cfg$server_options())
 
   withr::with_envvar(
     c("ORDERLY_API_SERVER_IDENTITY" = "something-else"),
     expect_error(
-      orderly_config(path)$remote_identity,
-      "remote_identity must be one of 'main', 'other'"))
+      orderly_config$new(path)$remote_identity,
+      "identity must be one of 'main', 'other'"))
 })
 
 
@@ -144,11 +151,11 @@ test_that("api server has only one primary", {
 
   writeLines(yaml::as.yaml(dat), path_orderly_config_yml(path))
   expect_error(
-    orderly_config(path),
+    orderly_config$new(path),
     "At most one remote can be listed as primary but here 2 are")
   dat$remote$other$primary <- FALSE
   writeLines(yaml::as.yaml(dat), path_orderly_config_yml(path))
-  cfg <- orderly_config(path)
+  cfg <- orderly_config$new(path)
   expect_true(cfg$remote$main$primary)
   expect_false(cfg$remote$other$primary)
 })
@@ -164,8 +171,8 @@ test_that("remote parse check", {
                   master_only = "yeah")))
   writeLines(yaml::as.yaml(dat), path_orderly_config_yml(path))
   expect_error(
-    orderly_config(path),
-    "'.+/orderly_config.yml:remote:myhost:master_only' must be logical")
+    orderly_config$new(path),
+    "'orderly_config.yml:remote:myhost:master_only' must be logical")
 })
 
 test_that("no global folder", {
@@ -177,67 +184,66 @@ test_that("no global folder", {
   writeLines(yaml::as.yaml(dat), path_config)
 
   expect_error(
-    orderly_config(root = path),
-    "global resource does not exist: 'invalid_directory'",
+    orderly_config$new(root = path),
+    "Global resource directory does not exist: 'invalid_directory'",
     fixed = TRUE
   )
 })
 
 
 test_that("vault configuration validation when absent", {
-  expect_null(config_check_vault(NULL, NULL, "orderly.yml"))
+  expect_null(config_validate_vault(NULL, NULL, "orderly.yml"))
 })
 
 
 test_that("vault configuration validation for typical use", {
   vault <- list(addr = "https://vault.example.com")
-  expect_identical(config_check_vault(vault, NULL, "orderly.yml"), vault)
+  expect_identical(config_validate_vault(vault, NULL, "orderly.yml"), vault)
 
   vault <- list(addr = "https://vault.example.com",
                 auth = list(method = "github"))
-  expect_identical(config_check_vault(vault, NULL, "orderly.yml"), vault)
+  expect_identical(config_validate_vault(vault, NULL, "orderly.yml"), vault)
 })
 
 
 test_that("vault configuration requires string for url", {
   oo <- options(orderly.nowarnings = TRUE)
   on.exit(options(oo))
-  expect_error(config_check_vault(NULL, TRUE, "orderly.yml"),
+  expect_error(config_validate_vault(NULL, TRUE, "orderly.yml"),
                "'orderly.yml:vault_server' must be character")
   expect_error(
-    config_check_vault(NULL, c("a", "b"), "orderly.yml"),
+    config_validate_vault(NULL, c("a", "b"), "orderly.yml"),
     "'orderly.yml:vault_server' must be a scalar")
-  expect_null(config_check_vault(NULL, NULL, "orderly.yml"))
+  expect_null(config_validate_vault(NULL, NULL, "orderly.yml"))
 })
 
 
 test_that("previous configuration is transformed with warning", {
   addr <- "https://vault.example.com"
   expect_warning(
-    res <- config_check_vault(NULL, addr, "orderly.yml"),
+    res <- config_validate_vault(NULL, addr, "orderly.yml"),
     "Use of 'vault_server' is deprecated")
   expect_equal(res, list(addr = addr))
 })
 
 test_that("vault_server (not vault) in configuration yaml", {
-
-  # 1.0.10 - this fails if config.R:55 uses $vault instead of [['vault']]
+  ## 1.0.10 - this fails if config.R:55 uses $vault instead of [["vault"]]
 
   path <- prepare_orderly_example("minimal")
   path_config <- file.path(path, "orderly_config.yml")
   text <- readLines(path_config)
 
-  expect_null(orderly_config(root = path)$vault)
+  expect_null(orderly_config$new(root = path)$vault)
 
   url <- "https://vault.example.com"
   writeLines(c(text, sprintf("vault_server: %s", url)), path_config)
-  expect_warning(res <- orderly_config(root = path)$vault,
+  expect_warning(res <- orderly_config$new(root = path)$vault,
                  "Use of 'vault_server' is deprecated")
   expect_equal(res, list(addr = url))
 })
 
 test_that("Can't use both new and old vault configurations", {
-  expect_error(config_check_vault(list(login = "token"),
+  expect_error(config_validate_vault(list(login = "token"),
                                   "https://vault.example.com",
                                   "orderly.yml"),
                "Can't specify both 'vault' and 'vault_server' in orderly.yml")
@@ -249,11 +255,11 @@ test_that("vault configuration", {
   path_config <- file.path(path, "orderly_config.yml")
   text <- readLines(path_config)
 
-  expect_null(orderly_config(root = path)$vault)
+  expect_null(orderly_config$new(root = path)$vault)
 
   url <- "https://vault.example.com"
   writeLines(c(text, sprintf("vault:\n  addr: %s", url)), path_config)
-  expect_equal(orderly_config(root = path)$vault, list(addr = url))
+  expect_equal(orderly_config$new(root = path)$vault, list(addr = url))
 })
 
 
@@ -264,7 +270,7 @@ test_that("can't use both database and source sections", {
   dat <- list(source = list(driver = "RSQLite::SQLite",
                             dbname = "source.sqlite"))
   writeLines(c(txt, yaml::as.yaml(dat)), path_config)
-  expect_error(orderly_config(path),
+  expect_error(orderly_config$new(path),
                "Both 'database' and 'source' fields may not be used",
                fixed = TRUE)
 })
@@ -272,35 +278,37 @@ test_that("can't use both database and source sections", {
 
 test_that("can read a configuration with no database", {
   path <- prepare_orderly_example("db0", testing = TRUE)
-  config <- orderly_config(path)
-  expect_false("database" %in% names(config))
+  config <- orderly_config$new(path)
+  expect_null(config$database)
 })
 
 
 test_that("can read a configuration with two databases", {
   path <- prepare_orderly_example("db2", testing = TRUE)
-  config <- orderly_config(path)
+  config <- orderly_config$new(path)
   expect_setequal(names(config$database), c("source1", "source2"))
   expect_equal(config$database$source1$args, list(dbname = "source1.sqlite"))
   expect_equal(config$database$source2$args, list(dbname = "source2.sqlite"))
 
   con <- orderly_db("source", root = path)
-  DBI::dbListTables(con$source1)
-  DBI::dbListTables(con$source2)
+  expect_equal(DBI::dbListTables(con$source1), "mtcars")
+  expect_equal(DBI::dbListTables(con$source2), "iris")
 })
 
 
 test_that("warn when reading old-style configuration", {
+  skip("FIXME")
   path <- withr::with_options(
     list(orderly.nowarnings = TRUE),
     prepare_orderly_example("olddb", testing = TRUE))
 
-  expect_warning(orderly_config(path),
+  expect_warning(orderly_config$new(path),
                  "Use of 'source' is deprecated and will be removed")
 })
 
 
 test_that("warn when reading old-style db config", {
+  skip("FIXME")
   path <- prepare_orderly_example("minimal")
   content <- c(
     "database:",
@@ -309,11 +317,11 @@ test_that("warn when reading old-style db config", {
     "    dbname: source.sqlite")
   writeLines(content, file.path(path, "orderly_config.yml"))
   expect_warning(
-    orderly_config(path),
+    orderly_config$new(path),
     "Please move your database arguments")
   withr::with_options(
     list(orderly.nowarnings = TRUE),
-    expect_warning(orderly_config(path), NA))
+    expect_warning(orderly_config$new(path), NA))
 })
 
 
@@ -329,11 +337,11 @@ test_that("warn when using url in remote definition", {
     "    slack_url: https://httpbin.org/post"),
     file.path(path, "orderly_config.yml"))
   expect_warning(
-    orderly_config(path),
+    orderly_config$new(path),
     "deprecated and will be dropped")
   withr::with_options(
     list(orderly.nowarnings = TRUE),
-    expect_warning(orderly_config(path), NA))
+    expect_warning(orderly_config$new(path), NA))
 })
 
 
@@ -351,7 +359,7 @@ test_that("multiple database configurations", {
     "        dbname: production.sqlite",
     "    default_instance: production"),
     p)
-  cfg <- orderly_config(path)
+  cfg <- orderly_config$new(path)
   expect_equal(cfg$database$source$args, list(dbname = "production.sqlite"))
   expect_equal(cfg$database$source$instances,
                list(production = list(dbname = "production.sqlite"),
@@ -370,6 +378,8 @@ test_that("instances not supported for destination db", {
     "        dbname: staging.sqlite",
     "destination:",
     "    driver: RSQLite::SQLite",
+    "    args:",
+    "      dbname: orderly.sqlite",
     "    instances:",
     "      staging:",
     "        dbname: dest-staging.sqlite",
@@ -377,7 +387,7 @@ test_that("instances not supported for destination db", {
     "        dbname: dest-production.sqlite"),
     p)
   expect_error(
-    orderly_config(path),
+    orderly_config$new(path),
     "Unknown fields in .*orderly_config.yml:destination: instances")
 })
 
@@ -394,7 +404,7 @@ test_that("default_instance not allowed without instances", {
     "    default_instance: production"),
     p)
   expect_error(
-    orderly_config(path),
+    orderly_config$new(path),
     "Can't specify 'default_instance' with no defined instances")
 })
 
@@ -413,47 +423,47 @@ test_that("default instance from an environmental variable", {
     "        dbname: production.sqlite",
     "    default_instance: $ORDERLY_TEST_DEFAULT_INSTANCE"),
     p)
-  cfg <- orderly_config(path)
+  cfg <- orderly_config$new(path)
   expect_equal(cfg$database$source$args, list(dbname = "staging.sqlite"))
 
   cfg <- withr::with_envvar(
     c("ORDERLY_TEST_DEFAULT_INSTANCE" = "production"),
-    orderly_config(path))
+    orderly_config$new(path))
   expect_equal(cfg$database$source$args, list(dbname = "production.sqlite"))
 
   cfg <- withr::with_envvar(
     c("ORDERLY_TEST_DEFAULT_INSTANCE" = "staging"),
-    orderly_config(path))
+    orderly_config$new(path))
   expect_equal(cfg$database$source$args, list(dbname = "staging.sqlite"))
 
   cfg_db <- withr::with_envvar(
     c("ORDERLY_TEST_DEFAULT_INSTANCE" = "production"),
-    db_instance_select(NULL, orderly_config(path)$database))
+    db_instance_select(NULL, orderly_config$new(path)$database))
   expect_equal(cfg_db$source$args, list(dbname = "production.sqlite"))
 
   cfg_db <- withr::with_envvar(
     c("ORDERLY_TEST_DEFAULT_INSTANCE" = "staging"),
-    db_instance_select(NULL, orderly_config(path)$database))
+    db_instance_select(NULL, orderly_config$new(path)$database))
   expect_equal(cfg_db$source$args, list(dbname = "staging.sqlite"))
 
   writeLines("ORDERLY_TEST_DEFAULT_INSTANCE: production",
              file.path(path, "orderly_envir.yml"))
-  cfg <- orderly_config(path)
+  cfg <- orderly_config$new(path)
   expect_equal(cfg$database$source$args, list(dbname = "production.sqlite"))
 
   cfg_db <- withr::with_envvar(
     c("ORDERLY_TEST_DEFAULT_INSTANCE" = "production"),
-    db_instance_select(NULL, orderly_config(path)$database))
+    db_instance_select(NULL, orderly_config$new(path)$database))
   expect_equal(cfg_db$source$args, list(dbname = "production.sqlite"))
 })
 
 
 test_that("tags can be included in the configuration", {
   path <- prepare_orderly_example("minimal")
-  expect_null(orderly_config(path)$tags)
+  expect_null(orderly_config$new(path)$tags)
   p <- file.path(path, "orderly_config.yml")
   append_lines(c("tags:", "  - tag1", "  - tag2"), p)
-  expect_equal(orderly_config(path)$tags, c("tag1", "tag2"))
+  expect_equal(orderly_config$new(path)$tags, c("tag1", "tag2"))
 })
 
 
@@ -462,7 +472,7 @@ test_that("tags are validated", {
   p <- file.path(path, "orderly_config.yml")
   append_lines(c("tags:", "  - 1", "  - 2"), p)
   expect_error(
-    orderly_config(path),
+    orderly_config$new(path),
     "orderly_config.yml:tags' must be character")
 })
 
@@ -475,6 +485,6 @@ test_that("adding new fields in new versions gives good errors", {
       "minimum_orderly_version: 9.9.9"),
     file.path(path, "orderly_config.yml"))
   expect_error(
-    orderly_config(path),
+    orderly_config$new(path),
     "Orderly version '9.9.9' is required, but only '.+' installed")
 })

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -297,18 +297,15 @@ test_that("can read a configuration with two databases", {
 
 
 test_that("warn when reading old-style configuration", {
-  skip("FIXME")
   path <- withr::with_options(
     list(orderly.nowarnings = TRUE),
     prepare_orderly_example("olddb", testing = TRUE))
-
   expect_warning(orderly_config$new(path),
                  "Use of 'source' is deprecated and will be removed")
 })
 
 
 test_that("warn when reading old-style db config", {
-  skip("FIXME")
   path <- prepare_orderly_example("minimal")
   content <- c(
     "database:",

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -110,7 +110,7 @@ test_that("support declaring api server", {
   expect_null(cfg$remote$other$identity)
   expect_equal(
     cfg$server_options(),
-    list(primary = TRUE, master_only = TRUE))
+    list(primary = TRUE, master_only = TRUE, name = "main"))
 
   cfg <- withr::with_envvar(
     c("ORDERLY_API_SERVER_IDENTITY" = "other"),
@@ -119,7 +119,7 @@ test_that("support declaring api server", {
   expect_true(cfg$remote$other$identity)
   expect_equal(
     cfg$server_options(),
-    list(primary = FALSE, master_only = FALSE))
+    list(primary = FALSE, master_only = FALSE, name = "other"))
 
   cfg <- withr::with_envvar(
     c("ORDERLY_API_SERVER_IDENTITY" = NA),
@@ -192,17 +192,17 @@ test_that("no global folder", {
 
 
 test_that("vault configuration validation when absent", {
-  expect_null(config_validate_vault(NULL, NULL, "orderly.yml"))
+  expect_null(config_validate_vault(NULL, "orderly.yml"))
 })
 
 
 test_that("vault configuration validation for typical use", {
   vault <- list(addr = "https://vault.example.com")
-  expect_identical(config_validate_vault(vault, NULL, "orderly.yml"), vault)
+  expect_identical(config_validate_vault(vault, "orderly.yml"), vault)
 
   vault <- list(addr = "https://vault.example.com",
                 auth = list(method = "github"))
-  expect_identical(config_validate_vault(vault, NULL, "orderly.yml"), vault)
+  expect_identical(config_validate_vault(vault, "orderly.yml"), vault)
 })
 
 

--- a/tests/testthat/test-db.R
+++ b/tests/testthat/test-db.R
@@ -113,7 +113,7 @@ test_that("dialects", {
   expect_false(isTRUE(all.equal(s, p)))
 
   path <- prepare_orderly_example("minimal")
-  config <- orderly_config(path)
+  config <- orderly_config$new(path)
   con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
   on.exit(DBI::dbDisconnect(con))
   expect_error(report_db_init_create(con, config, "postgres"),

--- a/tests/testthat/test-deduplicate.R
+++ b/tests/testthat/test-deduplicate.R
@@ -86,7 +86,7 @@ test_that("print on run", {
 test_that("deduplicate empty", {
   skip_on_cran()
   path <- orderly_example("demo")
-  x <- orderly_deduplicate_info(orderly_config(path))
+  x <- orderly_deduplicate_info(orderly_config$new(path))
   expect_is(x, "orderly_deduplicate_info")
   expect_equal(nrow(x$files), 0)
   expect_equal(orderly_deduplicate(path, quiet = TRUE), x)
@@ -100,7 +100,7 @@ test_that("don't deduplicate across filesystem boundaries", {
   id2 <- orderly_run("minimal", root = path, echo = FALSE)
   orderly_commit(id1, root = path)
   orderly_commit(id2, root = path)
-  info <- orderly_deduplicate_info(orderly_config(path))
+  info <- orderly_deduplicate_info(orderly_config$new(path))
   info$files$device_id[[2]] <- info$files$device_id[[1]] + 1
   expect_error(
     orderly_deduplicate_prepare(info),
@@ -115,7 +115,7 @@ test_that("don't deduplicate hardlinked files", {
   id2 <- orderly_run("minimal", root = path, echo = FALSE)
   orderly_commit(id1, root = path)
   orderly_commit(id2, root = path)
-  info <- orderly_deduplicate_info(orderly_config(path))
+  info <- orderly_deduplicate_info(orderly_config$new(path))
   info$files$hard_links[[5]] <- 2
   expect_error(
     orderly_deduplicate_prepare(info),
@@ -134,7 +134,7 @@ test_that("don't deduplicate after file modification", {
   ## truncate the file
   file.create(file.path(path, "archive", "minimal", id1, "script.R"))
 
-  info <- orderly_deduplicate_info(orderly_config(path))
+  info <- orderly_deduplicate_info(orderly_config$new(path))
   expect_equal(sum(!info$files$unchanged), 1)
 
   expect_error(

--- a/tests/testthat/test-develop.R
+++ b/tests/testthat/test-develop.R
@@ -22,7 +22,7 @@ test_that("orderly_develop_location", {
   skip_on_cran_windows()
   path <- prepare_orderly_example("demo")
 
-  cfg <- orderly_config(path)
+  cfg <- orderly_config$new(path)
   name <- "minimal"
   cmp1 <- list(config = cfg,
                name = name,

--- a/tests/testthat/test-envir.R
+++ b/tests/testthat/test-envir.R
@@ -10,7 +10,7 @@ test_that("set env", {
            "      user: $MY_USER")
   writeLines(cfg, file.path(path, "orderly_config.yml"))
 
-  config <- orderly_config(path)
+  config <- orderly_config$new(path)
 
   expect_error(orderly_db_args(config$database$source, config, "loc"),
                "Environment variable 'MY_USER' is not set")

--- a/tests/testthat/test-helpers.R
+++ b/tests/testthat/test-helpers.R
@@ -7,7 +7,7 @@ test_that("can add resource to an orderly without resources", {
   res <- orderly_use_resource("new.txt", root = path, name = "example",
                               show = FALSE, prompt = FALSE)
 
-  config <- orderly_config(path)
+  config <- orderly_config$new(path)
   info <- recipe_read(file.path(path, "src", "example"), config)
   expect_equal(info$resources, "new.txt")
 })
@@ -98,7 +98,7 @@ test_that("Add source (minimal test)", {
   file.create(file.path(path, "src", "example", "new.R"))
   res <- orderly_use_source("new.R", root = path, name = "example",
                             show = FALSE, prompt = FALSE)
-  config <- orderly_config(path)
+  config <- orderly_config$new(path)
   info <- recipe_read(file.path(path, "src", "example"), config)
   expect_equal(info$sources, "new.R")
   expect_error(orderly_use_source("new.R", root = path, name = "example",
@@ -111,7 +111,7 @@ test_that("Add packages (minimal test)", {
   path <- prepare_orderly_example("minimal")
   res <- orderly_use_package("knitr", root = path, name = "example",
                              show = FALSE, prompt = FALSE)
-  config <- orderly_config(path)
+  config <- orderly_config$new(path)
   info <- recipe_read(file.path(path, "src", "example"), config)
   expect_equal(info$packages, "knitr")
   expect_error(orderly_use_package("knitr", root = path, name = "example",

--- a/tests/testthat/test-main.R
+++ b/tests/testthat/test-main.R
@@ -325,7 +325,7 @@ test_that("migrate", {
   on.exit(options(oo))
 
   path <- unpack_reference("0.3.2")
-  expect_equal(orderly_config(path)$archive_version, "0.0.0")
+  expect_equal(orderly_config$new(path)$archive_version, "0.0.0")
 
   args <- c("--root", path, "migrate")
   res <- cli_args_process(args)
@@ -336,7 +336,7 @@ test_that("migrate", {
   expect_identical(res$target, main_do_migrate)
 
   res$target(res)
-  expect_equal(orderly_config(path)$archive_version,
+  expect_equal(orderly_config$new(path)$archive_version,
                as.character(cache$current_archive_version))
 })
 

--- a/tests/testthat/test-migrate.R
+++ b/tests/testthat/test-migrate.R
@@ -7,7 +7,7 @@ test_that("0.3.2 -> 0.3.3", {
   path <- unpack_reference("0.3.2")
   cmp <- unpack_reference("0.4.8")
   orderly_migrate(path, to = "0.3.3")
-  patch_orderly_config(path)
+  patch_orderly_config$new(path)
 
   d <- orderly_list_archive(path)
   p <- file.path(d$name, d$id)
@@ -57,7 +57,7 @@ test_that("failed migrations are rolled back", {
     list(changed = TRUE, data = data)
   }
 
-  config <- orderly_config(path)
+  config <- orderly_config$new(path)
   expect_error(migrate_apply(path, "0.3.3", fun, config, FALSE, FALSE),
                "some sort of migration failure")
   cmp <- hash_files(list.files(path, recursive = TRUE, full.names = TRUE))
@@ -82,8 +82,8 @@ test_that("failed migrations can be skipped", {
     list(changed = TRUE, data = data)
   }
 
-  patch_orderly_config(path)
-  config <- orderly_config(path)
+  patch_orderly_config$new(path)
+  config <- orderly_config$new(path)
   migrate_apply(path, "0.3.3", fun, config, FALSE, TRUE)
 
   id <- "20170805-220525-1dc8fb81"
@@ -114,8 +114,8 @@ test_that("failed migrations warned in dry run", {
     list(changed = TRUE, data = data)
   }
 
-  patch_orderly_config(path)
-  config <- orderly_config(path)
+  patch_orderly_config$new(path)
+  config <- orderly_config$new(path)
   expect_message(
     migrate_apply(path, "0.3.3", fun, config, TRUE, TRUE),
     "this report would be moved to")
@@ -140,7 +140,7 @@ test_that("migrate_plan default is used", {
   on.exit(options(oo))
 
   path <- unpack_reference("0.3.2")
-  config <- orderly_config(path)
+  config <- orderly_config$new(path)
   expect_equal(migrate_plan(config$archive_version), available_migrations())
   expect_equal(migrate_plan(config$archive_version, to = "0.0.1"),
                set_names(character(), character()))
@@ -189,7 +189,7 @@ test_that("can't commit old version", {
   on.exit(options(oo))
 
   path <- unpack_reference("0.3.2")
-  patch_orderly_config(path)
+  patch_orderly_config$new(path)
   contents <- orderly_list_archive(path)
 
   id <- contents$id[contents$name == "depend"][[1L]]
@@ -211,7 +211,7 @@ test_that("don't migrate new orderly", {
   path <- prepare_orderly_example("minimal")
   p <- path_orderly_archive_version(path)
   unlink(p)
-  check_orderly_archive_version(orderly_config(path))
+  check_orderly_archive_version(orderly_config$new(path))
   expect_true(file.exists(p))
   expect_equal(read_orderly_archive_version(path),
                as.character(cache$current_archive_version))
@@ -251,7 +251,7 @@ test_that("automatic migrations", {
   on.exit(options(oo))
 
   path <- unpack_reference("0.5.1")
-  patch_orderly_config(path)
+  patch_orderly_config$new(path)
   con <- orderly_db("destination", path, validate = FALSE)
   dat <- DBI::dbReadTable(con, "report_version")
   DBI::dbDisconnect(con)
@@ -271,7 +271,7 @@ test_that("migrate 0.5.4 -> 0.5.5", {
   orderly_migrate(path, to = "0.5.5")
   orderly_rebuild(path)
 
-  patch_orderly_config(path)
+  patch_orderly_config$new(path)
   con <- orderly_db("destination", path, validate = FALSE)
   dat <- DBI::dbReadTable(con, "report_version")
   DBI::dbDisconnect(con)
@@ -286,7 +286,7 @@ test_that("rebuild db with incorrect schema information", {
   on.exit(options(oo))
 
   path <- unpack_reference("0.5.17")
-  patch_orderly_config(path)
+  patch_orderly_config$new(path)
   con <- orderly_db("destination", path, validate = FALSE)
   on.exit(DBI::dbDisconnect(con), add = TRUE)
 

--- a/tests/testthat/test-migrate.R
+++ b/tests/testthat/test-migrate.R
@@ -7,7 +7,7 @@ test_that("0.3.2 -> 0.3.3", {
   path <- unpack_reference("0.3.2")
   cmp <- unpack_reference("0.4.8")
   orderly_migrate(path, to = "0.3.3")
-  patch_orderly_config$new(path)
+  patch_orderly_config(path)
 
   d <- orderly_list_archive(path)
   p <- file.path(d$name, d$id)
@@ -82,7 +82,7 @@ test_that("failed migrations can be skipped", {
     list(changed = TRUE, data = data)
   }
 
-  patch_orderly_config$new(path)
+  patch_orderly_config(path)
   config <- orderly_config$new(path)
   migrate_apply(path, "0.3.3", fun, config, FALSE, TRUE)
 
@@ -114,7 +114,7 @@ test_that("failed migrations warned in dry run", {
     list(changed = TRUE, data = data)
   }
 
-  patch_orderly_config$new(path)
+  patch_orderly_config(path)
   config <- orderly_config$new(path)
   expect_message(
     migrate_apply(path, "0.3.3", fun, config, TRUE, TRUE),
@@ -189,7 +189,7 @@ test_that("can't commit old version", {
   on.exit(options(oo))
 
   path <- unpack_reference("0.3.2")
-  patch_orderly_config$new(path)
+  patch_orderly_config(path)
   contents <- orderly_list_archive(path)
 
   id <- contents$id[contents$name == "depend"][[1L]]
@@ -251,7 +251,7 @@ test_that("automatic migrations", {
   on.exit(options(oo))
 
   path <- unpack_reference("0.5.1")
-  patch_orderly_config$new(path)
+  patch_orderly_config(path)
   con <- orderly_db("destination", path, validate = FALSE)
   dat <- DBI::dbReadTable(con, "report_version")
   DBI::dbDisconnect(con)
@@ -271,7 +271,7 @@ test_that("migrate 0.5.4 -> 0.5.5", {
   orderly_migrate(path, to = "0.5.5")
   orderly_rebuild(path)
 
-  patch_orderly_config$new(path)
+  patch_orderly_config(path)
   con <- orderly_db("destination", path, validate = FALSE)
   dat <- DBI::dbReadTable(con, "report_version")
   DBI::dbDisconnect(con)
@@ -286,7 +286,7 @@ test_that("rebuild db with incorrect schema information", {
   on.exit(options(oo))
 
   path <- unpack_reference("0.5.17")
-  patch_orderly_config$new(path)
+  patch_orderly_config(path)
   con <- orderly_db("destination", path, validate = FALSE)
   on.exit(DBI::dbDisconnect(con), add = TRUE)
 

--- a/tests/testthat/test-recipe-read.R
+++ b/tests/testthat/test-recipe-read.R
@@ -14,7 +14,7 @@ test_that("minimal", {
   path <- prepare_orderly_example("minimal")
   on.exit(unlink(path))
 
-  config <- orderly_config(path)
+  config <- orderly_config$new(path)
   path_example <- file.path(path, "src", "example")
   info <- recipe_read(path_example, config)
 
@@ -91,7 +91,7 @@ test_that("minimal", {
 test_that("ill formed artefacts", {
   path <- prepare_orderly_example("minimal")
   on.exit(unlink(path))
-  config <- orderly_config(path)
+  config <- orderly_config$new(path)
   path_example <- file.path(path, "src", "example")
   yml <- file.path(path_example, "orderly.yml")
   dat <- yaml_read(yml)
@@ -108,7 +108,7 @@ test_that("ill formed artefacts", {
 test_that("unknown artefact type", {
   path <- prepare_orderly_example("minimal")
   on.exit(unlink(path))
-  config <- orderly_config(path)
+  config <- orderly_config$new(path)
   path_example <- file.path(path, "src", "example")
   yml <- file.path(path_example, "orderly.yml")
   dat <- yaml_read(yml)
@@ -124,7 +124,7 @@ test_that("unknown artefact type", {
 test_that("duplicate artefact filenames; within artefact", {
   path <- prepare_orderly_example("minimal")
   on.exit(unlink(path))
-  config <- orderly_config(path)
+  config <- orderly_config$new(path)
   path_example <- file.path(path, "src", "example")
   yml <- file.path(path_example, "orderly.yml")
   dat <- yaml_read(yml)
@@ -138,7 +138,7 @@ test_that("duplicate artefact filenames; within artefact", {
 test_that("duplicate artefact filenames; between artefacts", {
   path <- prepare_orderly_example("minimal")
   on.exit(unlink(path))
-  config <- orderly_config(path)
+  config <- orderly_config$new(path)
   path_example <- file.path(path, "src", "example")
   yml <- file.path(path_example, "orderly.yml")
   dat <- yaml_read(yml)
@@ -230,7 +230,7 @@ test_that("use_draft = newer ignores fails drafts", {
   dat$depends$example$draft <- NULL
   yaml_write(dat, filename)
 
-  config <- orderly_config(path)
+  config <- orderly_config$new(path)
   info <- recipe_read(file.path(path, "src", "depend"), config,
                       use_draft = "newer")
   expect_equal(basename(info$depends$path), id2)
@@ -298,7 +298,7 @@ test_that("can't use database in configurations that lack them", {
   dat <- list(data = list(dat = list(query = "SELECT name, number FROM thing")))
   writeLines(c(txt, yaml::as.yaml(dat)), p)
   expect_error(
-    recipe_read(dirname(p), orderly_config(path)),
+    recipe_read(dirname(p), orderly_config$new(path)),
     "No databases are configured - can't use a 'data' section")
 })
 
@@ -310,7 +310,7 @@ test_that("can't use connection in configurations that lack databases", {
   dat <- list(connection = "con")
   writeLines(c(txt, yaml::as.yaml(dat)), p)
   expect_error(
-    recipe_read(dirname(p), orderly_config(path)),
+    recipe_read(dirname(p), orderly_config$new(path)),
     "No databases are configured - can't use a 'connection' section")
 })
 
@@ -322,7 +322,7 @@ test_that("database names are required with more than one db", {
   dat$data$dat1$database <- NULL
   writeLines(yaml::as.yaml(dat), p)
   expect_error(
-    recipe_read(dirname(p), orderly_config(path)),
+    recipe_read(dirname(p), orderly_config$new(path)),
     "More than one database configured; a 'database' field is required for")
 })
 
@@ -334,7 +334,7 @@ test_that("connection names are required with more than one db", {
   dat$connection <- "con"
   writeLines(yaml::as.yaml(dat), p)
   expect_error(
-    suppressWarnings(recipe_read(dirname(p), orderly_config(path))),
+    suppressWarnings(recipe_read(dirname(p), orderly_config$new(path))),
     "More than one database configured; update 'connection' from 'con'")
 })
 
@@ -352,7 +352,7 @@ test_that("Can't use database name on old style configuration", {
 
   ## If database present, the new style is validated correctly:
   expect_warning(
-    config <- orderly_config(path),
+    config <- orderly_config$new(path),
     "Use of 'source' is deprecated")
 
   res <- recipe_read(dirname(p), config)
@@ -372,7 +372,7 @@ test_that("validate database names", {
   names(dat$database) <- c("db1", "db2")
   writeLines(yaml::as.yaml(dat), p)
 
-  cfg <- orderly_config(path)
+  cfg <- orderly_config$new(path)
 
   expect_error(recipe_read(file.path(path, "src", "example"), cfg),
                "orderly.yml:data:dat1:database must be one of 'db1', 'db2'",
@@ -389,7 +389,7 @@ test_that("warn old style db", {
     prepare_orderly_example("olddb", testing = TRUE))
   cfg <- withr::with_options(
     list(orderly.nowarnings = TRUE),
-    orderly_config(path))
+    orderly_config$new(path))
 
   expect_silent(
     recipe_read(file.path(path, "src", "example"), cfg))
@@ -399,7 +399,7 @@ test_that("warn old style db", {
   file.rename(file.path(path, "orderly_config.yml.new"),
               file.path(path, "orderly_config.yml"))
   expect_warning(
-    cfg <- orderly_config(path),
+    cfg <- orderly_config$new(path),
     "Please move your database arguments")
 
   expect_warning(
@@ -419,7 +419,7 @@ test_that("detect modified artefacts", {
   p <- orderly_commit(id, root = path)
   writeLines(character(0), file.path(p, "summary.csv"))
 
-  cfg <- orderly_config(path)
+  cfg <- orderly_config$new(path)
   expect_error(
     recipe_read(file.path(path, "src", "use_dependency"), config = cfg),
     paste("Validation of dependency 'summary.csv' (other/latest) failed:",
@@ -445,7 +445,7 @@ test_that("modified artefacts when more than one used", {
                                            mygraph.pdf = "mygraph.pdf")))
   yaml_write(yml, path_yml)
 
-  cfg <- orderly_config(path)
+  cfg <- orderly_config$new(path)
   expect_error(
     recipe_read(file.path(path, "src", "use_dependency"), config = cfg),
     paste("Validation of dependency 'mygraph.pdf' (multifile-artefact/latest)",
@@ -461,7 +461,7 @@ test_that("sources and resources are exclusive", {
   d$resources <- d$sources
   yaml_write(d, p)
 
-  config <- orderly_config(path)
+  config <- orderly_config$new(path)
   expect_error(
     recipe_read(file.path(path, "src", "other"), config),
     "Do not list source files \\(sources\\) as resources:\\s+- functions\\.R")
@@ -512,7 +512,7 @@ test_that("old style global resources deprecated", {
   writeLines(config_lines, path_yaml)
 
   expect_warning(
-    res <- recipe_read(path_example, orderly_config(path)),
+    res <- recipe_read(path_example, orderly_config$new(path)),
     "Use of strings for global_resources: is deprecated")
   expect_equal(
     res$global_resources,
@@ -523,7 +523,7 @@ test_that("old style global resources deprecated", {
 test_that("read parameters", {
   path <- prepare_orderly_example("parameters", testing = TRUE)
   path_example <- file.path(path, "src", "example")
-  info <- recipe_read(path_example, orderly_config(path))
+  info <- recipe_read(path_example, orderly_config$new(path))
   expect_equal(info$parameters,
                list(a = NULL, b = NULL, c = list(default = 1)))
 })
@@ -537,7 +537,7 @@ test_that("read old-style parameters", {
   dat$parameters <- list("a", "b", "c")
   yaml_write(dat, path_orderly)
   expect_warning(
-    info <- recipe_read(path_example, orderly_config(path)),
+    info <- recipe_read(path_example, orderly_config$new(path)),
     "Use of strings for parameters: is deprecated")
   expect_equal(info$parameters,
                list(a = NULL, b = NULL, c = NULL))
@@ -548,7 +548,7 @@ test_that("validate parameters", {
   path <- prepare_orderly_example("parameters", testing = TRUE)
   path_example <- file.path(path, "src", "example")
   path_orderly <- file.path(path_example, "orderly.yml")
-  config <- orderly_config(path)
+  config <- orderly_config$new(path)
 
   dat <- yaml_read(path_orderly)
   dat$parameters <- list(a = list(something = 1))
@@ -562,7 +562,7 @@ test_that("validate parameters", {
 
 test_that("Can resolve dependencies remotely", {
   dat <- prepare_orderly_remote_example()
-  config <- orderly_config(dat$path_local)
+  config <- orderly_config$new(dat$path_local)
   info <- recipe_read(file.path(path_src(config$root), "depend"), config,
                       FALSE)
   expect_equal(nrow(orderly_list_archive(dat$path_local)), 0)
@@ -584,7 +584,7 @@ test_that("Can resolve dependencies remotely", {
 
 test_that("resolve_dependencies_remote", {
   dat <- prepare_orderly_remote_example()
-  config <- orderly_config(dat$path_local)
+  config <- orderly_config$new(dat$path_local)
   remote <- get_remote("default", config)
 
   p <- file.path(normalizePath(dat$path_local), "archive", "example")
@@ -611,7 +611,7 @@ test_that("resolve_dependencies_remote", {
 
 test_that("Can't use queries when resolving dependencies remotely", {
   dat <- prepare_orderly_remote_example()
-  config <- orderly_config(dat$path_local)
+  config <- orderly_config$new(dat$path_local)
   remote <- get_remote("default", config)
   expect_error(
     resolve_dependencies_remote("latest()", "example", config, remote),
@@ -627,7 +627,7 @@ test_that("friendly error message if artefacts are incorrectly given", {
   dat$artefacts <- "mygraph.png"
   yaml_write(dat, p)
 
-  config <- orderly_config(path)
+  config <- orderly_config$new(path)
   err <- expect_error(
     recipe_read(dirname(p), config),
     "Your artefacts are misformatted.  You must provide")
@@ -649,7 +649,7 @@ test_that("friendly error message if artefacts are incorrectly given", {
 test_that("Read partial orderly.yml", {
   path <- prepare_orderly_example("minimal")
   p <- orderly_new("partial", root = path, quiet = TRUE)
-  config <- orderly_config(path)
+  config <- orderly_config$new(path)
   expect_message(
     recipe_read(p, config, develop = TRUE),
     "At least one artefact required")
@@ -663,7 +663,7 @@ test_that("Read completely empty orderly.yml", {
   path <- prepare_orderly_example("minimal")
   p <- orderly_new("partial", root = path, quiet = TRUE)
   file.create(file.path(p, "orderly.yml")) # truncates file
-  config <- orderly_config(path)
+  config <- orderly_config$new(path)
   expect_message(
     recipe_read(p, config, develop = TRUE),
     "Fields missing from .*: script, artefacts")
@@ -674,7 +674,7 @@ test_that("Validate report tag", {
   root <- prepare_orderly_example("minimal")
   append_lines(c("tags:", "  - tag1", "  - tag2"),
                file.path(root, "orderly_config.yml"))
-  config <- orderly_config(root)
+  config <- orderly_config$new(root)
   path <- file.path(root, "src", "example")
   path_config <- file.path(path, "orderly.yml")
   txt <- readLines(path_config)
@@ -699,7 +699,7 @@ test_that("Validate report tag", {
 
 test_that("Better error message where tags not enabled", {
   root <- prepare_orderly_example("minimal")
-  config <- orderly_config(root)
+  config <- orderly_config$new(root)
   path <- file.path(root, "src", "example")
   path_config <- file.path(path, "orderly.yml")
   txt <- readLines(path_config)
@@ -778,7 +778,7 @@ test_that("Query interface", {
   root <- dat$root
   ids <- dat$ids
 
-  config <- orderly_config(root)
+  config <- orderly_config$new(root)
 
   p <- file.path(root, "src", "use_dependency", "orderly.yml")
   txt <- readLines(p)
@@ -816,7 +816,7 @@ test_that("pass parameters through query interface", {
   root <- dat$root
   ids <- dat$ids
 
-  config <- orderly_config(root)
+  config <- orderly_config$new(root)
 
   p <- file.path(root, "src", "use_dependency", "orderly.yml")
   txt <- readLines(p)

--- a/tests/testthat/test-recipe-read.R
+++ b/tests/testthat/test-recipe-read.R
@@ -1,8 +1,8 @@
 context("recipe_read")
 
 test_that("nonexistant file", {
-  ## TODO: I think that we should be normalising the path here?
-  config <- orderly_config_read_yaml("example_config.yml", ".")
+  path <- prepare_orderly_example("minimal")
+  config <- orderly_config$new(path)
   expect_error(recipe_read(tempfile(), config),
                "Report working directory does not exist")
   expect_error(recipe_read(tempdir(), config),

--- a/tests/testthat/test-recipe-read.R
+++ b/tests/testthat/test-recipe-read.R
@@ -391,10 +391,12 @@ test_that("warn old style db", {
     list(orderly.nowarnings = TRUE),
     orderly_config$new(path))
 
-  expect_silent(
-    recipe_read(file.path(path, "src", "example"), cfg))
-  expect_silent(
-    recipe_read(file.path(path, "src", "connection"), cfg))
+  expect_warning(
+    recipe_read(file.path(path, "src", "example"), cfg),
+    "Use of strings for queries is deprecated")
+  expect_warning(
+    recipe_read(file.path(path, "src", "connection"), cfg),
+    "Use of strings for connection: is deprecated")
 
   file.rename(file.path(path, "orderly_config.yml.new"),
               file.path(path, "orderly_config.yml"))

--- a/tests/testthat/test-remote-path.R
+++ b/tests/testthat/test-remote-path.R
@@ -19,7 +19,7 @@ test_that("get remote", {
   path1 <- prepare_orderly_example("minimal")
   path2 <- prepare_orderly_example("minimal")
 
-  obj <- get_remote(path1, orderly_config(path2))
+  obj <- get_remote(path1, orderly_config$new(path2))
   expect_is(obj, "orderly_remote_path")
   expect_equal(normalizePath(obj$name), normalizePath(path1))
 })

--- a/tests/testthat/test-remote.R
+++ b/tests/testthat/test-remote.R
@@ -181,7 +181,7 @@ test_that("silently ignore missing slack url, but resolve args", {
       "    slack_url: $ORDERLY_UNSET_SLACK_URL"),
     file.path(path, "orderly_config.yml"))
 
-  config <- orderly_config(path)
+  config <- orderly_config$new(path)
 
   clear_remote_cache()
   remote <- withr::with_envvar(

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -5,7 +5,7 @@ test_that("minimal", {
   path <- prepare_orderly_example("minimal")
   on.exit(unlink(path, recursive = TRUE))
 
-  config <- orderly_config(path)
+  config <- orderly_config$new(path)
   info <- recipe_read(file.path(path, "src/example"), config)
   data <- recipe_data(config, info, NULL, new.env(parent = .GlobalEnv),
                       instance = NULL)
@@ -55,7 +55,7 @@ test_that("orderly_data", {
 test_that("fail to create artefact", {
   path <- prepare_orderly_example("minimal")
   on.exit(unlink(path, recursive = TRUE))
-  config <- orderly_config(path)
+  config <- orderly_config$new(path)
   writeLines("1 + 1", file.path(path, "src/example/script.R"))
   info <- recipe_read(file.path(path, "src/example"), config)
   envir <- orderly_environment(NULL)
@@ -67,7 +67,7 @@ test_that("fail to create artefact", {
 test_that("leave device open", {
   path <- prepare_orderly_example("minimal")
   on.exit(unlink(path, recursive = TRUE))
-  config <- orderly_config(path)
+  config <- orderly_config$new(path)
   txt <- readLines(file.path(path, "src/example/script.R"))
   writeLines(txt[!grepl("dev.off()", txt, fixed = TRUE)],
              file.path(path, "src/example/script.R"))
@@ -89,13 +89,13 @@ test_that("close too many devices", {
     }
   })
 
-  config <- orderly_config(path)
+  config <- orderly_config$new(path)
   txt <- readLines(file.path(path, "src/example/script.R"))
   writeLines(c(txt, "dev.off()"), file.path(path, "src/example/script.R"))
   info <- recipe_read(file.path(path, "src/example"), config)
   envir <- orderly_environment(NULL)
   info <- recipe_prepare(config, "example")
-  config <- orderly_config(path)
+  config <- orderly_config$new(path)
   expect_error(recipe_run(info, NULL, envir, config = config, echo = FALSE),
                "Report closed 1 more devices than it opened")
 })
@@ -103,7 +103,7 @@ test_that("close too many devices", {
 test_that("sink imbalance", {
   skip_on_cran_windows()
   path <- prepare_orderly_example("minimal")
-  config <- orderly_config(path)
+  config <- orderly_config$new(path)
   path_script <- file.path(path, "src/example/script.R")
   txt <- readLines(path_script)
   writeLines(c("sink('somefile', split = TRUE)", txt), path_script)
@@ -138,7 +138,7 @@ test_that("leave connection open", {
   ## garbage collected.
   e <- new.env(parent = .GlobalEnv)
   path <- prepare_orderly_example("minimal")
-  config <- orderly_config(path)
+  config <- orderly_config$new(path)
   path_script <- file.path(path, "src/example/script.R")
 
   writeLines(
@@ -173,7 +173,7 @@ test_that("connection", {
   dat <- list(connection = list(con = "source"))
   writeLines(c(txt, yaml::as.yaml(dat)), yml)
 
-  config <- orderly_config(path)
+  config <- orderly_config$new(path)
   info <- recipe_read(path_example, config)
   expect_identical(info$connection, list("con" = "source"))
 
@@ -483,7 +483,7 @@ test_that("required field OK", {
   yml_path <- file.path(path_example, "orderly.yml")
   minimal_yml <- readLines(yml_path)
   # get required fields out of config
-  config <- orderly_config(path)
+  config <- orderly_config$new(path)
   req_fields <- config$fields$name[config$fields$required]
   # set required fields to correct type
   minimal_yml <- c(minimal_yml, sprintf("%s: %s", req_fields[1], "character"))
@@ -507,7 +507,7 @@ test_that("missing required field", {
   yml_path <- file.path(path_example, "orderly.yml")
   minimal_yml <- readLines(yml_path)
   # get required fields out of config
-  config <- orderly_config(path)
+  config <- orderly_config$new(path)
   req_fields <- config$fields$name[config$fields$required]
   # iterate over the required fields...
   for (field in req_fields) {
@@ -542,7 +542,7 @@ test_that("required field wrong type", {
   yml_path <- file.path(path_example, "orderly.yml")
   minimal_yml <- readLines(yml_path)
   # get required fields out of config
-  config <- orderly_config(path)
+  config <- orderly_config$new(path)
   req_fields <- config$fields$name[config$fields$required]
   # add the second required to the yml with the wrong type
   minimal_yml <- c(minimal_yml, sprintf("%s: %s", req_fields[1], "character"))

--- a/tests/testthat/test-slack.R
+++ b/tests/testthat/test-slack.R
@@ -196,7 +196,7 @@ test_that("main interface", {
 
   config <- withr::with_envvar(
     c("ORDERLY_API_SERVER_IDENTITY" = "production"),
-    orderly_config(path))
+    orderly_config$new(path))
 
   r <- slack_post_success(dat, config)
   expect_equal(r$status_code, 200L)
@@ -207,7 +207,7 @@ test_that("main interface", {
 
   config <- withr::with_envvar(
     c("ORDERLY_API_SERVER_IDENTITY" = "testing"),
-    orderly_config(path))
+    orderly_config$new(path))
 
   r <- slack_post_success(dat, config)
   expect_equal(r$status_code, 200L)

--- a/tests/testthat/test-slack.R
+++ b/tests/testthat/test-slack.R
@@ -152,13 +152,16 @@ test_that("main interface", {
               git = NULL)
 
   config <- list(remote_identity = "myserver",
+                 server_options = function() {
+                   list(slack_url = "https://httpbin.org/post",
+                        primary = TRUE,
+                        master_only = FALSE)
+                 },
                  remote = list(
                    myserver = list(
                      driver = c("orderly", "orderly_remote_path"),
                      args = list(path = path),
-                     slack_url = "https://httpbin.org/post",
                      name = "myserver",
-                     primary = FALSE,
                      url = "https://example.com")))
   r <- slack_post_success(dat, config)
 

--- a/tests/testthat/test-slack.R
+++ b/tests/testthat/test-slack.R
@@ -151,18 +151,22 @@ test_that("main interface", {
   dat <- list(meta = list(elapsed = 10, id = id, name = name),
               git = NULL)
 
-  config <- list(remote_identity = "myserver",
-                 server_options = function() {
-                   list(slack_url = "https://httpbin.org/post",
-                        primary = TRUE,
-                        master_only = FALSE)
-                 },
-                 remote = list(
-                   myserver = list(
-                     driver = c("orderly", "orderly_remote_path"),
-                     args = list(path = path),
-                     name = "myserver",
-                     url = "https://example.com")))
+  path <- tempfile()
+  dir.create(path)
+  writeLines(
+    c("remote:",
+      "  myserver:",
+      "    driver: orderly::orderly_remote_path",
+      "    args:",
+      paste("      path:", path),
+      "    slack_url: https://httpbin.org/post",
+      "    primary: true"),
+    file.path(path, "orderly_config.yml"))
+
+  config <- withr::with_envvar(
+    c(ORDERLY_API_SERVER_IDENTITY = "myserver"),
+    orderly_config$new(path))
+
   r <- slack_post_success(dat, config)
 
   expect_equal(r$status_code, 200L)

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -176,7 +176,7 @@ test_that("vault configuration honours environment variables", {
 
   x <- list(name = "alice",
             password = "VAULT:/secret/users/alice:password")
-  config <- orderly_config(path)
+  config <- orderly_config$new(path)
   ## Environment variable not resolved yet:
   expect_equal(config$vault$addr, "$ORDERLY_VAULT_ADDR")
   ## Sensible error if not set:

--- a/tests/testthat/test-z-runner.R
+++ b/tests/testthat/test-z-runner.R
@@ -428,7 +428,7 @@ test_that("prevent git changes", {
 test_that("allow ref logic", {
   testthat::skip_on_cran()
   path <- unzip_git_demo()
-  config <- list(server_options = list(master_only = FALSE),
+  config <- list(server_options = function() list(master_only = FALSE),
                  root = path)
 
   expect_false(runner_allow_ref(FALSE, TRUE, config))
@@ -437,13 +437,13 @@ test_that("allow ref logic", {
   expect_true(runner_allow_ref(TRUE, TRUE, config))
   expect_true(runner_allow_ref(TRUE, NULL, config))
 
-  config <- list(server_options = list(master_only = TRUE),
+  config <- list(server_options = function() list(master_only = TRUE),
                  root = path)
   expect_false(runner_allow_ref(TRUE, FALSE, config))
   expect_true(runner_allow_ref(TRUE, TRUE, config))
   expect_false(runner_allow_ref(TRUE, NULL, config))
 
-  config <- list(server_options = list(master_only = FALSE),
+  config <- list(server_options = function() list(master_only = FALSE),
                  root = tempfile())
   expect_false(runner_allow_ref(TRUE, FALSE, config))
   expect_false(runner_allow_ref(TRUE, TRUE, config))


### PR DESCRIPTION
This is a minimal refactor of the orderly configuration that aims to add no functionality, but to make things more maintainable. This is very much going to be a work in progress, and there are quite a few things that would be better as methods on the object (particularly with respect to the database)