### PR TITLE
vimc-4354: Don't use file.rename when it may cross filesystems

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.2.16
+Version: 1.2.17
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# orderly 1.2.17
+
+* Fixes bug where `orderly_bundle_pack` failed when the orderly tree and temporary directory were on different filesystems (VIMC-4354)
+
 # orderly 1.2.16
 
 * Fixes bug where `orderly_bundle_run` failed when using a relative path for a working directory (VIMC-4337)

--- a/R/orderly_version.R
+++ b/R/orderly_version.R
@@ -476,7 +476,11 @@ orderly_version <- R6::R6Class(
       saveRDS(manifest, file.path(path_meta, "manifest.rds"))
       saveRDS(info, file.path(path_meta, "info.rds"))
       saveRDS(session_info(), file.path(path_meta, "session.rds"))
-      file.rename(private$workdir, path_pack)
+      ## If we're on the same filesystem we could move the file with
+      ## fs::file_move or file.rename, but the temporary directory may
+      ## easily be in a different filesystem to the work tree.
+      fs::dir_copy(private$workdir, path_pack)
+      fs::dir_delete(private$workdir)
       zip <- zip_dir(dest_id)
 
       unlink(dest_id, recursive = TRUE)


### PR DESCRIPTION
`file.rename()` is not valid across filesystems, and that's the situation here when orderly is running in a container in orderlyweb.

Unfortunately, the default R behaviour here is to warn and continue, so have used fs functions instead. I've opened VIMC-4357 to move all the base file functions over (after talking with Jenny Bryan, I'm motivated to do this)