### PR TITLE
vimc-3783: Never allow multiple ids through

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.1.31
+Version: 1.1.32
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/R/query.R
+++ b/R/query.R
@@ -287,7 +287,7 @@ latest_id <- function(ids) {
 
   if (length(ids) > 1L) {
     ms <- sub(version_id_re, "\\2", ids)
-    ids <- ids[ms == last(ms)]
+    ids <- max(ids[ms == last(ms)])
   }
 
   ids

--- a/tests/testthat/test-query.R
+++ b/tests/testthat/test-query.R
@@ -93,17 +93,17 @@ test_that("latest_ids", {
   expect_identical(latest_id(sample(id_ms)), last(id_ms))
 
   ## Differ below the subsecond level
-  id_same <- replicate(5, new_report_id(t + 1))
-  expect_identical(latest_id(id_same), sort_c(id_same))
-  expect_identical(latest_id(sample(id_same)), sort_c(id_same))
+  id_same <- sort_c(replicate(5, new_report_id(t + 1)))
+  expect_identical(latest_id(id_same), last(id_same))
+  expect_identical(latest_id(sample(id_same)), last(id_same))
 
   id_both <- c(id_s, id_ms)
   expect_identical(latest_id(id_both), last(id_both))
   expect_identical(latest_id(sample(id_both)), last(id_both))
 
   id_all <- c(id_both, id_same)
-  expect_identical(latest_id(id_all), sort_c(id_same))
-  expect_identical(latest_id(sample(id_all)), sort_c(id_same))
+  expect_identical(latest_id(id_all), last(id_same))
+  expect_identical(latest_id(sample(id_all)), last(id_same))
 
   ## Unexpected inputs
   expect_error(latest_id(c(id, "other")),


### PR DESCRIPTION
This causes all sorts of breakage, and should be very rare.  Seen when launching orderly_run in parallel, which is something we'll have to think about properly at some point