### PR TITLE
Don't save output with colour and strip colour codes from testing

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.2.21
+Version: 1.2.22
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/R/util.R
+++ b/R/util.R
@@ -217,7 +217,7 @@ capture_log <- function(expr, filename) {
     close(con)
   })
   handle_message <- function(e) {
-    cat(e$message, file = stdout())
+    cat(crayon::strip_style(e$message), file = stdout())
   }
   handle_error <- function(e) {
     calls <- sys.calls()
@@ -225,7 +225,7 @@ capture_log <- function(expr, filename) {
     lab <- format(seq_along(str))
     str <- gsub("\n", sprintf("\n%s", strrep(" ", nchar(lab)[[1]] + 2)), str)
     trace <- paste(sprintf("%s: %s\n", lab, str), collapse = "")
-    cat(sprintf("Error: %s\nTraceback:\n%s", e$message, trace),
+    cat(crayon::strip_style(sprintf("Error: %s\nTraceback:\n%s", e$message, trace)),
         file = stdout())
   }
 
@@ -798,7 +798,6 @@ yaml_block_info <- function(name, text) {
 
 insert_into_file <- function(text, where, value, path, show, edit, prompt) {
   x <- filediff(text, where, value)
-
   if (length(x$changed) == 0L) {
     message(sprintf("No changes to make to '%s'", path))
     return(invisible(x))

--- a/R/util.R
+++ b/R/util.R
@@ -225,7 +225,8 @@ capture_log <- function(expr, filename) {
     lab <- format(seq_along(str))
     str <- gsub("\n", sprintf("\n%s", strrep(" ", nchar(lab)[[1]] + 2)), str)
     trace <- paste(sprintf("%s: %s\n", lab, str), collapse = "")
-    cat(sprintf("Error: %s\nTraceback:\n%s", e$message, trace), file = stdout())
+    cat(sprintf("Error: %s\nTraceback:\n%s", e$message, trace),
+        file = stdout())
   }
 
   suppressMessages(withCallingHandlers(

--- a/R/util.R
+++ b/R/util.R
@@ -225,7 +225,8 @@ capture_log <- function(expr, filename) {
     lab <- format(seq_along(str))
     str <- gsub("\n", sprintf("\n%s", strrep(" ", nchar(lab)[[1]] + 2)), str)
     trace <- paste(sprintf("%s: %s\n", lab, str), collapse = "")
-    cat(crayon::strip_style(sprintf("Error: %s\nTraceback:\n%s", e$message, trace)),
+    cat(crayon::strip_style(sprintf("Error: %s\nTraceback:\n%s",
+                                    e$message, trace)),
         file = stdout())
   }
 

--- a/R/util.R
+++ b/R/util.R
@@ -225,9 +225,7 @@ capture_log <- function(expr, filename) {
     lab <- format(seq_along(str))
     str <- gsub("\n", sprintf("\n%s", strrep(" ", nchar(lab)[[1]] + 2)), str)
     trace <- paste(sprintf("%s: %s\n", lab, str), collapse = "")
-    cat(crayon::strip_style(sprintf("Error: %s\nTraceback:\n%s",
-                                    e$message, trace)),
-        file = stdout())
+    cat(sprintf("Error: %s\nTraceback:\n%s", e$message, trace), file = stdout())
   }
 
   suppressMessages(withCallingHandlers(

--- a/tests/testthat/test-remote-path.R
+++ b/tests/testthat/test-remote-path.R
@@ -184,7 +184,8 @@ test_that("push report (path)", {
 
   res <- testthat::evaluate_promise(
     orderly_push_archive("multifile-artefact", "latest", ours, remote = remote))
-  expect_match(crayon::strip_style(res$messages), paste(re, "already exists, skipping\\n$"))
+  expect_match(crayon::strip_style(res$messages),
+               paste(re, "already exists, skipping\\n$"))
 })
 
 

--- a/tests/testthat/test-remote-path.R
+++ b/tests/testthat/test-remote-path.R
@@ -176,7 +176,7 @@ test_that("push report (path)", {
     orderly_push_archive("multifile-artefact", "latest", ours, remote = remote))
 
   re <- "^\\[ push\\s+\\]  multifile-artefact:[0-9]{8}-[0-9]{6}-[[:xdigit:]]{8}"
-  expect_match(res$messages, paste0(re, "\\n$"))
+  expect_match(crayon::strip_style(res$messages), paste0(re, "\\n$"))
 
   d <- orderly_list_archive(theirs)
   expect_equal(d$name, "multifile-artefact")
@@ -184,7 +184,7 @@ test_that("push report (path)", {
 
   res <- testthat::evaluate_promise(
     orderly_push_archive("multifile-artefact", "latest", ours, remote = remote))
-  expect_match(res$messages, paste(re, "already exists, skipping\\n$"))
+  expect_match(crayon::strip_style(res$messages), paste(re, "already exists, skipping\\n$"))
 })
 
 
@@ -211,15 +211,15 @@ test_that("push report & deps", {
   expect_equal(orderly_list_archive(ours), d)
 
   re <- "\\[ ([a-z]+)\\s*\\]  ([a-z0-9]+)[:/](.*?)\\s*$"
-  expect_true(all(grepl(re, res$messages)))
+  expect_true(all(grepl(re, crayon::strip_style(res$messages))))
   expect_equal(
-    sub(re, "\\1", res$messages),
+    sub(re, "\\1", crayon::strip_style(res$messages)),
     c("push", "depends", "push", "depends", "push"))
   expect_equal(
-    sub(re, "\\2", res$messages),
+    sub(re, "\\2", crayon::strip_style(res$messages)),
     c("depend3", "depend2", "depend2", "example", "example"))
   expect_equal(
-    sub(re, "\\3", res$messages),
+    sub(re, "\\3", crayon::strip_style(res$messages)),
     c(id3, id2, id2, id1, id1))
 })
 

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -708,9 +708,11 @@ test_that("insert into files", {
   path <- tempfile()
   writeLines(text, path)
 
-  res <- evaluate_promise(
-    insert_into_file(text, where, value, path,
-                     show = TRUE, edit = FALSE, prompt = FALSE))
+  withr::with_envvar(c("NO_COLOR" = "true"), {
+    res <- evaluate_promise(
+      insert_into_file(text, where, value, path,
+                       show = TRUE, edit = FALSE, prompt = FALSE))
+  })
   expect_match(res$messages, "Changes to '.+'")
   expect_equal(res$result, filediff(text, where, value))
   expect_equal(res$output,


### PR DESCRIPTION
This PR will
* Not save `output.log` with colour encoding
* Strip it elsewhere where it was causing test failures