### PR TITLE
vimc-3634: Export build args

### DIFF
--- a/docker/build
+++ b/docker/build
@@ -1,12 +1,15 @@
 #!/usr/bin/env bash
-set -e
+set -ex
 HERE=$(dirname $0)
 . $HERE/common
 
 docker build --pull \
-       -t $TAG_SHA \
-       -t $TAG_BRANCH \
-       -t $TAG_VERSION \
+       --build-arg GIT_ID=$GIT_SHA \
+       --build-arg GIT_BRANCH=$GIT_BRANCH \
+       --build-arg ORDERLY_VERSION=$PACKAGE_VERSION \
+       --tag $TAG_SHA \
+       --tag $TAG_BRANCH \
+       --tag $TAG_VERSION \
        -f docker/Dockerfile \
        .
 

--- a/docker/common
+++ b/docker/common
@@ -2,6 +2,8 @@
 PACKAGE_ROOT=$(realpath $HERE/..)
 PACKAGE_NAME=orderly
 PACKAGE_ORG=vimc
+PACKAGE_VERSION=$(cat $PACKAGE_ROOT/DESCRIPTION | \
+                      grep '^Version:' | sed 's/^.*: *//')
 
 # Buildkite doesn't check out a full history from the remote (just the
 # single commit) so you end up with a detached head and git rev-parse
@@ -11,7 +13,7 @@ if [ "$BUILDKITE" = "true" ]; then
 else
     GIT_SHA=$(git -C "$PACKAGE_ROOT" rev-parse --short=7 HEAD)
 fi
-PKG_VERSION=$(cat $PACKAGE_ROOT/DESCRIPTION | grep '^Version:' | sed 's/^.*: *//')
+
 
 if [ "$TRAVIS" = "true" ]; then
     GIT_BRANCH=$TRAVIS_BRANCH
@@ -23,5 +25,5 @@ fi
 
 TAG_SHA="${PACKAGE_ORG}/${PACKAGE_NAME}:${GIT_SHA}"
 TAG_BRANCH="${PACKAGE_ORG}/${PACKAGE_NAME}:${GIT_BRANCH}"
-TAG_VERSION="${PACKAGE_ORG}/${PACKAGE_NAME}:v${PKG_VERSION}"
+TAG_VERSION="${PACKAGE_ORG}/${PACKAGE_NAME}:v${PACKAGE_VERSION}"
 TAG_LATEST="${PACKAGE_ORG}/${PACKAGE_NAME}:latest"


### PR DESCRIPTION
I forgot all the build args, which mean that the version number was not included as an env var on buildkite builds