### PR TITLE
VIMC-3641: fixes two unbound variable failures

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.1.20
+Version: 1.1.21
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/R/develop.R
+++ b/R/develop.R
@@ -87,7 +87,7 @@ orderly_develop_start <- function(name = NULL, parameters = NULL,
   orderly_log("name", loc$name)
 
   info <- orderly_recipe$new(loc$name, loc$config, develop = TRUE)
-  info$resolve_dependencies(use_draft, use_parameters, remote)
+  info$resolve_dependencies(use_draft, parameters, remote)
 
   info$workdir <- loc$path
   withr::with_dir(info$workdir, {

--- a/R/orderly_recipe.R
+++ b/R/orderly_recipe.R
@@ -347,6 +347,7 @@ recipe_validate_tags <- function(tags, config, filename) {
   if (is.null(config$tags)) {
     stop("Tags are not supported; please edit orderly_config.yml to enable")
   }
+  name <- if (is.null(filename)) "tags" else sprintf("%s:tags", filename)
   assert_character(tags, name)
   err <- setdiff(tags, config$tags)
   if (length(err) > 0L) {

--- a/R/recipe_run.R
+++ b/R/recipe_run.R
@@ -192,7 +192,7 @@ recipe_prepare <- function(config, name, id_file = NULL, ref = NULL,
   info$resolve_dependencies(use_draft, parameters, remote)
 
   if (!is.null(tags)) {
-    info$tags <- union(info$tags, recipe_validate_tags(tags, config, "tags"))
+    info$tags <- union(info$tags, recipe_validate_tags(tags, config, NULL))
   }
 
   id <- new_report_id()

--- a/tests/testthat/test-develop.R
+++ b/tests/testthat/test-develop.R
@@ -210,9 +210,9 @@ test_that("Can develop a report with parameters and dependencies", {
 
   orderly_develop_start("use_dependency", list(nmin = 0), root = root,
                         use_draft = TRUE)
-  expect_equal(
-    hash_files(file.path(root, "src", "use_dependency", "incoming.csv"), FALSE),
-    hash_files(file.path(root, "draft", "other", id2, "summary.csv"), FALSE))
+  expect_equivalent(
+    hash_files(file.path(root, "src", "use_dependency", "incoming.csv")),
+    hash_files(file.path(root, "draft", "other", id2, "summary.csv")))
 
   orderly_develop_start("use_dependency", list(nmin = 0.3), root = root,
                         use_draft = TRUE)

--- a/tests/testthat/test-orderly-recipe.R
+++ b/tests/testthat/test-orderly-recipe.R
@@ -700,6 +700,10 @@ test_that("Validate report tag", {
   writeLines(c(txt, "tags:", "- tag1", "- tag2", "- tag1"), path_config)
   expect_error(orderly_recipe$new("example", config),
                "Duplicated tag: 'tag1'")
+
+  writeLines(c(txt, "tags: 1"), path_config)
+  expect_error(orderly_recipe$new("example", config),
+               "'orderly.yml:tags' must be character")
 })
 
 

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -882,6 +882,9 @@ test_that("Pass tags during run", {
   expect_error(
     orderly_run("example", root = root, echo = FALSE, tags = "tag3"),
     "Unknown tag: 'tag3'")
+  expect_error(
+    orderly_run("example", root = root, echo = FALSE, tags = 1),
+    "'tags' must be character")
 })
 
 


### PR DESCRIPTION
Fixes two bugs I introduced in #197 - annoyingly these were both visible as a NOTE in the R CMD check output!  Added a test for each.