### PR TITLE
VIMC-3789: Allow pulling based on query dependency

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -20,3 +20,4 @@
 ^\.hadolint\.yaml$
 ^buildkite$
 ^build$
+^ignore$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.1.34
+Version: 1.1.35
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# orderly 1.1.35
+
+* `orderly::orderly_pull_dependencies()` works where the dependencies use query ids, and `orderly::orderly_pull_archive()` accepts query ids (rather than just `latest`) as an argument (VIMC-3789)
+
 # orderly 1.1.34
 
 * `orderly::orderly_run_remote()` takes an instance argument to allow users to specify the source DB (VIMC-3698)

--- a/R/orderly_recipe_depends.R
+++ b/R/orderly_recipe_depends.R
@@ -95,8 +95,9 @@ recipe_resolve_dependencies <- function(self, use_draft, parameters, remote) {
 
 resolve_dependencies_local <- function(id, name, config, parameters,
                                        use_draft) {
-  is_latest <- grepl("^latest(\\(|$)", id)
-  if (grepl("^latest\\s*\\(", id)) {
+  is_query <- id_is_query(id)
+  is_latest <- is_query || id == "latest"
+  if (is_query) {
     query <- id
     id <- orderly_search(query, name, parameters, draft = use_draft,
                          root = config, locate = FALSE)
@@ -114,7 +115,7 @@ resolve_dependencies_local <- function(id, name, config, parameters,
 
 
 resolve_dependencies_remote <- function(id, name, config, remote) {
-  if (grepl("^latest\\s*\\(", id)) {
+  if (id_is_query(id)) {
     stop("Can't (yet) use query dependencies with remotes",
          call. = FALSE)
   }

--- a/R/paths.R
+++ b/R/paths.R
@@ -22,6 +22,11 @@ path_archive <- function(root, name = NULL) {
 }
 
 
+path_remote_cache <- function(root) {
+  file.path(root, ".orderly", "remote", "cache")
+}
+
+
 path_archive_broken <- function() {
   "archive_broken"
 }

--- a/R/query.R
+++ b/R/query.R
@@ -310,3 +310,8 @@ orderly_list_dir <- function(path, check_run_rds = FALSE) {
 
   files
 }
+
+
+id_is_query <- function(id) {
+  grepl("^latest\\s*\\(", id)
+}

--- a/R/query_search.R
+++ b/R/query_search.R
@@ -77,6 +77,10 @@
 ##'   \code{\link{orderly_run}}) if your query uses parameters on the
 ##'   right-hand-side of an expression.
 ##'
+##' @param remote A remote to use, if you want to apply the query
+##'   remotely.  If this is used then \code{draft} cannot be set to
+##'   \code{TRUE} as remotes do not expose draft reports.
+##'
 ##' @inheritParams orderly_list
 ##'
 ##' @return A character vector of matching report ids, possibly

--- a/R/remote.R
+++ b/R/remote.R
@@ -422,7 +422,7 @@ remote_report_versions <- function(name, config = NULL, locate = TRUE,
 
 
 remote_name <- function(remote) {
-  remote$name
+  remote$name %||% "(unknown)"
 }
 
 

--- a/R/remote.R
+++ b/R/remote.R
@@ -95,15 +95,24 @@ orderly_pull_archive <- function(name, id = "latest", root = NULL,
                                  locate = TRUE, remote = NULL) {
   config <- orderly_config_get(root, locate)
   config <- check_orderly_archive_version(config)
+
+  browser()
+
   remote <- get_remote(remote, config)
 
   v <- remote_report_versions(name, config, FALSE, remote)
   if (length(v) == 0L) {
-    stop("Unknown report")
+    stop(sprintf("No versions of '%s' were found at '%s'",
+                 name, remote_name(remote)), call. = FALSE)
   }
 
   if (id == "latest") {
     id <- latest_id(v)
+  } else if (grepl("^latest\(", id)) {
+    ## Options here:
+    ##
+    ## * Simplest is to just keep going through the list and grab
+    stop("Query interface not supported")
   }
 
   if (!(id %in% v)) {

--- a/R/remote.R
+++ b/R/remote.R
@@ -49,6 +49,14 @@
 ##'   for this orderly repository is used - by default that is the
 ##'   first listed remote.
 ##'
+##' @param parameters Parameters to pass through when doing depenency
+##'   resolution.  If you are using a query for \code{id} that
+##'   involves a parameter (e.g., \code{latest(parameter:x == p)}) you
+##'   will need to pass in the parameters here.  Similarly, if you are
+##'   pulling a report that uses query dependencies that reference
+##'   parameters you need to pass them here (the same parameter set
+##'   will be passed through to all dependencies).
+##'
 ##' @inheritParams orderly_list
 ##' @export
 ##'
@@ -64,7 +72,7 @@
 ##'
 ##' @example man-roxygen/example-remote.R
 orderly_pull_dependencies <- function(name = NULL, root = NULL, locate = TRUE,
-                                      remote = NULL) {
+                                      remote = NULL, parameters = NULL) {
   loc <- orderly_develop_location(name, root, locate)
   name <- loc$name
   config <- loc$config
@@ -79,7 +87,7 @@ orderly_pull_dependencies <- function(name = NULL, root = NULL, locate = TRUE,
     for (i in seq_len(nrow(depends))) {
       if (!isTRUE(depends$draft[[i]])) {
         orderly_pull_archive(depends$name[[i]], depends$id[[i]], config,
-                             FALSE, remote)
+                             FALSE, remote, parameters)
       }
     }
   }

--- a/R/remote.R
+++ b/R/remote.R
@@ -92,11 +92,10 @@ orderly_pull_dependencies <- function(name = NULL, root = NULL, locate = TRUE,
 ##' @param id The identifier (for \code{orderly_pull_archive}).  The default is
 ##'   to use the latest report.
 orderly_pull_archive <- function(name, id = "latest", root = NULL,
-                                 locate = TRUE, remote = NULL) {
+                                 locate = TRUE, remote = NULL,
+                                 parameters = NULL) {
   config <- orderly_config_get(root, locate)
   config <- check_orderly_archive_version(config)
-
-  browser()
 
   remote <- get_remote(remote, config)
 
@@ -108,11 +107,8 @@ orderly_pull_archive <- function(name, id = "latest", root = NULL,
 
   if (id == "latest") {
     id <- latest_id(v)
-  } else if (grepl("^latest\(", id)) {
-    ## Options here:
-    ##
-    ## * Simplest is to just keep going through the list and grab
-    stop("Query interface not supported")
+  } else if (id_is_query(id)) {
+    id <- orderly_search(id, name, parameters, root = root, remote = remote)
   }
 
   if (!(id %in% v)) {

--- a/R/remote.R
+++ b/R/remote.R
@@ -476,3 +476,19 @@ orderly_push_resolve_dependencies <- function(path, remote, config) {
     }
   }
 }
+
+
+## Where will this really be used?  I have it just in query_search at
+## the moment, and it is written just to support that, but are there
+## other times where we want this?  Probably working with dependency
+## graphs too.
+remote_report_update_metadata <- function(name, remote, config) {
+  ids <- remote$list_versions(name)
+  path_cache <- file.path(path_remote_cache(config$root), name)
+  dir.create(path_cache, FALSE, TRUE)
+  msg <- setdiff(ids, dir(path_cache))
+  for (i in msg) {
+    file_copy(remote$metadata(name, i), file.path(path_cache, i))
+  }
+  data_frame(id = ids, path = file.path(path_cache, ids))
+}

--- a/R/remote_path.R
+++ b/R/remote_path.R
@@ -56,6 +56,10 @@ orderly_remote_path_ <- R6::R6Class(
       d$id[d$name == name]
     },
 
+    metadata = function(name, id) {
+      path_orderly_run_rds(file.path(path_archive(self$config$root), name, id))
+    },
+
     pull = function(name, id) {
       src <- file.path(path_archive(self$config$root), name, id)
       dest <- tempfile()

--- a/man/orderly_pull_dependencies.Rd
+++ b/man/orderly_pull_dependencies.Rd
@@ -10,7 +10,8 @@ orderly_pull_dependencies(
   name = NULL,
   root = NULL,
   locate = TRUE,
-  remote = NULL
+  remote = NULL,
+  parameters = NULL
 )
 
 orderly_pull_archive(
@@ -52,6 +53,14 @@ using \code{\link{orderly_remote_path}}, or one provided by
 another package).  If left \code{NULL}, then the default remote
 for this orderly repository is used - by default that is the
 first listed remote.}
+
+\item{parameters}{Parameters to pass through when doing depenency
+resolution.  If you are using a query for \code{id} that
+involves a parameter (e.g., \code{latest(parameter:x == p)}) you
+will need to pass in the parameters here.  Similarly, if you are
+pulling a report that uses query dependencies that reference
+parameters you need to pass them here (the same parameter set
+will be passed through to all dependencies).}
 
 \item{id}{The identifier (for \code{orderly_pull_archive}).  The default is
 to use the latest report.}

--- a/man/orderly_pull_dependencies.Rd
+++ b/man/orderly_pull_dependencies.Rd
@@ -18,7 +18,8 @@ orderly_pull_archive(
   id = "latest",
   root = NULL,
   locate = TRUE,
-  remote = NULL
+  remote = NULL,
+  parameters = NULL
 )
 
 orderly_push_archive(

--- a/man/orderly_search.Rd
+++ b/man/orderly_search.Rd
@@ -10,7 +10,8 @@ orderly_search(
   parameters = NULL,
   draft = FALSE,
   root = NULL,
-  locate = TRUE
+  locate = TRUE,
+  remote = NULL
 )
 }
 \arguments{
@@ -38,6 +39,10 @@ directory if \code{locate} is \code{TRUE}.}
 searched for.  If \code{TRUE} and \code{config} is not given,
 then orderly looks in the working directory and up through its
 parents until it finds an \code{orderly_config.yml} file.}
+
+\item{remote}{A remote to use, if you want to apply the query
+remotely.  If this is used then \code{draft} cannot be set to
+\code{TRUE} as remotes do not expose draft reports.}
 }
 \value{
 A character vector of matching report ids, possibly

--- a/tests/testthat/test-deduplicate.R
+++ b/tests/testthat/test-deduplicate.R
@@ -142,6 +142,7 @@ test_that("don't deduplicate after file modification", {
     "Can't deduplicate files that have been modified:.+- minimal/.+/script.R")
 })
 
+
 test_that("relink basic case", {
   skip_on_cran()
   path <- tempfile()

--- a/tests/testthat/test-main.R
+++ b/tests/testthat/test-main.R
@@ -571,7 +571,8 @@ test_that("run captures output", {
   ids <- list.files(archive_path)
   expect_length(ids, 2)
   id <- ids[ids != id]
-  expect_true(sprintf("[ id         ]  %s\n", id) %in% out$messages)
+  expect_true(sprintf("[ id         ]  %s\n", id)
+              %in% crayon::strip_style(out$messages))
   log_file <- file.path(archive_path, id, "orderly.log")
   ## Logs have not been written to file
   expect_false(file.exists(log_file))
@@ -617,7 +618,8 @@ test_that("batch", {
     expect_true(file.exists(log_file))
     logs <- readLines(log_file)
     ## Logs are only for one report
-    expect_true(sprintf("[ id         ]  %s", id) %in% logs)
+    expect_true(sprintf("[ id         ]  %s", id) %in%
+                crayon::strip_style(logs))
     expect_equal(sum(grepl("\\[ id         \\].*", logs)), 1)
   }))
 
@@ -634,7 +636,8 @@ test_that("batch", {
   ids <- d$id[d$id != ids]
   archive_path <- file.path(path, "archive", "other")
   invisible(lapply(ids, function(id) {
-    expect_true(sprintf("[ id         ]  %s\n", id) %in% out$messages)
+    expect_true(sprintf("[ id         ]  %s\n", id) %in%
+                crayon::strip_style(out$messages))
     log_file <- file.path(archive_path, id, "orderly.log")
     ## Logs have not been written to file
     expect_false(file.exists(log_file))

--- a/tests/testthat/test-query-search.R
+++ b/tests/testthat/test-query-search.R
@@ -416,3 +416,23 @@ test_that("run query on remote", {
                         remote = remote, root = root)
   expect_equal(res, dat$ids[2:3])
 })
+
+
+test_that("run query on remote", {
+  skip_on_cran()
+  dat <- prepare_orderly_query_example()
+  remote <- orderly_remote_path(dat$root)
+  root <- prepare_orderly_example("demo")
+  expect_error(
+    orderly_search("latest(parameter:nmin > 0.15)", "other",
+                   draft = TRUE, remote = remote, root = root),
+    "Can't use 'draft' along with 'remote'")
+  expect_error(
+    orderly_search("latest(parameter:nmin > 0.15)", "other",
+                   draft = "always", remote = remote, root = root),
+    "Can't use 'draft' along with 'remote'")
+  expect_error(
+    orderly_search("latest(parameter:nmin > 0.15)", "other",
+                   draft = "newer", remote = remote, root = root),
+    "Can't use 'draft' along with 'remote'")
+})

--- a/tests/testthat/test-query-search.R
+++ b/tests/testthat/test-query-search.R
@@ -398,3 +398,21 @@ test_that("skip failed drafts on search", {
     orderly_search("parameter:nmin > 0.15", "other", root = root, draft = TRUE),
     ids[2])
 })
+
+
+test_that("run query on remote", {
+  skip_on_cran()
+
+  dat <- prepare_orderly_query_example()
+  remote <- orderly_remote_path(dat$root)
+
+  root <- prepare_orderly_example("demo")
+
+  res <- orderly_search("latest(parameter:nmin > 0.15)", "other",
+                        remote = remote, root = root)
+  expect_equal(res, dat$ids[[3]])
+
+  res <- orderly_search("parameter:nmin > 0.15", "other",
+                        remote = remote, root = root)
+  expect_equal(res, dat$ids[2:3])
+})

--- a/tests/testthat/test-remote-path.R
+++ b/tests/testthat/test-remote-path.R
@@ -280,3 +280,26 @@ test_that("pull archive using query and parameters", {
     orderly_list_archive(root),
     data_frame(name = "other", id = dat$ids[[2]]))
 })
+
+
+test_that("pull dependencies that use a query", {
+  dat <- prepare_orderly_query_example()
+  remote <- orderly_remote_path(dat$root)
+
+  root <- prepare_orderly_example("demo")
+
+  p <- file.path(root, "src", "use_dependency", "orderly.yml")
+  txt <- readLines(p)
+  writeLines(sub("latest$", "latest(parameter:nmin < n)", txt), p)
+
+  expect_error(
+    orderly_pull_dependencies("use_dependency", root = root, remote = remote),
+    "Query parameter 'n' not found in supplied parameters")
+
+  orderly_pull_dependencies("use_dependency", root = root, remote = remote,
+                            parameters = list(n = 0.25))
+
+  expect_equal(
+    orderly_list_archive(root),
+    data_frame(name = "other", id = dat$ids[[2]]))
+})

--- a/tests/testthat/test-remote-path.R
+++ b/tests/testthat/test-remote-path.R
@@ -249,3 +249,34 @@ test_that("fetch remote metadata", {
     dat$remote$metadata("name", "version"),
     file.path(base, "name", "version", "orderly_run.rds"))
 })
+
+
+test_that("pull archive using query", {
+  dat <- prepare_orderly_query_example()
+  remote <- orderly_remote_path(dat$root)
+
+  root <- prepare_orderly_example("demo")
+  orderly_pull_archive("other", "latest(parameter:nmin < 0.25)", root = root,
+                       remote = remote)
+  expect_equal(
+    orderly_list_archive(root),
+    data_frame(name = "other", id = dat$ids[[2]]))
+})
+
+
+test_that("pull archive using query and parameters", {
+  dat <- prepare_orderly_query_example()
+  remote <- orderly_remote_path(dat$root)
+
+  root <- prepare_orderly_example("demo")
+  expect_error(
+    orderly_pull_archive("other", "latest(parameter:nmin < n)", root = root,
+                         remote = remote),
+    "Query parameter 'n' not found in supplied parameters")
+
+  orderly_pull_archive("other", "latest(parameter:nmin < n)", root = root,
+                       remote = remote, parameters = list(n = 0.25))
+  expect_equal(
+    orderly_list_archive(root),
+    data_frame(name = "other", id = dat$ids[[2]]))
+})

--- a/tests/testthat/test-remote-path.R
+++ b/tests/testthat/test-remote-path.R
@@ -236,3 +236,16 @@ test_that("Fail to push if not supported", {
     orderly_push_archive("multifile-artefact", "latest", ours, remote = remote),
     "'push' is not supported by this remote")
 })
+
+
+test_that("fetch remote metadata", {
+  dat <- prepare_orderly_remote_example()
+  base <- normalizePath(file.path(dat$path_remote, "archive"))
+
+  expect_equal(
+    dat$remote$metadata("example", dat$id1),
+    file.path(base, "example", dat$id1, "orderly_run.rds"))
+  expect_equal(
+    dat$remote$metadata("name", "version"),
+    file.path(base, "name", "version", "orderly_run.rds"))
+})

--- a/tests/testthat/test-remote-path.R
+++ b/tests/testthat/test-remote-path.R
@@ -53,7 +53,7 @@ test_that("pull report: error not found", {
 
   expect_error(
     orderly_pull_archive("example", new_report_id(), path2, remote = remote),
-    "Unknown report")
+    "No versions of 'example' were found at")
 })
 
 

--- a/tests/testthat/test-remote.R
+++ b/tests/testthat/test-remote.R
@@ -53,6 +53,33 @@ test_that("pull dependencies", {
 })
 
 
+test_that("pull dependencies", {
+  path_local <- orderly_example("demo")
+  path_remote <- orderly_example("demo")
+  remote <- orderly_remote_path(path_remote)
+  orderly_pull_dependencies("use_dependency",
+                            root = path_local, remote = path_remote)
+
+  expect_log_message(
+    orderly_pull_dependencies("depend", root = dat$config,
+                              remote = dat$remote),
+    "\\[ pull\\s+ \\]  example:")
+  expect_equal(orderly_list_archive(dat$config),
+               data_frame(name = "example", id = dat$id2))
+
+  ## and update
+  id3 <- orderly_run("example", root = dat$path_remote, echo = FALSE)
+  orderly_commit(id3, root = dat$path_remote)
+  expect_log_message(
+    orderly_pull_dependencies("depend", root = dat$config,
+                              remote = dat$remote),
+    "\\[ pull\\s+ \\]  example:")
+  expect_equal(orderly_list_archive(dat$config),
+               data_frame(name = "example", id = c(dat$id2, id3)))
+})
+
+
+
 test_that("pull dependencies with implied name", {
   dat <- prepare_orderly_remote_example()
     expect_equal(nrow(orderly_list_archive(dat$config)), 0)

--- a/tests/testthat/test-remote.R
+++ b/tests/testthat/test-remote.R
@@ -53,33 +53,6 @@ test_that("pull dependencies", {
 })
 
 
-test_that("pull dependencies", {
-  path_local <- orderly_example("demo")
-  path_remote <- orderly_example("demo")
-  remote <- orderly_remote_path(path_remote)
-  orderly_pull_dependencies("use_dependency",
-                            root = path_local, remote = path_remote)
-
-  expect_log_message(
-    orderly_pull_dependencies("depend", root = dat$config,
-                              remote = dat$remote),
-    "\\[ pull\\s+ \\]  example:")
-  expect_equal(orderly_list_archive(dat$config),
-               data_frame(name = "example", id = dat$id2))
-
-  ## and update
-  id3 <- orderly_run("example", root = dat$path_remote, echo = FALSE)
-  orderly_commit(id3, root = dat$path_remote)
-  expect_log_message(
-    orderly_pull_dependencies("depend", root = dat$config,
-                              remote = dat$remote),
-    "\\[ pull\\s+ \\]  example:")
-  expect_equal(orderly_list_archive(dat$config),
-               data_frame(name = "example", id = c(dat$id2, id3)))
-})
-
-
-
 test_that("pull dependencies with implied name", {
   dat <- prepare_orderly_remote_example()
     expect_equal(nrow(orderly_list_archive(dat$config)), 0)


### PR DESCRIPTION
This PR allows pulling of reports based on a query (so rather than `latest`, we might pull on `latest(parameter:x == 1)`), as noticed by @lwhittles on the ncov work.