### PR TITLE
vimc-4032: Allow orderly_new to work when src is missing

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.2.13
+Version: 1.2.14
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# orderly 1.2.14
+
+* `orderly::orderly_new()` works in an orderly repo that does not (yet) have a `src/` directory (VIMC-4032)
+
 # orderly 1.2.13
 
 * Remove `orderly::orderly_runner` which has been moved to `vimc/orderly.server` (VIMC-4073)

--- a/R/new.R
+++ b/R/new.R
@@ -58,19 +58,17 @@ orderly_new <- function(name, root = NULL, locate = TRUE, quiet = FALSE,
   if (grepl("[[:space:]]", name)) {
     stop("'name' cannot contain spaces")
   }
-
   dest <- file.path(path_src(config$root), name)
   if (file.exists(dest)) {
     stop(sprintf("A report already exists called '%s'", name))
   }
-
-  dir.create(path_src(config$root), FALSE, TRUE)
 
   if (is.null(template)) {
     template <-
       if (has_template(config$root, "default")) "default" else "system"
   }
 
+  dir.create(path_src(config$root), FALSE, TRUE)
   if (template == "system") {
     orderly_new_system(dest, config)
   } else {

--- a/R/new.R
+++ b/R/new.R
@@ -58,10 +58,13 @@ orderly_new <- function(name, root = NULL, locate = TRUE, quiet = FALSE,
   if (grepl("[[:space:]]", name)) {
     stop("'name' cannot contain spaces")
   }
+
   dest <- file.path(path_src(config$root), name)
   if (file.exists(dest)) {
     stop(sprintf("A report already exists called '%s'", name))
   }
+
+  dir.create(path_src(config$root), FALSE, TRUE)
 
   if (is.null(template)) {
     template <-

--- a/tests/testthat/test-new.R
+++ b/tests/testthat/test-new.R
@@ -115,3 +115,11 @@ test_that("missing templates are an error", {
     "Did not find file 'template/foo/orderly.yml' within orderly root")
   expect_false(file.exists(file.path(path, "src", "testing")))
 })
+
+
+test_that("can create src directory if needed", {
+  path <- prepare_orderly_example("minimal")
+  unlink(file.path(path, "src"), recursive = TRUE)
+  orderly_new("test", root = path)
+  expect_true(file.exists(file.path(path, "src", "test", "orderly.yml")))
+})


### PR DESCRIPTION
Allows `orderly::orderly_new()` to work when src/ is entirely missing. Reported in the ncov work. Obviously not a very common situation, but it's an obscure enough error message:

```
> orderly_new("test", root = path)
Error in file_copy(template, dest_yml) : Error copying files
In addition: Warning messages:
1: In dir.create(dest) :
  cannot create dir '/private/var/folders/z7/c2kx_kt96zn2tt_6179bkc4m0000gp/T/RtmpLrWlCi/file5964278f5e38/src/test', reason 'No such file or directory'
2: In file.create(to[okay]) :
  cannot create file '/private/var/folders/z7/c2kx_kt96zn2tt_6179bkc4m0000gp/T/RtmpLrWlCi/file5964278f5e38/src/test/orderly.yml', reason 'No such file or directory'
```