### PR TITLE
VIMC-3660: Extend the batch cli interface to accept file input

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.1.23
+Version: 1.1.24
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# orderly 1.1.24
+
+* Batches of parameters can be supplied to `orderly batch` using a csv file via `--file` (VIMC-3569)
+
 # orderly 1.1.23
 
 * New function `orderly::orderly_remote()` for geting an "orderly remote" object, as declared in the `orderly_config.yml` (VIMC-3655)

--- a/R/main.R
+++ b/R/main.R
@@ -28,7 +28,7 @@ cli_args_process <- function(args) {
     dat$options$type <- cli_args_process_list_type(dat$options)
   } else if (dat$command == "batch") {
     dat$options$parameters <- cli_args_process_batch_parameters(
-      dat$options$parameter)
+      dat$options$parameter, dat$options$file)
     dat$options$name <- dat$options[["<name>"]] # docopt bug?
   }
 
@@ -90,8 +90,13 @@ cli_args_process_run_parameters <- function(parameters) {
   }
 }
 
-cli_args_process_batch_parameters <- function(parameters) {
-  if (length(parameters) == 0L) {
+cli_args_process_batch_parameters <- function(parameters, file) {
+  if (!is.null(file)) {
+    ## For now just assuming that this is a csv file but we can switch
+    ## behaviour here and take json if needed.
+    assert_file_exists(file, FALSE, name = "Parameters file")
+    read_csv(file, check.names = FALSE)
+  } else if (length(parameters) == 0L) {
     NULL
   } else {
     p <- split_key_values(parameters)
@@ -335,9 +340,10 @@ main_do_migrate <- function(x) {
 
 ## 8. batch
 usage_batch <- "Usage:
-  orderly batch [options] <name> [<parameter>...]
+  orderly batch [options] <name> ([<parameter>...]|--file=FILE)
 
 Options:
+  --file=FILE      File to read batch parameters from
   --instance=NAME  Database instance to use (if instances are configured)
   --print-log      Print the logs (rather than storing it)
   --ref=REF        Git reference (branch or sha) to use

--- a/R/util.R
+++ b/R/util.R
@@ -118,7 +118,7 @@ sql_str_sub <- function(s, data) {
 }
 
 read_csv <- function(filename, ...) {
-  utils::read.csv(filename, stringsAsFactors = FALSE)
+  utils::read.csv(filename, ..., stringsAsFactors = FALSE)
 }
 
 write_csv <- function(data, filename, ...) {

--- a/tests/testthat/test-main.R
+++ b/tests/testthat/test-main.R
@@ -578,6 +578,21 @@ test_that("run captures output", {
 })
 
 
+test_that("batch parameters can be passed via file", {
+  skip_on_cran_windows()
+  f <- function(...) {
+    cli_args_process(c("batch", "report", ...))$options
+  }
+
+  expect_error(f("--file=myfile.csv"),
+               "Parameters file does not exist: 'myfile.csv'")
+  path <- tempfile()
+  pars <- data_frame(a = 1:5, b = letters[1:5])
+  write.csv(pars, path, row.names = FALSE)
+  expect_equal(f("--file", path)$parameters, pars)
+})
+
+
 test_that("batch", {
   testthat::skip_on_cran()
   path <- unzip_git_demo()


### PR DESCRIPTION
This PR lets us accept batch parameters via a csv file like

```
orderly batch --file=parameters.csv
```

This is not super useful for most of the vimc/montagu use cases, but will be in the ncov work.  We can extend this interface to accept other parameters in future (json being an obvious one).