### PR TITLE
vimc-4382: Allow orderly_bundle_import to work with arbitrary filename

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.2.17
+Version: 1.2.18
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# orderly 1.2.18
+
+* Allow `orderly_bundle_import` to accept a filename that has been renamed from `<id>.zip`. While this is not generally desireable, it may be needed for some workflows (VIMC-4382)
+
 # orderly 1.2.17
 
 * Fixes bug where `orderly_bundle_pack` failed when the orderly tree and temporary directory were on different filesystems (VIMC-4354)

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -199,13 +199,15 @@ orderly_bundle_complete <- function(path) {
 
 
 orderly_bundle_info <- function(path) {
+  id <- fs::path_split(zip::zip_list(path)$filename[[1]])[[1]]
+
   tmp <- tempfile()
   dir_create(tmp)
   on.exit(unlink(tmp))
-  id <- sub("\\.zip$", "", basename(path))
+
   tryCatch(
-    zip::unzip(path, sprintf("%s/meta/info.rds", id),
-               junkpaths = TRUE, exdir = tmp),
+    zip::unzip(path, sprintf("%s/meta/info.rds", id), exdir = tmp,
+               junkpaths = TRUE),
     error = function(e)
       stop(sprintf("Failed to extract bundle info from '%s'\n(%s)",
                    path, e$message), call. = FALSE))

--- a/tests/testthat/test-bundle.R
+++ b/tests/testthat/test-bundle.R
@@ -230,8 +230,8 @@ test_that("can't import an unrun bundle", {
 
 test_that("sensible error when given junk input", {
   path <- orderly::orderly_example("minimal")
-  tmp <- tempfile()
-  file.create(tmp)
+  tmp <- tempfile(fileext = ".zip")
+  zip_dir(file.path(path, "src"), tmp)
   expect_error(
     orderly_bundle_import(tmp, root = path),
     "Failed to extract bundle info from '.*'")

--- a/tests/testthat/test-bundle.R
+++ b/tests/testthat/test-bundle.R
@@ -256,3 +256,19 @@ test_that("can run a bundle from a relative path", {
   ## Just ensure that we run without error
   expect_equal(length(dir(workdir)), 1)
 })
+
+
+test_that("Can rename a bundle before import", {
+  path <- prepare_orderly_example("minimal")
+  on.exit(unlink(path, recursive = TRUE))
+
+  path_bundles <- tempfile()
+  res <- orderly_bundle_pack(path_bundles, "example", root = path)
+  ans <- orderly_bundle_run(res$path, echo = FALSE)
+  tmp <- tempfile()
+  on.exit(unlink(tmp), add = TRUE)
+  file_copy(ans$path, tmp)
+  expect_true(orderly_bundle_import(tmp, root = path))
+  expect_equal(orderly_list_archive(path),
+               data_frame(name = "example", id = res$id))
+})


### PR DESCRIPTION
Currently we assume filename is of form `<id>.zip` which will not be the case in (say) orderly.server. This PR relaxes this and works out the filename from the file itself.