### PR TITLE
VIMC-3595: Fix error downloading reports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.1.14
+Version: 1.1.15
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# orderly 1.1.15
+
+* Fix bug where report downloading did not work for some pathalogical windows paths (VIMC-3595)
+
 # orderly 1.1.14
 
 * Fix bug in instance selection, probably introduced in 1.0.6 (VIMC-3589)

--- a/R/util.R
+++ b/R/util.R
@@ -505,7 +505,7 @@ file_canonical_case <- function(filename) {
 }
 
 copy_directory <- function(src, as, rollback_on_error = FALSE) {
-  assert_is_directory(src)
+  assert_is_directory(src, FALSE)
   files <- dir(src, all.files = TRUE, no.. = TRUE, full.names = TRUE)
   if (rollback_on_error) {
     if (file.exists(as)) {


### PR DESCRIPTION
This PR fixes (empirically) a bug where the directory case check caused downloading and copying of an archive from a remote to fail, on windows paths where a name with spaces was converted into a "short name".

VIMC-3594 contains the real problem, which will take more rooting out. This is probably unreplicable without a windows system and a username with spaces in it, so some carful mocking will be required when fixing VIMC-3594