### PR TITLE
vimc-3702: Backup before rebuild

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.1.30
+Version: 1.1.31
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# orderly 1.1.31
+
+* `orderly::orderly_rebuild()` creates a dated backup of the database before running, allowing this potentially destructive operation to be recovered from (VIMC-3702)
+
 # orderly 1.1.28
 
 * `orderly::orderly_develop_clean()` no longer deletes artefacts that are re-exported from sources (VIMC-3671, reported by @cewalters)

--- a/R/db.R
+++ b/R/db.R
@@ -175,6 +175,7 @@ orderly_rebuild <- function(root = NULL, locate = TRUE, verbose = TRUE,
   on.exit(options(oo))
 
   config <- orderly_config_get(root, locate)
+  orderly_backup(config, suffix = paste0(".", iso_time_str(Sys.time())))
 
   if (length(migrate_plan(config$archive_version, to = NULL)) > 0L) {
     orderly_log("migrate", "archive")
@@ -202,12 +203,12 @@ orderly_rebuild <- function(root = NULL, locate = TRUE, verbose = TRUE,
 ## > backup may be performed on a live source database without
 ## > preventing other database connections from reading or writing to
 ## > the source database while the backup is underway.
-orderly_backup <- function(config = NULL, locate = TRUE) {
+orderly_backup <- function(config = NULL, locate = TRUE, suffix = NULL) {
   config <- orderly_config_get(config, locate)
   if (config$destination$driver[[1]] == "RSQLite") {
     curr <- orderly_db_args(config$destination, config)$args$dbname
 
-    dest <- path_db_backup(config$root, curr)
+    dest <- path_db_backup(config$root, curr, suffix)
     dir.create(dirname(dest), FALSE, TRUE)
 
     prefix <- paste0(config$root, "/")

--- a/R/db.R
+++ b/R/db.R
@@ -175,7 +175,6 @@ orderly_rebuild <- function(root = NULL, locate = TRUE, verbose = TRUE,
   on.exit(options(oo))
 
   config <- orderly_config_get(root, locate)
-  orderly_backup(config, suffix = paste0(".", iso_time_str(Sys.time())))
 
   if (length(migrate_plan(config$archive_version, to = NULL)) > 0L) {
     orderly_log("migrate", "archive")
@@ -185,6 +184,7 @@ orderly_rebuild <- function(root = NULL, locate = TRUE, verbose = TRUE,
   }
 
   if (!if_schema_changed || report_db_needs_rebuild(config)) {
+    orderly_backup(config, suffix = paste0(".", iso_time_str(Sys.time())))
     orderly_log("rebuild", "db")
     report_db_rebuild(config, verbose)
     invisible(TRUE)

--- a/R/paths.R
+++ b/R/paths.R
@@ -63,8 +63,13 @@ path_changelog_txt <- function(path, type) {
 }
 
 
-path_db_backup <- function(root, file) {
-  file.path(root, "backup", "db", basename(file), fsep = "/")
+path_db_backup <- function(root, file, suffix = NULL) {
+  if (is.null(suffix)) {
+    filename <- basename(file)
+  } else {
+    filename <- paste0(basename(file), suffix)
+  }
+  file.path(root, "backup", "db", filename, fsep = "/")
 }
 
 


### PR DESCRIPTION
This would have been useful with the published problem as reported by Kim, but might be useful generally going forward (and the cost is low).  Uses the already-tested backup db that uses the "proper" way of backing up a SQLite database.