### PR TITLE
VIMC-3610: Write entire Rprofile.site

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get -y install --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
 
 
-RUN sed  -i'' '/mran.microsoft.com/d' /usr/local/lib/R/etc/Rprofile.site
+COPY docker/Rprofile.site /usr/local/lib/R/etc/Rprofile.site
 
 # R package dependencies, including a few extras that we'll want handy
 RUN install2.r \

--- a/docker/Rprofile.site
+++ b/docker/Rprofile.site
@@ -1,2 +1,2 @@
-options(repos = c(CRAN = "https://cloud.r-project.org",
+options(repos = c(CRAN = "https://cloud.r-project.org"),
         download.file.method = "libcurl")

--- a/docker/Rprofile.site
+++ b/docker/Rprofile.site
@@ -1,0 +1,2 @@
+options(repos = c(CRAN = "https://cloud.r-project.org",
+        download.file.method = "libcurl")


### PR DESCRIPTION
This PR attempts to fix the docker build by writing the entire Rprofile.site to a reasonable value, setting the mirror to CRAN rather than to MRAN.  The reasons for doing this were discussed on other repos (hintr, at least, probably others) and this fix will be required on those repos too.  I see at least:

* naomi
* hintr
* rrq
* pointr

