### PR TITLE
vimc-4608: Add support for creating a git repository

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.2.25
+Version: 1.2.26
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/R/testing.R
+++ b/R/testing.R
@@ -16,6 +16,9 @@
 ##' @param quiet Logical, indicating if informational messages should
 ##'   be suppressed when running the demo.
 ##'
+##' @param git Logical, indicating if we should create an empty git
+##'   repository along with the demo.
+##'
 ##' @return Returns the path to the orderly example
 ##' @export
 ##' @examples
@@ -26,10 +29,13 @@
 ##' # Example reports within this repository:
 ##' orderly::orderly_list(path)
 orderly_example <- function(name, path = tempfile(), run_demo = FALSE,
-                            quiet = FALSE) {
+                            quiet = FALSE, git = FALSE) {
   path <- prepare_orderly_example(name, path)
   if (run_demo && file.exists(path_demo_yml(path))) {
     run_orderly_demo(path, quiet)
+  }
+  if (git) {
+    gert::git_init(path)
   }
   path
 }
@@ -39,8 +45,9 @@ orderly_example <- function(name, path = tempfile(), run_demo = FALSE,
 ## with prepare_orderly_example below that simply prepares the
 ## source).  This is used to create a set of data for testing the API.
 ## See inst/demo/demo.yml for more information.
-create_orderly_demo <- function(path = tempfile(), quiet = FALSE) {
-  orderly_example("demo", path, TRUE, quiet)
+create_orderly_demo <- function(path = tempfile(), quiet = FALSE,
+                                git = FALSE) {
+  orderly_example("demo", path, TRUE, quiet, git)
 }
 
 

--- a/man/orderly_example.Rd
+++ b/man/orderly_example.Rd
@@ -4,7 +4,13 @@
 \alias{orderly_example}
 \title{Set up an orderly example}
 \usage{
-orderly_example(name, path = tempfile(), run_demo = FALSE, quiet = FALSE)
+orderly_example(
+  name,
+  path = tempfile(),
+  run_demo = FALSE,
+  quiet = FALSE,
+  git = FALSE
+)
 }
 \arguments{
 \item{name}{Name of the example}
@@ -19,6 +25,9 @@ committed), should these be run?}
 
 \item{quiet}{Logical, indicating if informational messages should
 be suppressed when running the demo.}
+
+\item{git}{Logical, indicating if we should create an empty git
+repository along with the demo.}
 }
 \value{
 Returns the path to the orderly example

--- a/tests/testthat/test-testing.R
+++ b/tests/testthat/test-testing.R
@@ -8,3 +8,10 @@ test_that("orderly_example can be quiet", {
   expect_silent(
     orderly_example("minimal", run_demo = TRUE, quiet = TRUE))
 })
+
+
+test_that("create_orderly_demo can create a git repo", {
+  skip_on_cran()
+  path <- create_orderly_demo(quiet = TRUE, git = TRUE)
+  expect_true(file.exists(file.path(path, ".git")))
+})


### PR DESCRIPTION
This PR adds an argument `git` which allows creation of an empty git repo within a demo directory. Needed for working with orderly.server