### PR TITLE
VIMC-4037: Save orderly_fail.rds when report run is unsuccessful

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.2.25
+Version: 1.2.26
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.2.28
+Version: 1.2.29
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# orderly 1.2.26
+
+* `orderly_run`, `orderly_run_internal` and `bundle_run` will now save a `orderly_fail.rds` if run fails containing metadata and info about failure reason (VIMC-4037)
+
 # orderly 1.2.25
 
 * `orderly_cleanup` will now sanitise the report name passed to it

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# orderly 1.2.28
+# orderly 1.2.29
 
 * `orderly_run`, `orderly_run_internal` and `bundle_run` will now save a `orderly_fail.rds` if run fails containing metadata and info about failure reason (VIMC-4037)
 

--- a/R/orderly_version.R
+++ b/R/orderly_version.R
@@ -377,10 +377,10 @@ orderly_version <- R6::R6Class(
       trace <- utils::limitedLabels(sys.calls())
       if (length(trace) > 4) {
         ## Remove the last 4 entries, these will always be calls to:
-        ## .handleSimpleError(...
-        ## h(simpleError(msg, call))
-        ## self$run_failed_cleanup(e)
-        ## private$write_orderly_fail_rds(error)
+        ## .handleSimpleError(...                  # nolint
+        ## h(simpleError(msg, call))               # nolint
+        ## self$run_failed_cleanup(e)              # nolint
+        ## private$write_orderly_fail_rds(error)   # nolint
         ## which aren't really interesting
         trace <- trace[seq(1, length(trace) - 4)]
       }

--- a/R/orderly_version.R
+++ b/R/orderly_version.R
@@ -362,7 +362,7 @@ orderly_version <- R6::R6Class(
     write_orderly_run_rds = function() {
       session <- withr::with_envvar(private$envvar, session_info())
       session$meta <- private$metadata()
-      ## NOTE: git is here twice for some reason
+      ## NOTE: git is here twice for some reason see VIMC-4613
       session$git <- session$meta$git
       session$archive_version <- cache$current_archive_version
       saveRDS(session, path_orderly_run_rds(private$workdir))
@@ -387,7 +387,7 @@ orderly_version <- R6::R6Class(
       error$trace <- trace
       session$error <- error
       session$meta <- private$metadata()
-      ## NOTE: git is here twice for some reason
+      ## NOTE: git is here twice for some reason see VIMC-4613
       session$git <- session$meta$git
       session$archive_version <- cache$current_archive_version
       saveRDS(session, path_orderly_fail_rds(private$workdir))

--- a/R/orderly_version.R
+++ b/R/orderly_version.R
@@ -377,10 +377,10 @@ orderly_version <- R6::R6Class(
       trace <- utils::limitedLabels(sys.calls())
       if (length(trace) > 4) {
         ## Remove the last 4 entries, these will always be calls to:
-        ## .handleSimpleError(...                  # nolint
-        ## h(simpleError(msg, call))               # nolint
-        ## self$run_failed_cleanup(e)              # nolint
-        ## private$write_orderly_fail_rds(error)   # nolint
+        ## > .handleSimpleError(...
+        ## > h(simpleError(msg, call))
+        ## > self$run_failed_cleanup(e)
+        ## > private$write_orderly_fail_rds(error)
         ## which aren't really interesting
         trace <- trace[seq(1, length(trace) - 4)]
       }

--- a/R/orderly_version.R
+++ b/R/orderly_version.R
@@ -369,6 +369,10 @@ orderly_version <- R6::R6Class(
     },
 
     write_orderly_fail_rds = function(error) {
+      if (is.null(private$workdir)) {
+        message("Can't save fail RDS, workdir not set")
+        return(invisible(FALSE))
+      }
       session <- withr::with_envvar(private$envvar, session_info())
       trace <- utils::limitedLabels(sys.calls())
       if (length(trace) > 4) {
@@ -401,9 +405,9 @@ orderly_version <- R6::R6Class(
     run = function(parameters = NULL, instance = NULL, envir = NULL,
                    message = NULL, tags = NULL, echo = TRUE,
                    use_draft = FALSE, remote = NULL) {
+      self$run_read(parameters, instance, envir, tags, use_draft,
+                    remote)
       withCallingHandlers({
-        self$run_read(parameters, instance, envir, tags, use_draft,
-                      remote)
         self$run_prepare(message)
         private$fetch()
         self$run_execute(echo)

--- a/R/orderly_version.R
+++ b/R/orderly_version.R
@@ -384,8 +384,7 @@ orderly_version <- R6::R6Class(
         ## which aren't really interesting
         trace <- trace[seq(1, length(trace) - 4)]
       }
-      error$trace <- trace
-      session$error <- error
+      session$error <- list(error = error, trace = trace)
       session$meta <- private$metadata()
       ## NOTE: git is here twice for some reason see VIMC-4613
       session$git <- session$meta$git

--- a/R/paths.R
+++ b/R/paths.R
@@ -40,6 +40,10 @@ path_orderly_run_rds <- function(path) {
   file.path(path, "orderly_run.rds")
 }
 
+path_orderly_fail_rds <- function(path) {
+  file.path(path, "orderly_fail.rds")
+}
+
 path_orderly_envir_yml <- function(path) {
   file.path(path, "orderly_envir.yml")
 }

--- a/tests/testthat/test-bundle.R
+++ b/tests/testthat/test-bundle.R
@@ -307,7 +307,7 @@ test_that("failed bundle run writes out failed rds", {
   expect_equal(names(failed_rds),
                c("session_info", "time", "env", "error", "meta",
                  "archive_version"))
-  expect_equal(failed_rds$error$message, "some error")
+  expect_equal(failed_rds$error$error$message, "some error")
   expect_true(length(failed_rds$error$trace) > 5)
   expect_match(failed_rds$error$trace[length(failed_rds$error$trace) - 3],
                "f()")

--- a/tests/testthat/test-bundle.R
+++ b/tests/testthat/test-bundle.R
@@ -272,3 +272,49 @@ test_that("Can rename a bundle before import", {
   expect_equal(orderly_list_archive(path),
                data_frame(name = "example", id = res$id))
 })
+
+test_that("failed bundle run writes out failed rds", {
+  path <- prepare_orderly_example("minimal")
+  on.exit(unlink(path, recursive = TRUE))
+
+  append_lines(
+    c("f <- function() g()",
+      "g <- function() h()",
+      "h <- function() stop('some error')",
+      "f()"),
+    file.path(path, "src", "example", "script.R"))
+
+  path_bundles <- tempfile()
+
+  res <- orderly_bundle_pack(path_bundles, "example", root = path)
+  expect_equal(dir(path_bundles), basename(res$path))
+  expect_equal(basename(res$path), paste0(res$id, ".zip"))
+
+  ## Move the orderly root to prevent any file references being valid:
+  path2 <- paste0(path, "-moved")
+  file.rename(path, path2)
+
+  workdir <- tempfile()
+  expect_error(orderly_bundle_run(res$path, workdir, echo = FALSE),
+               "some error")
+
+  ## Failed rds has been saved into pack
+  id <- list.files(workdir)
+  path_rds <- path_orderly_fail_rds(file.path(workdir, id, "pack"))
+  expect_true(file.exists(path_rds))
+
+  failed_rds <- readRDS(path_rds)
+  expect_equal(names(failed_rds),
+               c("session_info", "time", "env", "error", "meta",
+                 "archive_version"))
+  expect_equal(failed_rds$error$message, "some error")
+  expect_true(length(failed_rds$error$trace) > 5)
+  expect_match(failed_rds$error$trace[length(failed_rds$error$trace) - 3],
+               "f()")
+  expect_match(failed_rds$error$trace[length(failed_rds$error$trace) - 2],
+               "g()")
+  expect_match(failed_rds$error$trace[length(failed_rds$error$trace) - 1],
+               "h()")
+  expect_match(failed_rds$error$trace[length(failed_rds$error$trace)],
+               'stop\\("some error"\\)')
+})

--- a/tests/testthat/test-main.R
+++ b/tests/testthat/test-main.R
@@ -459,6 +459,13 @@ test_that("run: message", {
 
   table_message <- sprintf("[%s] %s", d$label, d$value)
   expect_equal(message, table_message)
+
+
+  path <- prepare_orderly_example("changelog", testing = TRUE)
+  message <- "[label1] This is a test message."
+  args <- c("--root", path, "run", "--message", squote(message),
+            "example")
+  res <- cli_args_process(args)
 })
 
 

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -1057,7 +1057,7 @@ test_that("message printed if run fails before working dir is set", {
   ## Contrive an example which will throw an error before working directory
   ## has been created
   unlockBinding("create_workdir", version$.__enclos_env__$private)
-  version$.__enclos_env__$private$create_workdir <- function() { stop("test") }
+  version$.__enclos_env__$private$create_workdir <- function() stop("test")
 
   expect_message(expect_error(version$run(), "test"),
                  "Can't save fail RDS, workdir not set")

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -1006,8 +1006,8 @@ test_that("failed run creates failed rds", {
                c("session_info", "time", "env", "git", "error", "meta",
                  "archive_version"))
 
-  expect_s3_class(failed_rds$error, "simpleError")
-  expect_equal(failed_rds$error$message, "some error")
+  expect_s3_class(failed_rds$error$error, "simpleError")
+  expect_equal(failed_rds$error$error$message, "some error")
   expect_true(length(failed_rds$error$trace) > 5)
   expect_match(failed_rds$error$trace[length(failed_rds$error$trace)],
                'stop\\("some error"\\)')
@@ -1041,7 +1041,7 @@ test_that("fail during cleanup creates failed rds", {
   expect_equal(names(failed_rds),
                c("session_info", "time", "env", "error", "meta",
                  "archive_version"))
-  expect_equal(failed_rds$error$message,
+  expect_equal(failed_rds$error$error$message,
                "Script did not produce expected artefacts: mygraph.png")
   expect_true(length(failed_rds$error$trace) > 5)
   expect_match(failed_rds$error$trace[length(failed_rds$error$trace)],
@@ -1086,7 +1086,7 @@ test_that("orderly_run_internal writes fail rds on error", {
   expect_equal(names(failed_rds),
                c("session_info", "time", "env", "error", "meta",
                  "archive_version"))
-  expect_equal(failed_rds$error$message, "some error")
+  expect_equal(failed_rds$error$error$message, "some error")
   expect_true(length(failed_rds$error$trace) > 5)
   expect_match(failed_rds$error$trace[length(failed_rds$error$trace) - 3],
                "f()")

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -987,3 +987,65 @@ test_that("parameters passed to dependency resolution include defaults", {
     path_orderly_run_rds(file.path(root, "draft", "use_dependency", id)))
   expect_equal(info$meta$depends$id, dat$ids[[1]])
 })
+
+test_that("failed run creates failed rds", {
+  testthat::skip_on_cran()
+  path <- prepare_orderly_git_example("minimal")
+  on.exit(unlink(path[["local"]], recursive = TRUE))
+
+  append_lines('stop("some error")',
+               file.path(path[["local"]], "src", "minimal", "script.R"))
+  expect_error(orderly_run("minimal", root = path[["local"]], echo = FALSE),
+               "some error")
+  drafts <- orderly_list_drafts(root = path[["local"]], include_failed = TRUE)
+  expect_equal(nrow(drafts), 1)
+
+  draft_dir <- file.path(path_draft(path[["local"]]), drafts$name, drafts$id)
+  expect_true(file.exists(path_orderly_fail_rds(draft_dir)))
+
+  failed_rds <- readRDS(path_orderly_fail_rds(draft_dir))
+  expect_equal(names(failed_rds),
+               c("session_info", "time", "env", "git", "error", "meta",
+                 "archive_version"))
+
+  expect_s3_class(failed_rds$error, "simpleError")
+  expect_equal(failed_rds$error$message, "some error")
+  expect_true(length(failed_rds$error$trace) > 5)
+  expect_equal(failed_rds$erro$trace[length(failed_rds$erro$trace)],
+               "script.R#5: stop(\"some error\")")
+
+  expect_equal(failed_rds$meta$id, drafts$id)
+  expect_equal(failed_rds$meta$name, "minimal")
+  expect_null(failed_rds$meta$parameters)
+  expect_true(!is.null(failed_rds$meta$elapsed))
+
+  expect_equal(failed_rds$archive_version, cache$current_archive_version)
+
+  expect_equal(failed_rds$meta$git$branch, "master")
+  expect_equal(failed_rds$meta$git$status, " M src/minimal/script.R")
+})
+
+test_that("fail during cleanup creates failed rds", {
+  path <- prepare_orderly_example("minimal")
+  on.exit(unlink(path, recursive = TRUE))
+
+  writeLines("1 + 1", file.path(path, "src/example/script.R"))
+  expect_error(orderly_run("example", root = path, echo = FALSE),
+               "Script did not produce expected artefacts: mygraph.png")
+
+  drafts <- orderly_list_drafts(root = path, include_failed = TRUE)
+  expect_equal(nrow(drafts), 1)
+
+  draft_dir <- file.path(path_draft(path), drafts$name, drafts$id)
+  expect_true(file.exists(path_orderly_fail_rds(draft_dir)))
+
+  failed_rds <- readRDS(path_orderly_fail_rds(draft_dir))
+  expect_equal(names(failed_rds),
+               c("session_info", "time", "env", "error", "meta",
+                 "archive_version"))
+  expect_equal(failed_rds$error$message,
+               "Script did not produce expected artefacts: mygraph.png")
+  expect_true(length(failed_rds$error$trace) > 5)
+  expect_match(failed_rds$erro$trace[length(failed_rds$erro$trace)],
+               "Script did not produce expected artefacts:")
+})

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -1049,23 +1049,11 @@ test_that("fail during cleanup creates failed rds", {
 })
 
 test_that("message printed if run fails before working dir is set", {
-  path <- prepare_orderly_example("minimal")
-
-  ## Contrive an example which will throw an error before working directory
-  ## has been created. We can't mock out private function of orderly_version
-  ## so instead extend the class and override to trigger an error.
-  mock_version <- R6::R6Class(
-    "test_version",
-    inherit = orderly_version,
-    private = list(
-      create_workdir = function() {
-        stop("test error")
-      }
-    ))
-  version <- mock_version$new("example", path, locate = TRUE)
-
-  expect_message(expect_error(version$run(), "test error"),
-                 "Can't save fail RDS, workdir not set")
+  ## git checkout happens before workdir is set, so we trigger an error there
+  expect_message(expect_error(
+    orderly_run_internal("minimal", root = path[["local"]],
+                         echo = FALSE, fetch = TRUE, ref = "123")),
+    "Can't save fail RDS, workdir not set")
 })
 
 test_that("orderly_run_internal writes fail rds on error", {

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -989,9 +989,7 @@ test_that("parameters passed to dependency resolution include defaults", {
 })
 
 test_that("failed run creates failed rds", {
-  testthat::skip_on_cran()
-  path <- prepare_orderly_git_example("minimal")
-  on.exit(unlink(path[["local"]], recursive = TRUE))
+  path <- prepare_orderly_git_example()
 
   append_lines('stop("some error")',
                file.path(path[["local"]], "src", "minimal", "script.R"))
@@ -1011,8 +1009,8 @@ test_that("failed run creates failed rds", {
   expect_s3_class(failed_rds$error, "simpleError")
   expect_equal(failed_rds$error$message, "some error")
   expect_true(length(failed_rds$error$trace) > 5)
-  expect_equal(failed_rds$error$trace[length(failed_rds$error$trace)],
-               "stop(\"some error\")")
+  expect_match(failed_rds$error$trace[length(failed_rds$error$trace)],
+               'stop\\("some error"\\)')
 
   expect_equal(failed_rds$meta$id, drafts$id)
   expect_equal(failed_rds$meta$name, "minimal")

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -1012,7 +1012,7 @@ test_that("failed run creates failed rds", {
   expect_equal(failed_rds$error$message, "some error")
   expect_true(length(failed_rds$error$trace) > 5)
   expect_equal(failed_rds$erro$trace[length(failed_rds$erro$trace)],
-               "script.R#5: stop(\"some error\")")
+               "stop(\"some error\")")
 
   expect_equal(failed_rds$meta$id, drafts$id)
   expect_equal(failed_rds$meta$name, "minimal")
@@ -1048,4 +1048,17 @@ test_that("fail during cleanup creates failed rds", {
   expect_true(length(failed_rds$error$trace) > 5)
   expect_match(failed_rds$erro$trace[length(failed_rds$erro$trace)],
                "Script did not produce expected artefacts:")
+})
+
+test_that("message printed if run fails before working dir is set", {
+  path <- prepare_orderly_example("minimal")
+
+  version <- orderly_version$new("example", path, locate = TRUE)
+  ## Contrive an example which will throw an error before working directory
+  ## has been created
+  unlockBinding("create_workdir", version$.__enclos_env__$private)
+  version$.__enclos_env__$private$create_workdir <- function() { stop("test") }
+
+  expect_message(expect_error(version$run(), "test"),
+                 "Can't save fail RDS, workdir not set")
 })

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -1049,6 +1049,7 @@ test_that("fail during cleanup creates failed rds", {
 })
 
 test_that("message printed if run fails before working dir is set", {
+  path <- prepare_orderly_git_example()
   ## git checkout happens before workdir is set, so we trigger an error there
   expect_message(expect_error(
     orderly_run_internal("minimal", root = path[["local"]],


### PR DESCRIPTION
This will save out failure rds from
* orderly_run
* orderly_run_internal
* bundle_run - I assume this is useful? but this will just exist in the working dir