### PR TITLE
VIMC-3953: Add function to get parameters for a report at a commit id

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.2.9
+Version: 1.2.10
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# orderly 1.2.10
+
+* Add function `get_report_parameters` to list parameters for a report at a particular commit id (VIMC-3953)
+
 # orderly 1.2.9
 
 * Add function `get_reports` to list reports available for a particular branch and commit from orderly_runner (VIMC-3945)

--- a/R/git.R
+++ b/R/git.R
@@ -167,13 +167,13 @@ get_report_parameters <- function(report, commit, root) {
   },
   error = function(e) {
     stop(sprintf(
-      "Failed to get report parameters for report %s and commit %s:\n%s",
+      "Failed to get report parameters for report '%s' and commit '%s':\n%s",
       report, commit, e$message))
   })
   tryCatch(
     report_cfg <- yaml_load(yml$output),
     error = function(e) {
-      stop(sprintf("Failed to parse yml for report %s and commit %s:\n%s",
+      stop(sprintf("Failed to parse yml for report '%s' and commit '%s':\n%s",
            report, commit, e$message))
     }
   )

--- a/R/git.R
+++ b/R/git.R
@@ -155,3 +155,11 @@ get_reports <- function(branch, commit, root) {
   }
   reports
 }
+
+get_report_parameters <- function(report, commit, root) {
+  yml <- git_run(
+    c("show", paste0(commit, file.path(":src", report, "orderly.yml"))),
+    root = root, check = TRUE)$output
+  report_cfg <- yaml_load(yml)
+  report_cfg$parameters
+}

--- a/R/runner.R
+++ b/R/runner.R
@@ -218,6 +218,10 @@ orderly_runner_ <- R6::R6Class(
       get_reports(branch, commit, self$path)
     },
 
+    get_report_parameters = function(report, commit) {
+      get_report_parameters(report, commit, self$path)
+    },
+
     cleanup = function(name = NULL, draft = TRUE, data = TRUE,
                        failed_only = FALSE) {
       orderly_cleanup(name = name, root = self$config, draft = draft,

--- a/tests/testthat/test-git.R
+++ b/tests/testthat/test-git.R
@@ -379,3 +379,45 @@ test_that("get_reports only shows one sided changes", {
   other_reports <- get_reports("other", other_commits$id, path[["local"]])
   expect_equal(other_reports, "other")
 })
+
+test_that("can get parameters from a report", {
+  testthat::skip_on_cran()
+  path <- prepare_orderly_git_example()
+
+  ## Write some parameters lines to the upstream yml and commit it
+  origin_yml <- file.path(path[["origin"]], "src", "minimal", "orderly.yml")
+  yml <- readLines(origin_yml)
+  text <- c(yml, c(
+    "parameters:",
+    "  a: ~",
+    "  b:",
+    "    default: test",
+    "  c:",
+    "    default: 2"
+  ))
+  writeLines(text, origin_yml)
+  invisible(git_run(c("add", "."), root = path[["origin"]]))
+  invisible(git_run(c("commit", "-m", "'add parameters'"),
+                    root = path[["origin"]]))
+  invisible(git_fetch(path[["local"]]))
+
+  commits <- git_commits("master", path[["local"]])
+  expect_equal(nrow(commits), 3)
+  params <- get_report_parameters("minimal", commits$id[1], path[["local"]])
+  expect_equal(params, list(
+    a = NULL,
+    b = list(
+      default = "test"
+    ),
+    c = list(
+      default = 2
+    )
+  ))
+  params <- get_report_parameters("global", commits$id[1], path[["local"]])
+  expect_equal(params, NULL)
+
+  other_commits <- git_commits("other", path[["local"]])
+  expect_equal(nrow(other_commits), 1)
+  params <- get_report_parameters("other", other_commits$id, path[["local"]])
+  expect_equal(params, list(nmin = NULL))
+})

--- a/tests/testthat/test-git.R
+++ b/tests/testthat/test-git.R
@@ -424,8 +424,8 @@ test_that("can get parameters from a report", {
 
 test_that("get_report_parameters handles errors", {
   expect_error(
-    get_report_parameters("report1", "commit1", "."),
-    "Failed to get report parameters for report report1 and commit commit1:")
+    get_report_parameters("rep1", "commit1", "."),
+    "Failed to get report parameters for report 'rep1' and commit 'commit1':")
 
   mockery::stub(get_report_parameters, "git_run", list(
     success = FALSE,
@@ -433,9 +433,9 @@ test_that("get_report_parameters handles errors", {
     output = NULL
   ))
   expect_error(
-    get_report_parameters("report1", "commit1", "."),
+    get_report_parameters("rep1", "commit1", "."),
     paste0(
-      "Failed to get report parameters for report report1 and commit commit1:",
+      "Failed to get report parameters for report 'rep1' and commit 'commit1':",
       "\nNon zero exit code from git"))
 
   mockery::stub(get_report_parameters, "git_run", list(
@@ -446,6 +446,6 @@ test_that("get_report_parameters handles errors", {
   expect_error(
     get_report_parameters("report1", "commit1", "."),
     paste0(
-      "Failed to parse yml for report report1 and commit commit1:",
+      "Failed to parse yml for report 'report1' and commit 'commit1':",
       "\nParser error: "))
 })

--- a/tests/testthat/test-git.R
+++ b/tests/testthat/test-git.R
@@ -421,3 +421,31 @@ test_that("can get parameters from a report", {
   params <- get_report_parameters("other", other_commits$id, path[["local"]])
   expect_equal(params, list(nmin = NULL))
 })
+
+test_that("get_report_parameters handles errors", {
+  expect_error(
+    get_report_parameters("report1", "commit1", "."),
+    "Failed to get report parameters for report report1 and commit commit1:")
+
+  mockery::stub(get_report_parameters, "git_run", list(
+    success = FALSE,
+    code = 1,
+    output = NULL
+  ))
+  expect_error(
+    get_report_parameters("report1", "commit1", "."),
+    paste0(
+      "Failed to get report parameters for report report1 and commit commit1:",
+      "\nNon zero exit code from git"))
+
+  mockery::stub(get_report_parameters, "git_run", list(
+    success = TRUE,
+    code = 0,
+    output = "[invalid_yml"
+  ))
+  expect_error(
+    get_report_parameters("report1", "commit1", "."),
+    paste0(
+      "Failed to parse yml for report report1 and commit commit1:",
+      "\nParser error: "))
+})

--- a/tests/testthat/test-z-runner.R
+++ b/tests/testthat/test-z-runner.R
@@ -580,3 +580,19 @@ test_that("can get report list from runner", {
   other_reports <- get_reports("other", other_commits$id, path[["local"]])
   expect_equal(other_reports, c("other"))
 })
+
+test_that("can get parameters list from runner", {
+  testthat::skip_on_cran()
+  path <- prepare_orderly_git_example()
+  runner <- orderly_runner(path[["local"]])
+
+  commits <- runner$git_commits("master")
+  expect_equal(nrow(commits), 1)
+  params <- runner$get_report_parameters("minimal", commits$id)
+  expect_equal(params, NULL)
+
+  other_commits <- git_commits("other", path[["local"]])
+  expect_equal(nrow(other_commits), 1)
+  params <- runner$get_report_parameters("other", other_commits$id)
+  expect_equal(params, list(nmin = NULL))
+})


### PR DESCRIPTION
Diff here noisy again as this builds on #242

Plan here is to return as a parsed list without any further processing. Then do the conversion from this list representation into the format we want to return from the endpoint in orderly.server

One thing to note is that I see there is an old format for the parameters
```
parameters:
  - param1
  - param2
```

Which is deprecated but still supported - there is some conversion code around. This currently doesn't support that but if we want to then I should probably do the conversion from the migration step here before returning it to orderly.server.