### PR TITLE
VIMC-3945: Add orderly support for listing available reports for a particular git branch and commit

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.2.8
+Version: 1.2.9
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # orderly 1.2.8
 
+* Add function `get_reports` to list reports available for a particular branch and commit from orderly_runner (VIMC-3945)
+
+# orderly 1.2.8
+
 * Add function `git_commits` to list commits for a particular branch from orderly_runner (VIMC-3941)
 
 # orderly 1.2.7

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# orderly 1.2.8
+# orderly 1.2.9
 
 * Add function `get_reports` to list reports available for a particular branch and commit from orderly_runner (VIMC-3945)
 

--- a/R/git.R
+++ b/R/git.R
@@ -118,7 +118,7 @@ git_commits <- function(branch, root = NULL) {
   } else {
     remote_branch <- sprintf("refs/remotes/origin/%s", branch)
     args <- c("log", "--pretty='%h,%cd'", "--date=unix", "--max-count=25",
-              sprintf("--cherry refs/remotes/origin/master...", remote_branch),
+              sprintf("--cherry refs/remotes/origin/master..%s", remote_branch),
               remote_branch)
   }
   commits <- git_run(args, root = root, check = TRUE)$output

--- a/R/git.R
+++ b/R/git.R
@@ -132,6 +132,7 @@ git_commits <- function(branch, root = NULL) {
   commits
 }
 
+
 get_reports <- function(branch, commit, root) {
   if (branch == "master") {
     ## Get all reports in commit if on master branch

--- a/R/git.R
+++ b/R/git.R
@@ -118,7 +118,7 @@ git_commits <- function(branch, root = NULL) {
   } else {
     remote_branch <- sprintf("refs/remotes/origin/%s", branch)
     args <- c("log", "--pretty='%h,%cd'", "--date=unix", "--max-count=25",
-              sprintf("--cherry refs/remotes/origin/master..%s", remote_branch),
+              paste0("--cherry refs/remotes/origin/master...", remote_branch),
               remote_branch)
   }
   commits <- git_run(args, root = root, check = TRUE)$output

--- a/R/git.R
+++ b/R/git.R
@@ -139,3 +139,17 @@ calculate_age <- function(times) {
 convert_unix_to_iso_time <- function(times) {
   strftime(as.POSIXct(times, origin = "1970-01-01", tz = "UTC"))
 }
+
+get_reports <- function(branch, commit, root) {
+  if (branch == "master") {
+    ## Get all reports in commit if on master branch
+    args <- c("ls-tree", "--name-only", "-d", sprintf("%s:src/", commit))
+  } else {
+    ## Get only files which have changed from master copy
+    ## Note this could inclue files as well as directories.
+    ## How can we exclude them?
+    args <- c("diff-tree", "--name-only",
+              sprintf("refs/remotes/origin/master:src/..%s:src/", commit))
+  }
+  git_run(args, root = root, check = TRUE)$output
+}

--- a/R/runner.R
+++ b/R/runner.R
@@ -214,6 +214,10 @@ orderly_runner_ <- R6::R6Class(
       git_commits(branch, self$path)
     },
 
+    get_reports = function(branch, commit) {
+      get_reports(branch, commit, self$path)
+    },
+
     cleanup = function(name = NULL, draft = TRUE, data = TRUE,
                        failed_only = FALSE) {
       orderly_cleanup(name = name, root = self$config, draft = draft,

--- a/R/util.R
+++ b/R/util.R
@@ -950,3 +950,15 @@ calculate_age <- function(times) {
 convert_unix_to_iso_time <- function(times) {
   strftime(as.POSIXct(times, origin = "1970-01-01", tz = "UTC"))
 }
+
+first_dirname <- function(paths) {
+  first_dir <- function(path) {
+    if (basename(path) == path) {
+      dir <- path
+    } else {
+      dir <- first_dirname(dirname(path))
+    }
+    dir
+  }
+  vcapply(paths, first_dir, USE.NAMES = FALSE)
+}

--- a/tests/testthat/test-git.R
+++ b/tests/testthat/test-git.R
@@ -344,7 +344,7 @@ test_that("get_reports only shows one sided changes", {
 
   ## At the moment we have
   ##
-  ## master  (A)-(B)
+  ## master  (A)-(B)        #nolint
   ##          \
   ## other    (X)
   ## Where B is a commit without a report in it
@@ -352,7 +352,7 @@ test_that("get_reports only shows one sided changes", {
   ## We want to test divergent branches where both branches contain a report
   ## which doesn't exist on the other branch.
   ## Create something like
-  ## master  (A)-(B)-(C)
+  ## master  (A)-(B)-(C)    #nolint
   ##          \
   ## other    (X)
   ##

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -894,3 +894,9 @@ test_that("calculating age uses seconds", {
   mockery::stub(calculate_age, "Sys.time", now)
   expect_equal(calculate_age(times), c(10000, -10000))
 })
+
+test_that("first_dirname gets the first dir part of the filename", {
+  expect_equal(
+    first_dirname(c("test/file/name.txt", "test", ".", "testing/file.txt")),
+    c("test", "test", ".", "testing"))
+})

--- a/tests/testthat/test-z-runner.R
+++ b/tests/testthat/test-z-runner.R
@@ -564,3 +564,19 @@ test_that("can get git commit info from runner", {
   ## Commit from master branch is not returned
   expect_true(commits$id != other_commits$id)
 })
+
+test_that("can get report list from runner", {
+  testthat::skip_on_cran()
+  path <- prepare_orderly_git_example()
+  runner <- orderly_runner(path[["local"]])
+
+  commits <- runner$git_commits("master")
+  expect_equal(nrow(commits), 1)
+  reports <- runner$get_reports("master", commits$id)
+  expect_equal(reports, c("global", "minimal"))
+
+  other_commits <- git_commits("other", path[["local"]])
+  expect_equal(nrow(other_commits), 1)
+  other_reports <- get_reports("other", other_commits$id, path[["local"]])
+  expect_equal(other_reports, c("other"))
+})


### PR DESCRIPTION
Couple of things to note here this follows on from #241

This fixes a bug in #241 and adds a test for it. I've left that in here as the test which recreates it is wrapped up with some testing of the feature added here. But I can separate out if you prefer.

