### PR TITLE
VIMC-3625: Cope with trailing slash on report name

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.1.21
+Version: 1.1.22
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/R/develop.R
+++ b/R/develop.R
@@ -140,8 +140,13 @@ orderly_develop_location <- function(name, root, locate) {
       stop("Unexpected working directory - expected src/<name>")
     }
     name <- rel[[2L]]
-  } else if (grepl("^src/.+", name)) {
-    name <- sub("^src/", "", name)
+  } else {
+    if (grepl("^src/.+", name)) {
+      name <- sub("^src/", "", name)
+    }
+    if (grepl("/$", name)) {
+      name <- sub("/$", "", name)
+    }
   }
 
   path <- file.path(path_src(config$root), name)

--- a/tests/testthat/test-db.R
+++ b/tests/testthat/test-db.R
@@ -434,3 +434,11 @@ test_that("add batch info to db", {
     DBI::dbReadTable(con, "report_version_batch"),
     data_frame(report_version = ids, report_batch = rep(batch_id, 3)))
 })
+
+
+## Regression test for vimc-3652
+test_that("trailing slash in report name is tolerated", {
+  path <- prepare_orderly_example("minimal")
+  id <- orderly_run("src/example/", root = path, echo = FALSE)
+  expect_error(orderly_commit(id, root = path), NA)
+})

--- a/tests/testthat/test-develop.R
+++ b/tests/testthat/test-develop.R
@@ -38,6 +38,9 @@ test_that("orderly_develop_location", {
 
   expect_equal(orderly_develop_location(name, path), cmp1)
   expect_equal(orderly_develop_location("src/minimal", path), cmp1)
+  ## Strip trailing slash too:
+  expect_equal(orderly_develop_location("minimal/", path), cmp1)
+  expect_equal(orderly_develop_location("src/minimal/", path), cmp1)
 
   expect_equal(
     withr::with_dir(cmp1$path, orderly_develop_location(name, path)),


### PR DESCRIPTION
As reported by @sangeetabhatia03, when running a report as:

```
orderly::orderly_run("src/name/")
```

with a trailing slash there is a foreign key error because we save the wrong name (`name/`) into the orderly_run.rds and then try to write that into db, which fails with a foreign key constraint.

Likely a regression since moving to use `orderly_develop_location` for identifying the report name.  While this affects orderly_run.rds, no need for a data migration because the import fails.