### PR TITLE
vimc-3694: Escape underscores in report name

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.1.29
+Version: 1.1.30
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/R/slack.R
+++ b/R/slack.R
@@ -125,7 +125,7 @@ prepare_content <- function(dat, remote_name, report_url, link_format) {
 
   list(
     fallback = sprintf("Ran '%s' as '%s'; view at %s", name, id, report_url),
-    title = sprintf("Ran report '%s'", name),
+    title = sprintf("Ran report `%s`", name),
     text = sprintf("on server *%s* in %s", remote_name, elapsed),
     id = sprintf("`%s`", id)
   )

--- a/R/slack.R
+++ b/R/slack.R
@@ -31,7 +31,8 @@ post_success <- function(dat, config) {
 }
 
 slack_data <- function(dat, remote_name, report_url, remote_is_primary) {
-  content <- prepare_content(dat, remote_name, report_url, "<{url}|{label}>")
+  content <- prepare_content(dat, remote_name, report_url, "<{url}|{label}>",
+                             escape = FALSE)
   fields <- list(list(title = "id", value = content$id, short = TRUE))
 
   if (!is.null(dat$git)) {
@@ -68,7 +69,8 @@ slack_data <- function(dat, remote_name, report_url, remote_is_primary) {
 }
 
 teams_data <- function(dat, remote_name, report_url, remote_is_primary) {
-  content <- prepare_content(dat, remote_name, report_url, "[{label}]({url})")
+  content <- prepare_content(dat, remote_name, report_url, "[{label}]({url})",
+                             escape = TRUE)
   facts <- list(list(name = "id:", value = content$id))
 
   if (!is.null(dat$git)) {
@@ -118,14 +120,21 @@ teams_data <- function(dat, remote_name, report_url, remote_is_primary) {
   )
 }
 
-prepare_content <- function(dat, remote_name, report_url, link_format) {
+prepare_content <- function(dat, remote_name, report_url, link_format,
+                            escape) {
   id <- dat$meta$id
   name <- dat$meta$name
   elapsed <- format(as.difftime(dat$meta$elapsed, units = "secs"), digits = 2)
 
+  if (escape) {
+    qname <- sprintf("`%s`", name)
+  } else {
+    qname <- sprintf("'%s'", name)
+  }
+
   list(
     fallback = sprintf("Ran '%s' as '%s'; view at %s", name, id, report_url),
-    title = sprintf("Ran report `%s`", name),
+    title = sprintf("Ran report %s", qname),
     text = sprintf("on server *%s* in %s", remote_name, elapsed),
     id = sprintf("`%s`", id)
   )

--- a/tests/testthat/test-slack.R
+++ b/tests/testthat/test-slack.R
@@ -20,7 +20,7 @@ test_that("slack payload is correct", {
       username = "orderly",
       icon_emoji = ":ambulance:",
       attachments = list(list(
-        title = "Ran report `example`",
+        title = "Ran report 'example'",
         text = "on server *myserver* in 10 secs",
         color = "warning",
         fallback = sprintf("Ran '%s' as '%s'; view at %s",
@@ -265,7 +265,7 @@ test_that("slack payload is correct given actual run data", {
   expect_setequal(names(a),
                   c("title", "text", "color", "fallback", "fields", "actions"))
 
-  expect_equal(a$title, "Ran report `minimal`")
+  expect_equal(a$title, "Ran report 'minimal'")
   expect_match(a$text, "on server \\*myserver\\* in [0-9]+(.[0-9]+)? secs")
   expect_equal(a$color, "warning")
   expect_equal(a$fallback,

--- a/tests/testthat/test-slack.R
+++ b/tests/testthat/test-slack.R
@@ -20,7 +20,7 @@ test_that("slack payload is correct", {
       username = "orderly",
       icon_emoji = ":ambulance:",
       attachments = list(list(
-        title = "Ran report 'example'",
+        title = "Ran report `example`",
         text = "on server *myserver* in 10 secs",
         color = "warning",
         fallback = sprintf("Ran '%s' as '%s'; view at %s",
@@ -265,7 +265,7 @@ test_that("slack payload is correct given actual run data", {
   expect_setequal(names(a),
                   c("title", "text", "color", "fallback", "fields", "actions"))
 
-  expect_equal(a$title, "Ran report 'minimal'")
+  expect_equal(a$title, "Ran report `minimal`")
   expect_match(a$text, "on server \\*myserver\\* in [0-9]+(.[0-9]+)? secs")
   expect_equal(a$color, "warning")
   expect_equal(a$fallback,
@@ -318,7 +318,7 @@ test_that("teams payload is correct", {
       themeColor = "DAA038",
       sections = list(
         list(
-          activityTitle = "Ran report 'example'",
+          activityTitle = "Ran report `example`",
           activityText = "on server *myserver* in 10 secs",
           activityImage = paste0("https://cdn.pixabay.com/photo/2017/",
                                  "06/10/07/18/list-2389219_960_720.png")
@@ -379,7 +379,7 @@ test_that("teams payload is correct with git information", {
       themeColor = "2EB886",
       sections = list(
         list(
-          activityTitle = "Ran report 'example'",
+          activityTitle = "Ran report `example`",
           activityText = "on server *myserver* in 10 secs",
           activityImage = paste0("https://cdn.pixabay.com/photo/2017/",
                                  "06/10/07/18/list-2389219_960_720.png")


### PR DESCRIPTION
This PR uses backticks around the report name so that it doesn't get munged by Teams (see image below). This might look slightly worse in the Slack version, as the quotes will come through, so there's a switch there to keep the old behaviour in slack.

<img width="295" alt="Screenshot 2020-04-23 at 19 30 06" src="https://user-images.githubusercontent.com/1558093/80135909-da2b1080-8598-11ea-9f93-2e05ab9fbd94.png">
