### PR TITLE
vimc-3669: Allow environment variable setting in develop mode

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.1.26
+Version: 1.1.27
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# orderly 1.1.27
+
+* Allow `orderly::orderly_develop_start()` to use environment variables declared in `orderly.yml` and defined in `orderly_envir.yml` (#214, VIMC-3669, reported by @sangeetabhatia03)
+
 # orderly 1.1.26
 
 * Add ability to post report commit notification to Microsoft Teams (VIMC-3640)

--- a/R/develop.R
+++ b/R/develop.R
@@ -90,13 +90,17 @@ orderly_develop_start <- function(name = NULL, parameters = NULL,
   info$resolve_dependencies(use_draft, parameters, remote)
 
   info$workdir <- loc$path
+
+  env <- orderly_envir_read(loc$config$root)
   withr::with_dir(info$workdir, {
-    info <- recipe_copy_global(info, loc$config)
+    withr::with_envvar(env, {
+      info <- recipe_copy_global(info, loc$config)
     info <- recipe_copy_depends(info)
-    orderly_prepare_data(loc$config, info, parameters, envir, instance)
+      orderly_prepare_data(loc$config, info, parameters, envir, instance)
+    })
   })
 
-  sys_setenv(orderly_envir_read(loc$config$root))
+  sys_setenv(env)
 
   invisible(loc$path)
 }

--- a/tests/testthat/test-develop.R
+++ b/tests/testthat/test-develop.R
@@ -223,3 +223,17 @@ test_that("Can develop a report with parameters and dependencies", {
     hash_files(file.path(root, "src", "use_dependency", "incoming.csv")),
     hash_files(file.path(root, "draft", "other", id1, "summary.csv")))
 })
+
+
+test_that("can load environment variables during develop", {
+  path <- prepare_orderly_example("minimal")
+  p <- file.path(path, "src", "example")
+  on.exit(Sys.unsetenv("ORDERLY_TEST_VARIABLE"))
+  writeLines("ORDERLY_TEST_VARIABLE: hello",
+             file.path(path, "orderly_envir.yml"))
+  append_lines(c("environment:", "  a: ORDERLY_TEST_VARIABLE"),
+               file.path(p, "orderly.yml"))
+  e <- new.env()
+  orderly_develop_start("example", envir = e, root = path)
+  expect_equal(e$a, "hello")
+})

--- a/vignettes/orderly.Rmd
+++ b/vignettes/orderly.Rmd
@@ -740,7 +740,7 @@ The expected use case for this is if you have data which you want to use in a re
 
 Environment variables can also be used in top-level `orderly_envir.yml` (since orderly 1.1.6) which can be accessed via `Sys.getenv()`. For example, if your `orderly_envir.yml` contains
 
-```r
+```yaml
 DATA_URL: https://www.example.com/thedata
 ```
 


### PR DESCRIPTION
As reported by @sangeetabhatia03 in #214, this PR fixes a bug and allows `orderly::orderly_develop_start()` to use environment variables declared in `orderly.yml` and defined in `orderly_envir.yml`