### PR TITLE
vimc-3671

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.1.27
+Version: 1.1.28
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# orderly 1.1.28
+
+* `orderly::orderly_develop_clean()` no longer deletes artefacts that are re-exported from sources (VIMC-3671, reported by @cewalters)
+
 # orderly 1.1.27
 
 * Allow `orderly::orderly_develop_start()` to use environment variables declared in `orderly.yml` and defined in `orderly_envir.yml` (#214, VIMC-3669, reported by @sangeetabhatia03)

--- a/R/develop.R
+++ b/R/develop.R
@@ -187,6 +187,9 @@ orderly_status <- function(path) {
   }
   status$present <- file.exists(file.path(path, status$filename))
   status$derived <- status$type %in% c("global", "dependency", "artefact")
+  ## Files that are re-exported are not derived:
+  status$derived <- status$derived &
+    !(status$filename %in% status$filename[!status$derived])
 
   class(status) <- c("orderly_status", "data.frame")
   status

--- a/tests/testthat/test-develop.R
+++ b/tests/testthat/test-develop.R
@@ -237,3 +237,26 @@ test_that("can load environment variables during develop", {
   orderly_develop_start("example", envir = e, root = path)
   expect_equal(e$a, "hello")
 })
+
+
+test_that("don't delete artefacts that are resources", {
+  path <- prepare_orderly_example("minimal")
+  name <- "example"
+  p <- file.path(path, "src", name)
+
+  path_orderly <- file.path(p, "orderly.yml")
+  dat <- yaml_read(path_orderly)
+  dat$artefacts <- list(dat$artefacts,
+                        list(data = list(description = "data",
+                                         filenames = "data.csv")))
+  dat$resources <- "data.csv"
+  yaml_write(dat, path_orderly)
+
+  file.create(file.path(p, "data.csv"))
+
+  d <- orderly_develop_status(name, root = path)
+  expect_false(d$derived[d$filename == "data.csv" & d$type == "artefact"])
+
+  orderly_develop_clean(name, root = path)
+  expect_true(file.exists(file.path(p, "data.csv")))
+})

--- a/tests/testthat/test-orderly-recipe.R
+++ b/tests/testthat/test-orderly-recipe.R
@@ -24,7 +24,8 @@ test_that("minimal", {
   expect_equal(info$data$dat$database, "source")
 
   expect_equal(info$script, "script.R")
-  expect_equal(info$path, normalizePath(file.path(path, "src", "example")))
+  expect_equal(normalizePath(info$path),
+               normalizePath(file.path(path, "src", "example")))
 
   expect_null(info$displayname)
   expect_null(info$description)


### PR DESCRIPTION
This PR fixes a bug reported by @cewalters where a file listed in both `resources:` and as an artefact will be deleted by `orderly::orderly_develop_clean`.  The fix here considers such files to be "non-derived" (they will be listed twice but I think that's ok)