### PR TITLE
vimc-4131: Upgrade R

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocker/r-ver:3.6.2
+FROM rocker/r-ver:4.0.2
 
 RUN apt-get update && apt-get -y install --no-install-recommends \
   git \

--- a/docker/Rprofile.site
+++ b/docker/Rprofile.site
@@ -1,2 +1,4 @@
-options(repos = c(CRAN = "https://cloud.r-project.org"),
-        download.file.method = "libcurl")
+options(repos = c(CRAN = 'https://packagemanager.rstudio.com/all/__linux__/focal/latest'), download.file.method = 'libcurl')
+options(HTTPUserAgent = sprintf("R/%s R (%s)", getRversion(),
+                 paste(getRversion(), R.version$platform,
+                       R.version$arch, R.version$os)))


### PR DESCRIPTION
XML is not installing, causing other packages not to install, as it is the first thing to declare a dependency on 4.0.0 or more. I think that we're probably ok to upgrade now it's been out for a couple of months, though I think it breaks stan (we don't use that anywhere, and stan is a fragile thing to get running anyway unfortunately)