### PR TITLE
orderly_envir.yml vignette example needs : instead of =

### DIFF
--- a/vignettes/orderly.Rmd
+++ b/vignettes/orderly.Rmd
@@ -741,7 +741,7 @@ The expected use case for this is if you have data which you want to use in a re
 Environment variables can also be used in top-level `orderly_envir.yml` (since orderly 1.1.6) which can be accessed via `Sys.getenv()`. For example, if your `orderly_envir.yml` contains
 
 ```r
-DATA_URL=https://www.example.com/thedata
+DATA_URL: https://www.example.com/thedata
 ```
 
 Then in your script you can use


### PR DESCRIPTION
In the Getting Started vignette, I believe that the example for setting environment variable in `orderly_envir.yml`:

> `DATA_URL=https://www.example.com/thedata` 

needs to be yaml formatted:

> `DATA_URL: https://www.example.com/thedata`

When I used `DATA_URL=https://www.example.com/thedata` , I got the error message: `Error: 'orderly_envir.yml' must be named`. It worked as expected when I changed `=` to `: `.