### PR TITLE
VIMC-3617: Add support for redirecting orderly logs to a file

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.1.17
+Version: 1.1.18
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/R/config.R
+++ b/R/config.R
@@ -81,11 +81,11 @@ orderly_config <- R6::R6Class(
       ret <- self$remote[[which(i)]]
       ret[setdiff(names(ret), c("identity", "driver", "args"))]
     },
-    
+
     add_run_option = function(name, value) {
       self$run_options[[name]] <- value
     },
-    
+
     get_run_option = function(name) {
       self$run_options[[name]]
     }

--- a/R/config.R
+++ b/R/config.R
@@ -37,6 +37,7 @@ orderly_config <- R6::R6Class(
     tags = NULL,
     database = NULL,
     archive_version = NULL,
+    run_options = list(),
 
     initialize = function(root, validate = TRUE) {
       assert_is_directory(root)
@@ -79,6 +80,14 @@ orderly_config <- R6::R6Class(
       ## TODO(VIMC-3590): Let's move these all under options at some point
       ret <- self$remote[[which(i)]]
       ret[setdiff(names(ret), c("identity", "driver", "args"))]
+    },
+    
+    add_run_option = function(name, value) {
+      self$run_options[[name]] <- value
+    },
+    
+    get_run_option = function(name) {
+      self$run_options[[name]]
     }
   ))
 

--- a/R/main.R
+++ b/R/main.R
@@ -136,7 +136,7 @@ main_do_run <- function(x) {
   fetch <- x$options$fetch
   pull <- x$options$pull
   message <- x$options$message
-  
+
   if (print_log) {
     sink(stderr(), type = "output")
     on.exit(sink(NULL, type = "output"))

--- a/R/recipe_commit.R
+++ b/R/recipe_commit.R
@@ -37,10 +37,10 @@ orderly_commit <- function(id, name = NULL, root = NULL, locate = TRUE) {
     }
   }
   workdir <- file.path(path_draft(config$root), name, id)
-  
+
   capture_log <- isTRUE(config$get_run_option("capture_log"))
   logfile <- file.path(path_draft(config$root), name, id, "orderly.log")
-  conditional_capture_log(capture_log, logfile, 
+  conditional_capture_log(capture_log, logfile,
                           recipe_commit(workdir, config$root))
 }
 

--- a/R/recipe_commit.R
+++ b/R/recipe_commit.R
@@ -37,7 +37,11 @@ orderly_commit <- function(id, name = NULL, root = NULL, locate = TRUE) {
     }
   }
   workdir <- file.path(path_draft(config$root), name, id)
-  recipe_commit(workdir, config$root)
+  
+  capture <- inherits(root, "orderly_config") && 
+    isTRUE(root$get_run_option("capture_log"))
+  logfile <- file.path(path_draft(config$root), name, id, "orderly.log")
+  conditional_capture_log(capture, logfile, recipe_commit(workdir, config$root))
 }
 
 recipe_commit <- function(workdir, config) {

--- a/R/recipe_commit.R
+++ b/R/recipe_commit.R
@@ -38,10 +38,10 @@ orderly_commit <- function(id, name = NULL, root = NULL, locate = TRUE) {
   }
   workdir <- file.path(path_draft(config$root), name, id)
   
-  capture <- inherits(root, "orderly_config") && 
-    isTRUE(root$get_run_option("capture_log"))
+  capture_log <- isTRUE(config$get_run_option("capture_log"))
   logfile <- file.path(path_draft(config$root), name, id, "orderly.log")
-  conditional_capture_log(capture, logfile, recipe_commit(workdir, config$root))
+  conditional_capture_log(capture_log, logfile, 
+                          recipe_commit(workdir, config$root))
 }
 
 recipe_commit <- function(workdir, config) {

--- a/R/recipe_run.R
+++ b/R/recipe_run.R
@@ -144,8 +144,7 @@ orderly_run <- function(name = NULL, parameters = NULL, envir = NULL,
 
   envir <- orderly_environment(envir)
 
-  capture <- inherits(root, "orderly_config") &&
-    isTRUE(root$get_run_option("capture_log"))
+  capture <- isTRUE(config$get_run_option("capture_log"))
   logfile <- tempfile()
   info <- conditional_capture_log(capture, logfile, {
     info <- recipe_prepare(config, name, id_file, ref, fetch, message,

--- a/R/recipe_run.R
+++ b/R/recipe_run.R
@@ -143,7 +143,11 @@ orderly_run <- function(name = NULL, parameters = NULL, envir = NULL,
   config <- check_orderly_archive_version(loc$config)
 
   envir <- orderly_environment(envir)
-  run <- function(capture) {
+  
+  capture <- inherits(root, "orderly_config") && 
+    isTRUE(root$get_run_option("capture_log"))
+  logfile <- tempfile()
+  info <- conditional_capture_log(capture, logfile, {
     info <- recipe_prepare(config, name, id_file, ref, fetch, message,
                            use_draft, parameters, remote, tags = tags,
                            batch_id = batch_id)
@@ -161,12 +165,7 @@ orderly_run <- function(name = NULL, parameters = NULL, envir = NULL,
       orderly_envir_read(config$root),
       recipe_run(info, parameters, envir, config, echo = echo,
                  instance = instance))
-  }
-  
-  capture <- inherits(root, "orderly_config") && 
-    isTRUE(root$get_run_option("capture_log"))
-  logfile <- tempfile()
-  info <- conditional_capture_log(capture, logfile, run(capture))
+  })
 
   info$id
 }

--- a/R/recipe_run.R
+++ b/R/recipe_run.R
@@ -143,24 +143,24 @@ orderly_run <- function(name = NULL, parameters = NULL, envir = NULL,
   config <- check_orderly_archive_version(loc$config)
 
   envir <- orderly_environment(envir)
-  
-  capture <- inherits(root, "orderly_config") && 
+
+  capture <- inherits(root, "orderly_config") &&
     isTRUE(root$get_run_option("capture_log"))
   logfile <- tempfile()
   info <- conditional_capture_log(capture, logfile, {
     info <- recipe_prepare(config, name, id_file, ref, fetch, message,
                            use_draft, parameters, remote, tags = tags,
                            batch_id = batch_id)
-    
+
     if (capture) {
       dest <- path_draft(config$root)
-      on.exit(file_copy(logfile, file.path(dest, name, info$id, "orderly.log")), 
+      on.exit(file_copy(logfile, file.path(dest, name, info$id, "orderly.log")),
               add = TRUE)
     }
-    
+
     recipe_current_run_set(info)
     on.exit(recipe_current_run_clear(), add = TRUE)
-    
+
     withr::with_envvar(
       orderly_envir_read(config$root),
       recipe_run(info, parameters, envir, config, echo = echo,

--- a/R/recipe_run.R
+++ b/R/recipe_run.R
@@ -143,17 +143,30 @@ orderly_run <- function(name = NULL, parameters = NULL, envir = NULL,
   config <- check_orderly_archive_version(loc$config)
 
   envir <- orderly_environment(envir)
-  info <- recipe_prepare(config, name, id_file, ref, fetch, message,
-                         use_draft, parameters, remote, tags = tags,
-                         batch_id = batch_id)
-
-  recipe_current_run_set(info)
-  on.exit(recipe_current_run_clear())
-
-  info <- withr::with_envvar(
-    orderly_envir_read(config$root),
-    recipe_run(info, parameters, envir, config, echo = echo,
-               instance = instance))
+  run <- function(capture) {
+    info <- recipe_prepare(config, name, id_file, ref, fetch, message,
+                           use_draft, parameters, remote, tags = tags,
+                           batch_id = batch_id)
+    
+    if (capture) {
+      dest <- path_draft(config$root)
+      on.exit(file_copy(logfile, file.path(dest, name, info$id, "orderly.log")), 
+              add = TRUE)
+    }
+    
+    recipe_current_run_set(info)
+    on.exit(recipe_current_run_clear(), add = TRUE)
+    
+    withr::with_envvar(
+      orderly_envir_read(config$root),
+      recipe_run(info, parameters, envir, config, echo = echo,
+                 instance = instance))
+  }
+  
+  capture <- inherits(root, "orderly_config") && 
+    isTRUE(root$get_run_option("capture_log"))
+  logfile <- tempfile()
+  info <- conditional_capture_log(capture, logfile, run(capture))
 
   info$id
 }

--- a/R/util.R
+++ b/R/util.R
@@ -196,7 +196,12 @@ pasteq <- function(x, sep = ", ") {
 
 capture_log <- function(expr, filename) {
   ## nolint start
-  con <- file(filename, "w")
+  if (file.exists(filename)) {
+    mode = "a"
+  } else {
+    mode = "w"
+  }
+  con <- file(filename, mode)
   sink(con, split = FALSE)
   on.exit({
     sink(NULL)
@@ -205,6 +210,14 @@ capture_log <- function(expr, filename) {
   ## nolint end
   handle_message <- function(e) cat(e$message, file = stdout())
   suppressMessages(withCallingHandlers(force(expr), message = handle_message))
+}
+
+conditional_capture_log <- function(capture, filename, expr) {
+  if (isTRUE(capture)) {
+    capture_log(expr, filename)
+  } else {
+    force(expr)
+  }
 }
 
 last <- function(x) {

--- a/R/util.R
+++ b/R/util.R
@@ -195,19 +195,13 @@ pasteq <- function(x, sep = ", ") {
 
 
 capture_log <- function(expr, filename) {
-  ## nolint start
-  if (file.exists(filename)) {
-    mode = "a"
-  } else {
-    mode = "w"
-  }
+  mode <- if (file.exists(filename)) "a" else "w"
   con <- file(filename, mode)
   sink(con, split = FALSE)
   on.exit({
     sink(NULL)
     close(con)
   })
-  ## nolint end
   handle_message <- function(e) cat(e$message, file = stdout())
   suppressMessages(withCallingHandlers(force(expr), message = handle_message))
 }

--- a/orderly.Rproj
+++ b/orderly.Rproj
@@ -12,6 +12,8 @@ Encoding: UTF-8
 RnwWeave: Sweave
 LaTeX: pdfLaTeX
 
+StripTrailingWhitespace: Yes
+
 BuildType: Package
 PackageUseDevtools: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -992,16 +992,16 @@ test_that("pick up name from the working directory", {
 test_that("orderly_run can capture messages", {
   path <- prepare_orderly_example("minimal")
   on.exit(unlink(path, recursive = TRUE))
-  
+
   config <- orderly_config_get(path, TRUE)
   config$add_run_option("capture_log", TRUE)
   id <- orderly_run("example", root = config, echo = FALSE)
-  
+
   draft_logs <- file.path(path, "draft", "example", id, "orderly.log")
   expect_true(file.exists(draft_logs))
   log <- readLines(draft_logs)
   expect_true("[ name       ]  example" %in% log)
-  
+
   path <- orderly_commit(id, root = config)
   archive_logs <- file.path(path, "orderly.log")
   expect_true(file.exists(archive_logs))
@@ -1013,7 +1013,7 @@ test_that("orderly_run can capture messages", {
 test_that("logs from failed runs can still be written to file", {
   path <- prepare_orderly_example("minimal")
   on.exit(unlink(path, recursive = TRUE))
-  
+
   config <- orderly_config_get(path, TRUE)
   config$add_run_option("capture_log", TRUE)
   append_lines('stop("some error")',
@@ -1021,7 +1021,7 @@ test_that("logs from failed runs can still be written to file", {
   expect_error(orderly_run("example", root = config, echo = FALSE),
                "some error")
   id <- dir(file.path(path, "draft", "example"))
-  
+
   draft_logs <- file.path(path, "draft", "example", id, "orderly.log")
   expect_true(file.exists(draft_logs))
   log <- readLines(draft_logs)

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -988,3 +988,42 @@ test_that("pick up name from the working directory", {
     orderly_run(echo = FALSE))
   expect_true(file.exists(file.path(path, "draft", "example", id)))
 })
+
+test_that("orderly_run can capture messages", {
+  path <- prepare_orderly_example("minimal")
+  on.exit(unlink(path, recursive = TRUE))
+  
+  config <- orderly_config_get(path, TRUE)
+  config$add_run_option("capture_log", TRUE)
+  id <- orderly_run("example", root = config, echo = FALSE)
+  
+  draft_logs <- file.path(path, "draft", "example", id, "orderly.log")
+  expect_true(file.exists(draft_logs))
+  log <- readLines(draft_logs)
+  expect_true("[ name       ]  example" %in% log)
+  
+  path <- orderly_commit(id, root = config)
+  archive_logs <- file.path(path, "orderly.log")
+  expect_true(file.exists(archive_logs))
+  log <- readLines(archive_logs)
+  expect_true("[ name       ]  example" %in% log)
+  expect_true(any(grepl("^\\[ commit     \\]  .*", log)))
+})
+
+test_that("logs from failed runs can still be written to file", {
+  path <- prepare_orderly_example("minimal")
+  on.exit(unlink(path, recursive = TRUE))
+  
+  config <- orderly_config_get(path, TRUE)
+  config$add_run_option("capture_log", TRUE)
+  append_lines('stop("some error")',
+               file.path(path, "src", "example", "script.R"))
+  expect_error(orderly_run("example", root = config, echo = FALSE),
+               "some error")
+  id <- dir(file.path(path, "draft", "example"))
+  
+  draft_logs <- file.path(path, "draft", "example", id, "orderly.log")
+  expect_true(file.exists(draft_logs))
+  log <- readLines(draft_logs)
+  expect_true("[ name       ]  example" %in% log)
+})

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -832,3 +832,20 @@ test_that("palette", {
       expect_equal(orderly_style("other")("x"), "x")
    })
 })
+
+test_that("can conditionally capture logs", {
+  fun <- function() {
+    message("Test")
+  }
+  t <- tempfile()
+  expect_message(conditional_capture_log(FALSE, t, fun()), "Test")
+  expect_false(file.exists(t))
+  
+  expect_silent(conditional_capture_log(TRUE, t, fun()))
+  expect_true(file.exists(t))
+  expect_equal(readLines(t), "Test")
+  
+  ## Logfile can be appended to
+  expect_silent(conditional_capture_log(TRUE, t, fun()))
+  expect_equal(readLines(t), c("Test", "Test"))
+})

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -840,11 +840,11 @@ test_that("can conditionally capture logs", {
   t <- tempfile()
   expect_message(conditional_capture_log(FALSE, t, fun()), "Test")
   expect_false(file.exists(t))
-  
+
   expect_silent(conditional_capture_log(TRUE, t, fun()))
   expect_true(file.exists(t))
   expect_equal(readLines(t), "Test")
-  
+
   ## Logfile can be appended to
   expect_silent(conditional_capture_log(TRUE, t, fun()))
   expect_equal(readLines(t), c("Test", "Test"))


### PR DESCRIPTION
This PR will
* Add support for `orderly_run` and `orderly_commit` to write logs to a `orderly.log` file based on a config flag
* Use config flag in CLI run