### PR TITLE
Fixed example of setting variables through orderly_envir.yml

### DIFF
--- a/vignettes/orderly.Rmd
+++ b/vignettes/orderly.Rmd
@@ -741,7 +741,7 @@ The expected use case for this is if you have data which you want to use in a re
 Environment variables can also be used in top-level `orderly_envir.yml` (since orderly 1.1.6) which can be accessed via `Sys.getenv()`. For example, if your `orderly_envir.yml` contains
 
 ```r
-DATA_URL=https://www.example.com/thedata
+DATA_URL: https://www.example.com/thedata
 ```
 
 Then in your script you can use


### PR DESCRIPTION
use colon instead of equals sign to separate keys and values.