### PR TITLE
VIMC-3781: Avoid database locking problems in parallel

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.1.32
+Version: 1.1.33
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/R/util.R
+++ b/R/util.R
@@ -894,7 +894,7 @@ with_retry <- function(callback, n = 10, backoff = 1, match = NULL) {
     if (!is.null(match) && !grepl(match, result$value$message)) {
       stop(result$value)
     }
-    sleep <- runif(1, 0, 2^(i - 1) * backoff)
+    sleep <- runif(1, 0, 2^(i - 1) * backoff) # nolint
     message(sprintf("Command failed; trying again in %f seconds", sleep))
     Sys.sleep(sleep)
   }

--- a/R/util.R
+++ b/R/util.R
@@ -882,3 +882,21 @@ deparse_str <- function(x) {
 df2list <- function(df) {
   unname(split(df, seq_len(nrow(df))))
 }
+
+
+with_retry <- function(callback, n = 10, backoff = 1, match = NULL) {
+  for (i in seq_len(n)) {
+    result <- tryCatch(list(success = TRUE, value = callback()),
+                       error = function(e) list(success = FALSE, value = e))
+    if (result$success) {
+      return(result$value)
+    }
+    if (!is.null(match) && !grepl(match, result$value$message)) {
+      stop(result$value)
+    }
+    sleep <- runif(1, 0, 2^(i - 1) * backoff)
+    message(sprintf("Command failed; trying again in %f seconds", sleep))
+    Sys.sleep(sleep)
+  }
+  stop(sprintf("Failed to run command after %d attempts", n))
+}

--- a/R/util.R
+++ b/R/util.R
@@ -898,5 +898,6 @@ with_retry <- function(callback, n = 10, backoff = 1, match = NULL) {
     message(sprintf("Command failed; trying again in %f seconds", sleep))
     Sys.sleep(sleep)
   }
-  stop(sprintf("Failed to run command after %d attempts", n))
+  stop(sprintf("Failed to run command after %d attempts: %s", n,
+               result$value$message), call. = FALSE)
 }

--- a/man/orderly_commit.Rd
+++ b/man/orderly_commit.Rd
@@ -4,7 +4,14 @@
 \alias{orderly_commit}
 \title{Commit a generated report}
 \usage{
-orderly_commit(id, name = NULL, root = NULL, locate = TRUE)
+orderly_commit(
+  id,
+  name = NULL,
+  root = NULL,
+  locate = TRUE,
+  retry_n = 5,
+  retry_backoff = 1
+)
 }
 \arguments{
 \item{id}{The identifier of the report}
@@ -20,6 +27,16 @@ directory if \code{locate} is \code{TRUE}.}
 searched for.  If \code{TRUE} and \code{config} is not given,
 then orderly looks in the working directory and up through its
 parents until it finds an \code{orderly_config.yml} file.}
+
+\item{retry_n}{Number of times to retry the commit; in parallel
+the database may become locked and so we can retry with a
+stochastic exponential backoff in this case for up to
+\code{retry_n} times}
+
+\item{retry_backoff}{The rate at which to backoff; after the
+\code{i}th attempt we will sleep for up to \code{2^(i - 1) *
+backoff} seconds.  The default of 1 is probably reasonable for
+most situations.}
 }
 \value{
 The path to the newly committed report


### PR DESCRIPTION
This PR solves one of a couple of problems with running orderly in parallel - if multiple jobs try to write to the DB at once it can lead to errors as they can't get a write lock (this is problematic with the way we do the whole db addition as one atomic commit within a transaction).  I've added an exponential backoff here to try and address this.  It's awful to test and the implementation also relies on an error string in the RSQLite sources