### PR TITLE
VIMC-3941: Add orderly support for returning git commit info

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.2.7
+Version: 1.2.8
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# orderly 1.2.8
+
+* Add function `git_commits` to list commits for a particular branch from orderly_runner (VIMC-3941)
+
 # orderly 1.2.7
 
 * Add function `git_branches_no_merged` to get unmerged branches from orderly_runner (VIMC-3857)

--- a/R/git.R
+++ b/R/git.R
@@ -112,10 +112,16 @@ git_branches_no_merged <- function(root = NULL, include_master = FALSE) {
 ## This gets last 25 commits from master
 ## if not master then gets the unmerged commits (limit 25)
 git_commits <- function(branch, root = NULL) {
-  commits <- git_run(c("log", "--pretty='%h,%cd'",
-                       "--date=unix", "--max-count=25",
-                       sprintf("refs/remotes/origin/%s", branch)),
-                     root = root, check = TRUE)$output
+  if (branch == "master") {
+    args <- c("log", "--pretty='%h,%cd'", "--date=unix", "--max-count=25",
+              sprintf("refs/remotes/origin/%s", branch))
+  } else {
+    remote_branch <- sprintf("refs/remotes/origin/%s", branch)
+    args <- c("log", "--pretty='%h,%cd'", "--date=unix", "--max-count=25",
+              sprintf("--cherry refs/remotes/origin/master...", remote_branch),
+              remote_branch)
+  }
+  commits <- git_run(args, root = root, check = TRUE)$output
   commits <- utils::read.table(text = commits, stringsAsFactors = FALSE,
                                sep = ",", col.names = c("id", "date_time"))
   commits$age <- calculate_age(commits$date_time)

--- a/R/git.R
+++ b/R/git.R
@@ -102,22 +102,22 @@ git_branches_no_merged <- function(root = NULL, include_master = FALSE) {
     branches <- c(master, branches)
   }
   branches <- utils::read.table(text = branches, stringsAsFactors = FALSE,
-                                sep = ",",
-                                col.names = c("name", "last_commit"))
+                                sep = ",", col.names = c("name", "last_commit"))
   branches <- branches[branches$name != "gh-pages", ]
   branches$last_commit_age <- calculate_age(branches$last_commit)
   branches$last_commit <- convert_unix_to_iso_time(branches$last_commit)
   branches
 }
 
-## This gets last 25 commits from the remote
+## This gets last 25 commits from master
+## if not master then gets the unmerged commits (limit 25)
 git_commits <- function(branch, root = NULL) {
   commits <- git_run(c("log", "--pretty='%h,%cd'",
                        "--date=unix", "--max-count=25",
                        sprintf("refs/remotes/origin/%s", branch)),
                      root = root, check = TRUE)$output
-  commits <- utils::read.table(text = text, stringsAsFactors = FALSE, sep = ",",
-                               col.names = c("id", "date_time"))
+  commits <- utils::read.table(text = commits, stringsAsFactors = FALSE,
+                               sep = ",", col.names = c("id", "date_time"))
   commits$age <- calculate_age(commits$date_time)
   commits$date_time <- convert_unix_to_iso_time(commits$date_time)
   ## ID can be parsed as an integer by read.table if by chance the id contains

--- a/R/git.R
+++ b/R/git.R
@@ -101,8 +101,9 @@ git_branches_no_merged <- function(root = NULL, include_master = FALSE) {
                       root = root, check = TRUE)$output
     branches <- c(master, branches)
   }
-  branches <- read.table(text = branches, stringsAsFactors = FALSE, sep = ",",
-                         col.names = c("name", "last_commit"))
+  branches <- utils::read.table(text = branches, stringsAsFactors = FALSE,
+                                sep = ",",
+                                col.names = c("name", "last_commit"))
   branches <- branches[branches$name != "gh-pages", ]
   branches$last_commit_age <- calculate_age(branches$last_commit)
   branches$last_commit <- convert_unix_to_iso_time(branches$last_commit)
@@ -115,8 +116,8 @@ git_commits <- function(branch, root = NULL) {
                        "--date=unix", "--max-count=25",
                        sprintf("refs/remotes/origin/%s", branch)),
                      root = root, check = TRUE)$output
-  commits <- read.table(text = text, stringsAsFactors = FALSE, sep = ",",
-                     col.names = c("id", "date_time"))
+  commits <- utils::read.table(text = text, stringsAsFactors = FALSE, sep = ",",
+                               col.names = c("id", "date_time"))
   commits$age <- calculate_age(commits$date_time)
   commits$date_time <- convert_unix_to_iso_time(commits$date_time)
   ## ID can be parsed as an integer by read.table if by chance the id contains

--- a/R/git.R
+++ b/R/git.R
@@ -131,11 +131,3 @@ git_commits <- function(branch, root = NULL) {
   commits$id <- as.character(commits$id)
   commits
 }
-
-calculate_age <- function(times) {
-  rep(as.integer(Sys.time()), length(times)) - times
-}
-
-convert_unix_to_iso_time <- function(times) {
-  strftime(as.POSIXct(times, origin = "1970-01-01", tz = "UTC"))
-}

--- a/R/runner.R
+++ b/R/runner.R
@@ -210,6 +210,10 @@ orderly_runner_ <- R6::R6Class(
       git_branches_no_merged(self$path, include_master)
     },
 
+    git_commits = function(branch) {
+      git_commits(branch, self$path)
+    },
+
     cleanup = function(name = NULL, draft = TRUE, data = TRUE,
                        failed_only = FALSE) {
       orderly_cleanup(name = name, root = self$config, draft = draft,

--- a/R/util.R
+++ b/R/util.R
@@ -942,3 +942,11 @@ with_retry <- function(callback, n = 10, backoff = 1, match = NULL) {
   stop(sprintf("Failed to run command after %d attempts: %s", n,
                result$value$message), call. = FALSE)
 }
+
+calculate_age <- function(times) {
+  as.integer(as.numeric(Sys.time(), "secs")) - times
+}
+
+convert_unix_to_iso_time <- function(times) {
+  strftime(as.POSIXct(times, origin = "1970-01-01", tz = "UTC"))
+}

--- a/tests/testthat/test-git.R
+++ b/tests/testthat/test-git.R
@@ -270,3 +270,25 @@ test_that("gh-pages branch is ignored in list of not merged branches", {
   expect_equal(nrow(branches), 1)
   expect_true(!("gh-pages" %in% branches$name))
 })
+
+test_that("can get commit history for a branch", {
+  testthat::skip_on_cran()
+  path <- prepare_orderly_git_example()
+
+  commits <- git_commits("master", path[["local"]])
+  expect_equal(nrow(commits), 1)
+  expect_equal(colnames(commits), c("id", "date_time", "age"))
+  expect_type(commits$id, "character")
+  expect_match(commits$date_time,
+               "^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}$")
+  expect_type(commits$age, "integer")
+
+  other_commits <- git_commits("other", path[["local"]])
+  expect_equal(nrow(other_commits), 2)
+  expect_equal(colnames(other_commits), c("id", "date_time", "age"))
+  expect_type(other_commits$id, "character")
+  expect_match(other_commits$date_time,
+               "^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}$")
+  expect_equal(other_commits[2, ]$id, commits$id)
+  expect_equal(other_commits[2, ]$date_time, commits$date_time)
+})

--- a/tests/testthat/test-git.R
+++ b/tests/testthat/test-git.R
@@ -284,11 +284,11 @@ test_that("can get commit history for a branch", {
   expect_type(commits$age, "integer")
 
   other_commits <- git_commits("other", path[["local"]])
-  expect_equal(nrow(other_commits), 2)
+  expect_equal(nrow(other_commits), 1)
   expect_equal(colnames(other_commits), c("id", "date_time", "age"))
   expect_type(other_commits$id, "character")
   expect_match(other_commits$date_time,
                "^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}$")
-  expect_equal(other_commits[2, ]$id, commits$id)
-  expect_equal(other_commits[2, ]$date_time, commits$date_time)
+  ## Commit from master branch is not returned
+  expect_true(commits$id != other_commits$id)
 })

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -886,3 +886,11 @@ test_that("Can filter error messages", {
   expect_true(
     with_retry(g, n = 2, match = "Resource not ready", backoff = 0))
 })
+
+test_that("calculating age uses seconds", {
+  now <- Sys.time()
+  times <- c(as.integer(now - 10000), as.integer(now + 10000))
+  ## Stub Sys.time for easy of testing
+  mockery::stub(calculate_age, 'Sys.time', now)
+  expect_equal(calculate_age(times), c(10000, -10000))
+})

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -891,6 +891,6 @@ test_that("calculating age uses seconds", {
   now <- Sys.time()
   times <- c(as.integer(now - 10000), as.integer(now + 10000))
   ## Stub Sys.time for easy of testing
-  mockery::stub(calculate_age, 'Sys.time', now)
+  mockery::stub(calculate_age, "Sys.time", now)
   expect_equal(calculate_age(times), c(10000, -10000))
 })

--- a/tests/testthat/test-z-runner.R
+++ b/tests/testthat/test-z-runner.R
@@ -556,11 +556,11 @@ test_that("can get git commit info from runner", {
   expect_type(commits$age, "integer")
 
   other_commits <- runner$git_commits("other")
-  expect_equal(nrow(other_commits), 2)
+  expect_equal(nrow(other_commits), 1)
   expect_equal(colnames(other_commits), c("id", "date_time", "age"))
   expect_type(other_commits$id, "character")
   expect_match(other_commits$date_time,
                "^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}$")
-  expect_equal(other_commits[2, ]$id, commits$id)
-  expect_equal(other_commits[2, ]$date_time, commits$date_time)
+  ## Commit from master branch is not returned
+  expect_true(commits$id != other_commits$id)
 })

--- a/tests/testthat/test-z-runner.R
+++ b/tests/testthat/test-z-runner.R
@@ -541,3 +541,26 @@ test_that("can get git branch info from runner", {
     expect_equal(colnames(branches),
                  c("name", "last_commit", "last_commit_age"))
 })
+
+test_that("can get git commit info from runner", {
+  testthat::skip_on_cran()
+  path <- prepare_orderly_git_example()
+  runner <- orderly_runner(path[["local"]])
+
+  commits <- runner$git_commits("master")
+  expect_equal(nrow(commits), 1)
+  expect_equal(colnames(commits), c("id", "date_time", "age"))
+  expect_type(commits$id, "character")
+  expect_match(commits$date_time,
+               "^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}$")
+  expect_type(commits$age, "integer")
+
+  other_commits <- runner$git_commits("other")
+  expect_equal(nrow(other_commits), 2)
+  expect_equal(colnames(other_commits), c("id", "date_time", "age"))
+  expect_type(other_commits$id, "character")
+  expect_match(other_commits$date_time,
+               "^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}$")
+  expect_equal(other_commits[2, ]$id, commits$id)
+  expect_equal(other_commits[2, ]$date_time, commits$date_time)
+})


### PR DESCRIPTION
This PR will

* Add a function `git_commits` to orderly_runner which takes parameter branch which if master returns the last 25 commits, otherwise returns the commits not merged into master (limit 25)

Do we want to limit to return last 25 commits or limit based on some time period instead?