### PR TITLE
vimc-4135: Correct handling of parameter value defaults in dependency resolution

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.2.14
+Version: 1.2.15
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# orderly 1.2.15
+
+* Fixes bug where default parameter values were not used in resolving query dependencies (VIMC-4135)
+
 # orderly 1.2.14
 
 * `orderly::orderly_new()` works in an orderly repo that does not (yet) have a `src/` directory (VIMC-4032)

--- a/R/orderly_version.R
+++ b/R/orderly_version.R
@@ -521,7 +521,8 @@ orderly_version <- R6::R6Class(
       private$tags <- union(private$recipe$tags,
                             recipe_validate_tags(tags, private$config, NULL))
       private$depends <-
-        private$recipe$resolve_dependencies(use_draft, parameters, remote)
+        private$recipe$resolve_dependencies(use_draft, private$parameters,
+                                            remote)
     },
 
     ## Prepare phase of a report - create id, load changelog and


### PR DESCRIPTION
Long title, short fix. We were not allowing parameters to use their default values in resolving dependencies. From the ticket:

if we have a report A with parameters x and a report B that uses it and has parameter y, and depends like:

```
latest(parameter:x == y)
```

then the query will fail unless the parameter is passed explicitly (i.e., the default is ignored)

This was/is affecting a few ncov reports