### PR TITLE
Sanitise name for orderly_pull_archive

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.2.19
+Version: 1.2.20
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# orderly 1.2.20
+
+* `orderly_pull_archive` is now more tolerant of trailing slashes (#260)
+
 # orderly 1.2.19
 
 * New functions `orderly_bundle_pack_remote` and `orderly_bundle_import_remote` which create a bundle from a remote and return the completed bundle back to the remote (VIMC-4457)

--- a/R/develop.R
+++ b/R/develop.R
@@ -130,11 +130,11 @@ orderly_develop_location <- function(name, root, locate) {
     }
     name <- rel[[2L]]
   } else {
-    if (grepl("^src/.+", name)) {
-      name <- sub("^src/", "", name)
+    if (grepl("^src[/\\].+", name)) {
+      name <- sub("^src[/\\]+", "", name)
     }
-    if (grepl("/$", name)) {
-      name <- sub("/$", "", name)
+    if (grepl("[/\\]$", name)) {
+      name <- sub("[/\\]+$", "", name)
     }
   }
 

--- a/R/remote.R
+++ b/R/remote.R
@@ -102,7 +102,9 @@ orderly_pull_dependencies <- function(name = NULL, root = NULL, locate = TRUE,
 orderly_pull_archive <- function(name, id = "latest", root = NULL,
                                  locate = TRUE, remote = NULL,
                                  parameters = NULL) {
-  config <- orderly_config(root, locate)
+  loc <- orderly_develop_location(name, root, locate)
+  name <- loc$name
+  config <- loc$config
   config <- check_orderly_archive_version(config)
 
   remote <- get_remote(remote, config)

--- a/tests/testthat/test-develop.R
+++ b/tests/testthat/test-develop.R
@@ -74,6 +74,24 @@ test_that("orderly_develop_location", {
 })
 
 
+test_that("orderly_develop_location strips trailing slashes of all types", {
+  path <- prepare_orderly_example("minimal")
+  expect_equal(orderly_develop_location("foo/", path, FALSE)$name, "foo")
+  expect_equal(orderly_develop_location("foo//", path, FALSE)$name, "foo")
+  expect_equal(orderly_develop_location("foo\\", path, FALSE)$name, "foo")
+  expect_equal(orderly_develop_location("foo\\\\", path, FALSE)$name, "foo")
+})
+
+
+test_that("orderly_develop_location strips src with any slash", {
+  path <- prepare_orderly_example("minimal")
+  expect_equal(orderly_develop_location("src/foo", path, FALSE)$name, "foo")
+  expect_equal(orderly_develop_location("src//foo", path, FALSE)$name, "foo")
+  expect_equal(orderly_develop_location("src\\foo", path, FALSE)$name, "foo")
+  expect_equal(orderly_develop_location("src\\\\foo", path, FALSE)$name, "foo")
+})
+
+
 test_that("status can detect dependencies", {
   path <- prepare_orderly_example("demo")
   name <- "use_dependency"


### PR DESCRIPTION
See VIMC-4485 for an issue about renaming the internal function here.

Fixes #260 
