### PR TITLE
VIMC-4580: Make orderly_cleanup chattier and sanitise report name

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -70,6 +70,11 @@ jobs:
             eval sudo $cmd
           done < <(Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "20.04"))')
 
+      - name: "[macOS] system dependencies"
+        if: runner.os == 'macOS'
+        run: |
+          brew install libgit2
+
       - name: Install dependencies
         run: |
           remotes::install_deps(dependencies = TRUE)

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Install libs
         run: |
-          brew install libgit
+          brew install libgit2
 
       - name: Set env
         run: echo "VAULTR_TEST_SERVER_BIN_PATH=$GITHUB_WORKSPACE/.vault" >> $GITHUB_ENV

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -39,6 +39,10 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
           restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
 
+      - name: Install libs
+        run: |
+          brew install libgit
+
       - name: Set env
         run: echo "VAULTR_TEST_SERVER_BIN_PATH=$GITHUB_WORKSPACE/.vault" >> $GITHUB_ENV
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.2.22
+Version: 1.2.24
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# orderly 1.2.24
+
+* Make `orderly_cleanup` much chattier (#265)
+
 # orderly 1.2.20
 
 * `orderly_pull_archive` is now more tolerant of trailing slashes (#260)

--- a/R/cleanup.R
+++ b/R/cleanup.R
@@ -60,6 +60,12 @@ orderly_cleanup_drafts <- function(config, name = NULL, failed_only = FALSE) {
   if (failed_only) {
     p <- p[!file.exists(path_orderly_run_rds(p))]
   }
+  msg <- sprintf("Found %s draft %s", length(p),
+                 ngettext(length(p), "report", "reports"))
+  if (!is.null(name)) {
+    msg <- paste(msg, sprintf("for report name '%s'", name))
+  }
+  orderly_log("clean", msg)
   if (length(p) > 0L) {
     orderly_log(if (failed_only) "prune" else "clean", p)
     unlink(p, recursive = TRUE)
@@ -85,12 +91,18 @@ orderly_cleanup_data <- function(config) {
 
   csv <- orderly_db("csv", config, FALSE)
   drop_csv <- setdiff(csv$list(), used)
+  msg <- sprintf("Found %s csv %s", length(drop_csv),
+                 ngettext(length(drop_csv), "file", "files"))
+  orderly_log("clean", msg)
   if (length(drop_csv) > 0L) {
     csv$del(drop_csv)
   }
 
   rds <- orderly_db("rds", config, FALSE)
   drop_rds <- setdiff(rds$list(), used)
+  msg <- sprintf("Found %s rds %s", length(drop_rds),
+                 ngettext(length(drop_rds), "file", "files"))
+  orderly_log("clean", msg)
   if (length(drop_rds) > 0L) {
     rds$del(drop_rds)
   }

--- a/R/cleanup.R
+++ b/R/cleanup.R
@@ -54,6 +54,7 @@ orderly_cleanup_drafts <- function(config, name = NULL, failed_only = FALSE) {
   d <- orderly_list_drafts(config, FALSE, include_failed = TRUE)
   if (!is.null(name)) {
     assert_character(name)
+    name <- clean_report_name(name)
     d <- d[d$name %in% name, , drop = FALSE]
   }
   p <- file.path(path_draft(config$root), d$name, d$id)

--- a/R/develop.R
+++ b/R/develop.R
@@ -130,12 +130,7 @@ orderly_develop_location <- function(name, root, locate) {
     }
     name <- rel[[2L]]
   } else {
-    if (grepl("^src[/\\].+", name)) {
-      name <- sub("^src[/\\]+", "", name)
-    }
-    if (grepl("[/\\]$", name)) {
-      name <- sub("[/\\]+$", "", name)
-    }
+    name <- clean_report_name(name)
   }
 
   path <- file.path(path_src(config$root), name)

--- a/R/file_store.R
+++ b/R/file_store.R
@@ -41,6 +41,7 @@ file_store <- R6::R6Class(
     },
 
     del = function(hash) {
+      orderly_log("clean", self$filename(hash))
       invisible(file.remove(self$filename(hash)))
     },
 

--- a/R/util.R
+++ b/R/util.R
@@ -925,3 +925,13 @@ lock_bindings <- function(syms, env) {
   }
   invisible(NULL)
 }
+
+clean_report_name <- function(name) {
+  if (grepl("^src[/\\].+", name)) {
+    name <- sub("^src[/\\]+", "", name)
+  }
+  if (grepl("[/\\]$", name)) {
+    name <- sub("[/\\]+$", "", name)
+  }
+  name
+}

--- a/tests/testthat/helper-orderly.R
+++ b/tests/testthat/helper-orderly.R
@@ -193,6 +193,12 @@ expect_log_message <- function(expr, ...) {
     ..., all = FALSE)
 }
 
+capture_logs <- function(expr) {
+  res <- testthat::evaluate_promise(expr)
+  res$messages <- crayon::strip_style(res$messages)
+  res
+}
+
 
 if (Sys.getenv("NOT_CRAN") != "true") {
   options(orderly.nogit = TRUE)

--- a/tests/testthat/test-cleanup.R
+++ b/tests/testthat/test-cleanup.R
@@ -92,3 +92,17 @@ test_that("cleanup by name", {
   expect_match(out$messages, "Found 0 csv files", all = FALSE)
   expect_match(out$messages, "Found 0 rds files", all = FALSE)
 })
+
+test_that("cleanup by name sanitises report name", {
+  skip_on_cran_windows()
+  path <- prepare_orderly_example("demo")
+  id1 <- orderly_run("minimal", root = path, echo = FALSE)
+  id2 <- orderly_run("other", list(nmin = 0), root = path, echo = FALSE)
+  out <- capture_logs(orderly_cleanup("minimal/", path))
+  expect_equal(orderly_list_drafts(path),
+               data.frame(name = "other", id = id2, stringsAsFactors = FALSE))
+  expect_match(out$messages, "Found 1 draft report for report name 'minimal'",
+               all = FALSE)
+  expect_match(out$messages, "Found 0 csv files", all = FALSE)
+  expect_match(out$messages, "Found 0 rds files", all = FALSE)
+})

--- a/tests/testthat/test-cleanup.R
+++ b/tests/testthat/test-cleanup.R
@@ -2,8 +2,12 @@ context("cleanup")
 
 test_that("cleanup nothing", {
   path <- prepare_orderly_example("minimal")
-  expect_null(orderly_cleanup(root = path))
+  out <- capture_logs(orderly_cleanup(root = path))
+  expect_null(out$result)
   expect_equal(orderly_list(root = path), "example")
+  expect_match(out$messages, "Found 0 draft reports", all = FALSE)
+  expect_match(out$messages, "Found 0 csv files", all = FALSE)
+  expect_match(out$messages, "Found 0 rds files", all = FALSE)
 })
 
 test_that("cleanup draft", {
@@ -12,9 +16,12 @@ test_that("cleanup draft", {
   id <- orderly_run("example", root = path, echo = FALSE)
   expect_equal(nrow(orderly_list_drafts(root = path)), 1)
   expect_equal(length(orderly_db("csv", path)$list()), 1)
-  orderly_cleanup(root = path)
+  out <- capture_logs(orderly_cleanup(root = path))
   expect_equal(nrow(orderly_list_drafts(root = path)), 0)
   expect_equal(length(orderly_db("csv", path)$list()), 0)
+  expect_match(out$messages, "Found 1 draft report", all = FALSE)
+  expect_match(out$messages, "Found 1 csv file", all = FALSE)
+  expect_match(out$messages, "Found 1 rds file", all = FALSE)
 })
 
 test_that("cleanup keeps draft data", {
@@ -23,8 +30,10 @@ test_that("cleanup keeps draft data", {
   id <- orderly_run("example", root = path, echo = FALSE)
   rds <- orderly_db("rds", root = path)
   h <- rds$list()
-  orderly_cleanup(root = path, draft = FALSE)
+  out <- capture_logs(orderly_cleanup(root = path, draft = FALSE))
   expect_identical(rds$list(), h)
+  expect_match(out$messages, "Found 0 csv files", all = FALSE)
+  expect_match(out$messages, "Found 0 rds files", all = FALSE)
 })
 
 test_that("cleanup with archive", {
@@ -38,10 +47,13 @@ test_that("cleanup with archive", {
 
   orderly_commit(id2, root = path)
 
-  orderly_cleanup(root = path)
+  out <- capture_logs(orderly_cleanup(root = path))
   expect_equal(nrow(orderly_list_drafts(root = path)), 0)
   expect_equal(nrow(orderly_list_archive(root = path)), 1)
   expect_equal(length(orderly_db("csv", path)$list()), 1)
+  expect_match(out$messages, "Found 1 draft report", all = FALSE)
+  expect_match(out$messages, "Found 0 csv files", all = FALSE)
+  expect_match(out$messages, "Found 0 rds files", all = FALSE)
 })
 
 test_that("cleanup failed", {
@@ -58,10 +70,13 @@ test_that("cleanup failed", {
   d <- orderly_list_drafts("example", root = path, include_failed = TRUE)
   expect_equal(nrow(d), 3)
 
-  orderly_cleanup(root = path, failed_only = TRUE)
+  out <- capture_logs(orderly_cleanup(root = path, failed_only = TRUE))
   d <- orderly_list_drafts("example", root = path, include_failed = TRUE)
   expect_equal(nrow(d), 2)
   expect_true(all(c(id1, id2) %in% d$id))
+  expect_match(out$messages, "Found 1 draft report", all = FALSE)
+  expect_match(out$messages, "Found 0 csv files", all = FALSE)
+  expect_match(out$messages, "Found 0 rds files", all = FALSE)
 })
 
 test_that("cleanup by name", {
@@ -69,7 +84,12 @@ test_that("cleanup by name", {
   path <- prepare_orderly_example("demo")
   id1 <- orderly_run("minimal", root = path, echo = FALSE)
   id2 <- orderly_run("other", list(nmin = 0), root = path, echo = FALSE)
-  orderly_cleanup("minimal", path)
+  out <- capture_logs(orderly_cleanup("minimal", path))
   expect_equal(orderly_list_drafts(path),
                data.frame(name = "other", id = id2, stringsAsFactors = FALSE))
+  expect_match(out$messages, "Found 1 draft report for report name 'minimal'",
+               all = FALSE)
+  expect_match(out$messages, "Found 0 csv files", all = FALSE)
+  expect_match(out$messages, "Found 0 rds files", all = FALSE)
 })
+

--- a/tests/testthat/test-cleanup.R
+++ b/tests/testthat/test-cleanup.R
@@ -92,4 +92,3 @@ test_that("cleanup by name", {
   expect_match(out$messages, "Found 0 csv files", all = FALSE)
   expect_match(out$messages, "Found 0 rds files", all = FALSE)
 })
-

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -869,3 +869,9 @@ test_that("lock_bindings can lock multiple variables at once", {
   expect_error(obj$a <- "2", "cannot change value of locked binding for 'a'")
   expect_error(obj$b <- "2", "cannot change value of locked binding for 'b'")
 })
+
+test_that("clean_report_name strips slashes and src dir", {
+  expect_equal(clean_report_name("test"), "test")
+  expect_equal(clean_report_name("test/"), "test")
+  expect_equal(clean_report_name("src/test"), "test")
+})


### PR DESCRIPTION
* This will now print out how many draft reports, csv files and rds files are going to be deleted
* And sanitise report name before running cleanup (i.e. strip / and strip preceeding `src`)

I think this should address #265 