### PR TITLE
vimc-3620: Skip failed draft on search

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.1.16
+Version: 1.1.17
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/R/query_search.R
+++ b/R/query_search.R
@@ -176,7 +176,7 @@ orderly_search_do_search <- function(dat, name, draft, config) {
     search_parameters <- search_parameters_archive
     search_tags <- search_tags_archive
   }
-  versions <- orderly_list_dir(file.path(config$root, where, name))
+  versions <- orderly_list_dir(file.path(config$root, where, name), TRUE)
 
   if (dat$use$parameter) {
     parameters <- search_parameters(name, config)
@@ -260,7 +260,7 @@ search_tags_archive <- function(name, config) {
 
 search_x_draft <- function(name, config, extract) {
   path <- file.path(config$root, "draft", name)
-  versions <- orderly_list_dir(path)
+  versions <- orderly_list_dir(path, TRUE)
   f <- function(p) {
     extract(readRDS(path_orderly_run_rds(p)))
   }

--- a/tests/testthat/test-query-search.R
+++ b/tests/testthat/test-query-search.R
@@ -387,3 +387,14 @@ test_that("is.null requires a namespace", {
           "but found 'tag'"),
     fixed = TRUE)
 })
+
+
+test_that("skip failed drafts on search", {
+  dat <- prepare_orderly_query_example(TRUE)
+  root <- dat$root
+  ids <- dat$ids
+  file.remove(file.path(root, "draft", "other", ids[[3]], "orderly_run.rds"))
+  expect_equal(
+    orderly_search("parameter:nmin > 0.15", "other", root = root, draft = TRUE),
+    ids[2])
+})


### PR DESCRIPTION
Previously this listed all directories in drafts, including those that failed (and therefore do not have an orderly_run.rds).  This PR skips those which lets the query actually complete in the face of failed drafts