### PR TITLE
Bump orderly schema version number

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.2.5
+Version: 1.2.6
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/R/db2.R
+++ b/R/db2.R
@@ -8,7 +8,7 @@
 ## namespace/module feature so that implementation details can be
 ## hidden away a bit further.
 
-orderly_schema_version <- "1.1.26"
+orderly_schema_version <- "1.2.6"
 orderly_schema_table <- "orderly_schema"
 orderly_table_list <- "orderly_schema_tables"
 

--- a/R/db2.R
+++ b/R/db2.R
@@ -8,7 +8,7 @@
 ## namespace/module feature so that implementation details can be
 ## hidden away a bit further.
 
-orderly_schema_version <- "1.1.25"
+orderly_schema_version <- "1.1.26"
 orderly_schema_table <- "orderly_schema"
 orderly_table_list <- "orderly_schema_tables"
 


### PR DESCRIPTION
Forgot to bump this during #234 so currently user is not prompted to run `orderly::orderly_rebuild()` to fix `workflow` tables not existing.