### PR TITLE
Capture error in failed run

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.2.3
+Version: 1.2.4
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# orderly 1.2.4
+
+* Error messages and stack traces are now preserved in `orderly.log` after a faied run; this primarily impacts the cli runner and then primarily when being run in parallel where the log is not printed to screen (VIMC-3841)
+
 # orderly 1.2.3
 
 * New function `orderly::orderly_workflow` allows users to run a "workflow" - a list of reports which to be run in order. Workflows are configured via a yml file in `workflows/` directory.

--- a/docker/build_website
+++ b/docker/build_website
@@ -9,8 +9,8 @@ HERE=$(dirname $0)
 ORDERLY_BASE="$TAG_SHA"
 ORDERLY_DEV="${PACKAGE_ORG}/${PACKAGE_NAME}-dev:${GIT_SHA}"
 
-USER_UID=`id -u`
-USER_GID=`id -g`
+USER_UID=$(id -u)
+USER_GID=$(id -g)
 USER_STR="${USER_UID}:${USER_GID}"
 
 DB_CONTAINER=orderly-db

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -922,8 +922,13 @@ test_that("logs from failed runs can still be written to file", {
   path <- prepare_orderly_example("minimal")
   on.exit(unlink(path, recursive = TRUE))
 
-  append_lines('stop("some error")',
-               file.path(path, "src", "example", "script.R"))
+  append_lines(
+    c("f <- function() g()",
+      "g <- function() h()",
+      "h <- function() stop('some error')",
+      "f()"),
+    file.path(path, "src", "example", "script.R"))
+
   expect_error(orderly_run_internal("example", root = path, echo = FALSE,
                                     capture_log = TRUE),
                "some error")
@@ -933,6 +938,12 @@ test_that("logs from failed runs can still be written to file", {
   expect_true(file.exists(draft_logs))
   log <- readLines(draft_logs)
   expect_true("[ name       ]  example" %in% log)
+
+  ## Error is found
+  expect_match(log, "Error: some error", all = FALSE)
+
+  ## traceback preserved
+  expect_match(log, "script\\.R#[0-9]+: f\\(\\)", all = FALSE)
 })
 
 

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -943,7 +943,8 @@ test_that("logs from failed runs can still be written to file", {
   expect_match(log, "Error: some error", all = FALSE)
 
   ## traceback preserved
-  expect_match(log, "script\\.R#[0-9]+: f\\(\\)", all = FALSE)
+  expect_match(log, "f()", all = FALSE, fixed = TRUE)
+  expect_match(log, "g()", all = FALSE, fixed = TRUE)
 })
 
 


### PR DESCRIPTION
This PR allows the error thrown in a failed orderly run to be recorded in the logfile - currently it is only printed to screen.  This has proved quite annoying in parallel runs. We also print the traceback here too