### PR TITLE
Make orderly_pull_archive parameter arg more behaviour more predictable

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.2.20
+Version: 1.2.21
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# orderly 1.2.21
+
+* Make `orderly_pull_archive` parameter arg more predictable - it will now construct a query from parameters if id = `latest` (VIMC-4492)
+
 # orderly 1.2.20
 
 * `orderly_pull_archive` is now more tolerant of trailing slashes (#260)

--- a/R/query_search.R
+++ b/R/query_search.R
@@ -450,3 +450,26 @@ remote_report_metadata <- function(name, remote, config) {
   candidates$type <- "remote"
   candidates[c("id", "type", "path")]
 }
+
+
+build_query <- function(parameters) {
+  withCallingHandlers({
+    lapply(names(parameters), function(name) {
+      assert_scalar(parameters[[name]], name)
+    })
+  }, error = function(e) {
+    e$message <- paste0("Failed to build default query:\n", e$message)
+    stop(e)
+  })
+  quote_character <- function(x) {
+    out <- x
+    if (is.character(x)) {
+      out <- paste0('"', x, '"')
+    }
+    out
+  }
+  params <- lapply(parameters, quote_character)
+  sprintf("latest(%s)",
+          paste(sprintf("parameter:%s == %s", names(params), unlist(params)),
+                collapse = " && "))
+}

--- a/R/query_search.R
+++ b/R/query_search.R
@@ -453,23 +453,6 @@ remote_report_metadata <- function(name, remote, config) {
 
 
 build_query <- function(parameters) {
-  withCallingHandlers({
-    lapply(names(parameters), function(name) {
-      assert_scalar(parameters[[name]], name)
-    })
-  }, error = function(e) {
-    e$message <- paste0("Failed to build default query:\n", e$message)
-    stop(e)
-  })
-  quote_character <- function(x) {
-    out <- x
-    if (is.character(x)) {
-      out <- paste0('"', x, '"')
-    }
-    out
-  }
-  params <- lapply(parameters, quote_character)
-  sprintf("latest(%s)",
-          paste(sprintf("parameter:%s == %s", names(params), unlist(params)),
-                collapse = " && "))
+  params <- sprintf("parameter:%s == %s", names(parameters), names(parameters))
+  sprintf("latest(%s)", paste(params, collapse = " && "))
 }

--- a/R/remote.R
+++ b/R/remote.R
@@ -58,9 +58,12 @@
 ##'   will be passed through to all dependencies). If passed with
 ##'   \code{id = "latest"} then query will be constructed to pull latest
 ##'   version of report with report parameters equal to those passed e.g. if
-##'   \code{parameters = list(nmin = 0.5, nmax = 1)} this will pull latest
-##'   report run where \code{nmin == 0.5 && nmax == 1}. For anything more
-##'   complicated than equality and && connectors use \code{id} to build
+##'   \code{parameters = list(nmin = 0.5, nmax = 1)} this is equivalent
+##'   to providing the query
+##'   \code{latest(parameter:nmin == nmin && parameter:nmax == nmax)}.
+##'   It will pull latest report run where \code{nmin == 0.5 && nmax == 1}.
+##'   For anything more complicated than equality and && connectors use
+##'   \code{id} to build
 ##'   the query.
 ##'
 ##' @inheritParams orderly_list
@@ -108,9 +111,7 @@ orderly_pull_dependencies <- function(name = NULL, root = NULL, locate = TRUE,
 ##'   \code{orderly_search} see \code{\link{orderly_search}} for details.
 ##'   If \code{id = "latest"} and parameters are not NULL then query will
 ##'   be constructed to pull latest version of report  with report parameters
-##'   equal to those passed e.g. if
-##'   \code{parameters = list(nmin = 0.5, nmax = 1)} this will pull latest
-##'   report run where \code{nmin == 0.5 && nmax == 1}.
+##'   equal to those passed see parameters for details.
 orderly_pull_archive <- function(name, id = "latest", root = NULL,
                                  locate = TRUE, remote = NULL,
                                  parameters = NULL) {

--- a/R/remote.R
+++ b/R/remote.R
@@ -49,13 +49,19 @@
 ##'   for this orderly repository is used - by default that is the
 ##'   first listed remote.
 ##'
-##' @param parameters Parameters to pass through when doing depenency
+##' @param parameters Parameters to pass through when doing dependency
 ##'   resolution.  If you are using a query for \code{id} that
 ##'   involves a parameter (e.g., \code{latest(parameter:x == p)}) you
 ##'   will need to pass in the parameters here.  Similarly, if you are
 ##'   pulling a report that uses query dependencies that reference
 ##'   parameters you need to pass them here (the same parameter set
-##'   will be passed through to all dependencies).
+##'   will be passed through to all dependencies). If passed with
+##'   \code{id = "latest"} then query will be constructed to pull latest
+##'   version of report with report parameters equal to those passed e.g. if
+##'   \code{parameters = list(nmin = 0.5, nmax = 1)} this will pull latest
+##'   report run where \code{nmin == 0.5 && nmax == 1}. For anything more
+##'   complicated than equality and && connectors use \code{id} to build
+##'   the query.
 ##'
 ##' @inheritParams orderly_list
 ##' @export
@@ -97,8 +103,14 @@ orderly_pull_dependencies <- function(name = NULL, root = NULL, locate = TRUE,
 ##' @export
 ##' @rdname orderly_pull_dependencies
 ##'
-##' @param id The identifier (for \code{orderly_pull_archive}).  The default is
-##'   to use the latest report.
+##' @param id The identifier (for \code{orderly_pull_archive}).  The default
+##'   is to use the latest report.  This can be a query string to
+##'   \code{orderly_search} see \code{\link{orderly_search}} for details.
+##'   If \code{id = "latest"} and parameters are not NULL then query will
+##'   be constructed to pull latest version of report  with report parameters
+##'   equal to those passed e.g. if
+##'   \code{parameters = list(nmin = 0.5, nmax = 1)} this will pull latest
+##'   report run where \code{nmin == 0.5 && nmax == 1}.
 orderly_pull_archive <- function(name, id = "latest", root = NULL,
                                  locate = TRUE, remote = NULL,
                                  parameters = NULL) {
@@ -116,8 +128,14 @@ orderly_pull_archive <- function(name, id = "latest", root = NULL,
   }
 
   if (id == "latest") {
-    id <- latest_id(v)
-  } else if (id_is_query(id)) {
+    if (!is.null(parameters)) {
+      id <- build_query(parameters)
+    } else {
+      id <- latest_id(v)
+    }
+  }
+
+  if (id_is_query(id)) {
     id <- orderly_search(id, name, parameters, root = root, remote = remote)
   }
 

--- a/man/orderly_pull_dependencies.Rd
+++ b/man/orderly_pull_dependencies.Rd
@@ -63,9 +63,12 @@ parameters you need to pass them here (the same parameter set
 will be passed through to all dependencies). If passed with
 \code{id = "latest"} then query will be constructed to pull latest
 version of report with report parameters equal to those passed e.g. if
-\code{parameters = list(nmin = 0.5, nmax = 1)} this will pull latest
-report run where \code{nmin == 0.5 && nmax == 1}. For anything more
-complicated than equality and && connectors use \code{id} to build
+\code{parameters = list(nmin = 0.5, nmax = 1)} this is equivalent
+to providing the query
+\code{latest(parameter:nmin == nmin && parameter:nmax == nmax)}.
+It will pull latest report run where \code{nmin == 0.5 && nmax == 1}.
+For anything more complicated than equality and && connectors use
+\code{id} to build
 the query.}
 
 \item{id}{The identifier (for \code{orderly_pull_archive}).  The default
@@ -73,9 +76,7 @@ is to use the latest report.  This can be a query string to
 \code{orderly_search} see \code{\link{orderly_search}} for details.
 If \code{id = "latest"} and parameters are not NULL then query will
 be constructed to pull latest version of report  with report parameters
-equal to those passed e.g. if
-\code{parameters = list(nmin = 0.5, nmax = 1)} this will pull latest
-report run where \code{nmin == 0.5 && nmax == 1}.}
+equal to those passed see parameters for details.}
 }
 \value{
 No return value, these functions are called only for their

--- a/man/orderly_pull_dependencies.Rd
+++ b/man/orderly_pull_dependencies.Rd
@@ -54,16 +54,28 @@ another package).  If left \code{NULL}, then the default remote
 for this orderly repository is used - by default that is the
 first listed remote.}
 
-\item{parameters}{Parameters to pass through when doing depenency
+\item{parameters}{Parameters to pass through when doing dependency
 resolution.  If you are using a query for \code{id} that
 involves a parameter (e.g., \code{latest(parameter:x == p)}) you
 will need to pass in the parameters here.  Similarly, if you are
 pulling a report that uses query dependencies that reference
 parameters you need to pass them here (the same parameter set
-will be passed through to all dependencies).}
+will be passed through to all dependencies). If passed with
+\code{id = "latest"} then query will be constructed to pull latest
+version of report with report parameters equal to those passed e.g. if
+\code{parameters = list(nmin = 0.5, nmax = 1)} this will pull latest
+report run where \code{nmin == 0.5 && nmax == 1}. For anything more
+complicated than equality and && connectors use \code{id} to build
+the query.}
 
-\item{id}{The identifier (for \code{orderly_pull_archive}).  The default is
-to use the latest report.}
+\item{id}{The identifier (for \code{orderly_pull_archive}).  The default
+is to use the latest report.  This can be a query string to
+\code{orderly_search} see \code{\link{orderly_search}} for details.
+If \code{id = "latest"} and parameters are not NULL then query will
+be constructed to pull latest version of report  with report parameters
+equal to those passed e.g. if
+\code{parameters = list(nmin = 0.5, nmax = 1)} this will pull latest
+report run where \code{nmin == 0.5 && nmax == 1}.}
 }
 \value{
 No return value, these functions are called only for their

--- a/tests/testthat/helper-orderly.R
+++ b/tests/testthat/helper-orderly.R
@@ -71,20 +71,23 @@ unpack_reference <- function(version, path = tempfile()) {
 }
 
 
-prepare_orderly_remote_example <- function(path = tempfile()) {
+prepare_orderly_remote_example <- function(path = tempfile(),
+                                           name = "depends",
+                                           testing = TRUE,
+                                           report_name = "example") {
   skip_on_cran_windows()
   path_remote <- file.path(path, "remote")
   path_local <- file.path(path, "local")
 
-  prepare_orderly_example("depends", path_remote, testing = TRUE)
+  prepare_orderly_example(name, path_remote, testing = testing)
 
-  id1 <- orderly_run("example", root = path_remote, echo = FALSE)
-  id2 <- orderly_run("example", root = path_remote, echo = FALSE)
+  id1 <- orderly_run(report_name, root = path_remote, echo = FALSE)
+  id2 <- orderly_run(report_name, root = path_remote, echo = FALSE)
   orderly_commit(id1, root = path_remote)
   orderly_commit(id2, root = path_remote)
   remote_path <- orderly_remote_path(path_remote)
 
-  path_local <- prepare_orderly_example("depends", testing = TRUE)
+  path_local <- prepare_orderly_example(name, testing = testing)
 
   r <- list(remote = list(
               default = list(

--- a/tests/testthat/test-query-search.R
+++ b/tests/testthat/test-query-search.R
@@ -436,3 +436,14 @@ test_that("run query on remote", {
                    draft = "newer", remote = remote, root = root),
     "Can't use 'draft' along with 'remote'")
 })
+
+test_that("query can be built from parameters list", {
+  expect_equal(build_query(list(nmin = 2)),
+               "latest(parameter:nmin == 2)")
+  expect_equal(build_query(list(iso3 = "AGO")),
+               'latest(parameter:iso3 == "AGO")')
+  expect_equal(build_query(list(nmin = 2, iso3 = "AGO")),
+               'latest(parameter:nmin == 2 && parameter:iso3 == "AGO")')
+  expect_error(build_query(list(nmin = c(1, 2))),
+               "Failed to build default query:\n'nmin' must be a scalar")
+})

--- a/tests/testthat/test-query-search.R
+++ b/tests/testthat/test-query-search.R
@@ -439,11 +439,9 @@ test_that("run query on remote", {
 
 test_that("query can be built from parameters list", {
   expect_equal(build_query(list(nmin = 2)),
-               "latest(parameter:nmin == 2)")
+               "latest(parameter:nmin == nmin)")
   expect_equal(build_query(list(iso3 = "AGO")),
-               'latest(parameter:iso3 == "AGO")')
+               'latest(parameter:iso3 == iso3)')
   expect_equal(build_query(list(nmin = 2, iso3 = "AGO")),
-               'latest(parameter:nmin == 2 && parameter:iso3 == "AGO")')
-  expect_error(build_query(list(nmin = c(1, 2))),
-               "Failed to build default query:\n'nmin' must be a scalar")
+               'latest(parameter:nmin == nmin && parameter:iso3 == iso3)')
 })

--- a/tests/testthat/test-query-search.R
+++ b/tests/testthat/test-query-search.R
@@ -441,7 +441,7 @@ test_that("query can be built from parameters list", {
   expect_equal(build_query(list(nmin = 2)),
                "latest(parameter:nmin == nmin)")
   expect_equal(build_query(list(iso3 = "AGO")),
-               'latest(parameter:iso3 == iso3)')
+               "latest(parameter:iso3 == iso3)")
   expect_equal(build_query(list(nmin = 2, iso3 = "AGO")),
-               'latest(parameter:nmin == nmin && parameter:iso3 == iso3)')
+               "latest(parameter:nmin == nmin && parameter:iso3 == iso3)")
 })

--- a/tests/testthat/test-remote.R
+++ b/tests/testthat/test-remote.R
@@ -321,3 +321,44 @@ test_that("orderly_bundle_(pack|import)_remote do not use root/locate", {
 
   expect_equal(remote$list_versions("example"), ans$id)
 })
+
+test_that("pull from remote builds query from parameters", {
+  ## Setup remote archive with some parametered reports having been run
+  dat <- prepare_orderly_remote_example(name = "demo", testing = FALSE,
+                                        report_name = "minimal")
+  id3 <- orderly_run("other", root = dat$path_remote, list(nmin = 0),
+                     echo = FALSE)
+  orderly_commit(id3, root = dat$path_remote)
+  id4 <- orderly_run("other", root = dat$path_remote, list(nmin = 0.25),
+                     echo = FALSE)
+  orderly_commit(id4, root = dat$path_remote)
+  id5 <- orderly_run("other", root = dat$path_remote, list(nmin = 0.5),
+                     echo = FALSE)
+  orderly_commit(id5, root = dat$path_remote)
+
+  ## Pulling with parameters nmin = 0 pulls correct report
+  expect_log_message(
+    orderly_pull_archive("other", parameters = list(nmin = 0),
+                         root = dat$config, remote = dat$remote),
+    "\\[ pull\\s+ \\]  other:")
+  expect_equal(orderly_list_archive(dat$config),
+               data_frame(name = "other", id = id3))
+
+  ## Pulling with parameters and ID specified
+  expect_log_message(
+    orderly_pull_archive("other", id = 'latest(parameter:nmin == n)',
+                         parameters = list(n = 0.25),
+                         root = dat$config, remote = dat$remote),
+    "\\[ pull\\s+ \\]  other:")
+  expect_equal(orderly_list_archive(dat$config),
+               data_frame(name = rep("other", 2),
+                          id = c(id3, id4)))
+
+  ## Pulls latest by default
+  expect_log_message(
+    orderly_pull_archive("other", root = dat$config, remote = dat$remote),
+    "\\[ pull\\s+ \\]  other:")
+  expect_equal(orderly_list_archive(dat$config),
+               data_frame(name = rep("other", 3),
+                          id = c(id3, id4, id5)))
+})

--- a/tests/testthat/test-remote.R
+++ b/tests/testthat/test-remote.R
@@ -346,7 +346,7 @@ test_that("pull from remote builds query from parameters", {
 
   ## Pulling with parameters and ID specified
   expect_log_message(
-    orderly_pull_archive("other", id = 'latest(parameter:nmin == n)',
+    orderly_pull_archive("other", id = "latest(parameter:nmin == n)",
                          parameters = list(n = 0.25),
                          root = dat$config, remote = dat$remote),
     "\\[ pull\\s+ \\]  other:")


### PR DESCRIPTION
This PR will:
* Construct a default query from parameters if `id = "latest"`
* Update docs to hopefully make this behaviour clear