### PR TITLE
MRC-2321: max-depth arg to orderly_graph now limits depth of tree returned

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.2.31
+Version: 1.2.32
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # orderly 1.2.32
 
-* `orderly_graph` arg `max_depth` now truncates depth of the tree instead of throwing error and arg `recursion_depth` added which works how `max_depth` used to
+* `orderly_graph` arg `max_depth` now truncates depth of the tree instead of throwing error and arg `recursion_limit` added which works how `max_depth` used to
 
 # orderly 1.2.30
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,8 @@
-# orderly 1.2.39
+# orderly 1.2.32
+
+* `orderly_graph` arg `max_depth` now truncates depth of the tree instead of throwing error and arg `recursion_depth` added which works how `max_depth` used to
+
+# orderly 1.2.30
 
 * New function `orderly_info` which returns details from report runs, both successful and failed (VIMC-4619)
 

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -62,7 +62,7 @@
 ##'   of date through the tree
 ##'
 ##' @param max_depth A numeric, how far back should the tree go, this
-##'   can be useful to truncate a very large tree. (default = 100)
+##'   can be useful to truncate a very large tree. (default = Inf)
 ##'
 ##' @param recursion_limit A numeric, limit for depth of tree, if the tree
 ##'   goes beyond this then an error is thrown. (default = 100)
@@ -94,7 +94,7 @@
 ##'                                  direction = "upstream")
 orderly_graph <- function(name, id = "latest", root = NULL, locate = TRUE,
                           direction = "downstream", propagate = TRUE,
-                          max_depth = 100, recursion_limit = 100,
+                          max_depth = Inf, recursion_limit = 100,
                           show_all = FALSE, use = "archive") {
   config <- orderly_config(root, locate)
   use <- match_value(use, c("archive", "src"))
@@ -110,7 +110,7 @@ orderly_graph <- function(name, id = "latest", root = NULL, locate = TRUE,
 
 
 orderly_graph_archive <- function(name, id, config, direction = "downstream",
-                                  propagate = TRUE, max_depth = 100,
+                                  propagate = TRUE, max_depth = Inf,
                                   recursion_limit = 100, show_all = FALSE) {
   assert_scalar_character(direction)
   direction <- match_value(direction, c("upstream", "downstream"))

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -61,11 +61,11 @@
 ##' @param propagate A boolean indicating if we want to propagate out
 ##'   of date through the tree
 ##'
-##' @param recursion_limit A numeric, limit for depth of tree, if the tree
-##'   goes beyond this then an error is thrown. (default = 100)
-##'
 ##' @param max_depth A numeric, how far back should the tree go, this
 ##'   can be useful to truncate a very large tree. (default = 100)
+##'
+##' @param recursion_limit A numeric, limit for depth of tree, if the tree
+##'   goes beyond this then an error is thrown. (default = 100)
 ##'
 ##' @param show_all A boolean, should we show all reports in the tree,
 ##'   not just the latest.
@@ -94,23 +94,24 @@
 ##'                                  direction = "upstream")
 orderly_graph <- function(name, id = "latest", root = NULL, locate = TRUE,
                           direction = "downstream", propagate = TRUE,
-                          recursion_limit = 100, show_all = FALSE,
-                          use = "archive") {
+                          max_depth = 100, recursion_limit = 100,
+                          show_all = FALSE, use = "archive") {
   config <- orderly_config(root, locate)
   use <- match_value(use, c("archive", "src"))
   if (use == "archive") {
     orderly_graph_archive(name, id, config, direction, propagate,
-                          recursion_limit, show_all)
+                          max_depth, recursion_limit, show_all)
   } else {
     ## id, propagate ignored
-    orderly_graph_src(name, config, direction, recursion_limit, show_all)
+    orderly_graph_src(name, config, direction, max_depth, recursion_limit,
+                      show_all)
   }
 }
 
 
 orderly_graph_archive <- function(name, id, config, direction = "downstream",
-                                  propagate = TRUE, recursion_limit = 100,
-                                  show_all = FALSE) {
+                                  propagate = TRUE, max_depth = 100,
+                                  recursion_limit = 100, show_all = FALSE) {
   assert_scalar_character(direction)
   direction <- match_value(direction, c("upstream", "downstream"))
 
@@ -118,6 +119,7 @@ orderly_graph_archive <- function(name, id, config, direction = "downstream",
   assert_scalar_character(id)
   assert_scalar_logical(propagate)
   assert_scalar_logical(show_all)
+  assert_scalar_numeric(max_depth)
   assert_scalar_numeric(recursion_limit)
 
   con <- orderly_db("destination", config)
@@ -129,8 +131,9 @@ orderly_graph_archive <- function(name, id, config, direction = "downstream",
     stop("This report does not exist")
   }
 
-  dep_tree <- build_tree(name = name, id = id, depth = recursion_limit,
-                         con = con, direction = direction, show_all = show_all)
+  dep_tree <- build_tree(name = name, id = id, depth = max_depth,
+                         limit = recursion_limit, con = con,
+                         direction = direction, show_all = show_all)
 
   # propagate out-of-date
   if (propagate) {
@@ -400,8 +403,9 @@ check_parents <- function(parent_vertex, name) {
 ##'
 ##' @param name the name of the report
 ##' @param id the id of the report, if omitted, use the id of the latest report
-##' @param depth [internal] - only used ensure we don't get trapped in an
-##'              infinite loop
+##' @param depth [internal] - The depth of dependencies we want to return
+##' @param limit [internal] - limit on number of dependencies - used ensure
+##'              we don't get trapped in an infinite loop
 ##' @param parent [internal] - the previous vertex in the tree
 ##' @param graph [internal] - The tree object that is built up and returned at
 ##'             the end
@@ -411,12 +415,12 @@ check_parents <- function(parent_vertex, name) {
 ##'
 ##' @return An R6 tree object
 ##' @noRd
-build_tree <- function(name, id, depth = 100, parent = NULL,
+build_tree <- function(name, id, depth = 100, limit = 100, parent = NULL,
                        tree = NULL, con, direction = "downstream",
                        show_all = FALSE) {
   ## this should never get triggered - it only exists the prevent an infinite
   ## recursion
-  if (depth < 0) {
+  if (limit < 0) {
     stop("The tree is very large or degenerate.")
   }
 
@@ -458,6 +462,9 @@ build_tree <- function(name, id, depth = 100, parent = NULL,
   } else { ## ...otherwise add a vertex
     v <- tree$add_child(parent, name, id, out_of_date)
   }
+  if (depth == 0) {
+    return(tree)
+  }
 
   dependency_ids <- get_dependencies_db(name = name, id = id, con = con,
                                         direction = direction,
@@ -466,8 +473,8 @@ build_tree <- function(name, id, depth = 100, parent = NULL,
     dependency_name <- id_to_name(id = dep_id, con = con)
 
     build_tree(name = dependency_name, id = dep_id, depth = depth - 1,
-               parent = v, tree = tree, con, direction = direction,
-               show_all = show_all)
+               limit = limit - 1, parent = v, tree = tree, con,
+               direction = direction, show_all = show_all)
   }
 
   tree

--- a/R/dependencies_src.R
+++ b/R/dependencies_src.R
@@ -1,5 +1,5 @@
 orderly_graph_src <- function(name, config, direction = "downstream",
-                              max_depth = 100, recursion_limit = 100,
+                              max_depth = Inf, recursion_limit = 100,
                               show_all = FALSE) {
   ## Start by reading all the src files; this would ideally be done
   ## with some caching layer I think.  The other option would be to

--- a/R/dependencies_src.R
+++ b/R/dependencies_src.R
@@ -1,5 +1,5 @@
 orderly_graph_src <- function(name, config, direction = "downstream",
-                              max_depth = 100, show_all = FALSE) {
+                              recursion_limit = 100, show_all = FALSE) {
   ## Start by reading all the src files; this would ideally be done
   ## with some caching layer I think.  The other option would be to
   ## make sure that we can rip through this really fast by not
@@ -32,7 +32,7 @@ orderly_graph_src <- function(name, config, direction = "downstream",
   ## We then can work with this fairly easily I think
   root <- report_vertex$new(NULL, name, "latest", FALSE)
   seen <- new.env()
-  build_tree_src(root, deps, max_depth, NULL)
+  build_tree_src(root, deps, recursion_limit, NULL)
   report_tree$new(root, direction)
 }
 

--- a/man/orderly_graph.Rd
+++ b/man/orderly_graph.Rd
@@ -11,6 +11,7 @@ orderly_graph(
   locate = TRUE,
   direction = "downstream",
   propagate = TRUE,
+  max_depth = 100,
   recursion_limit = 100,
   show_all = FALSE,
   use = "archive"
@@ -37,6 +38,9 @@ the tree permitted values are upstream, downstream}
 \item{propagate}{A boolean indicating if we want to propagate out
 of date through the tree}
 
+\item{max_depth}{A numeric, how far back should the tree go, this
+can be useful to truncate a very large tree. (default = 100)}
+
 \item{recursion_limit}{A numeric, limit for depth of tree, if the tree
 goes beyond this then an error is thrown. (default = 100)}
 
@@ -47,9 +51,6 @@ not just the latest.}
 dependency tree.  Current valid values are \code{archive} (the
 default), which reads from archive reports and \code{src} which
 reads from the source reports.}
-
-\item{max_depth}{A numeric, how far back should the tree go, this
-can be useful to truncate a very large tree. (default = 100)}
 }
 \value{
 An orderly tree object with the root corresponding to the given

--- a/man/orderly_graph.Rd
+++ b/man/orderly_graph.Rd
@@ -11,7 +11,7 @@ orderly_graph(
   locate = TRUE,
   direction = "downstream",
   propagate = TRUE,
-  max_depth = 100,
+  max_depth = Inf,
   recursion_limit = 100,
   show_all = FALSE,
   use = "archive"
@@ -39,7 +39,7 @@ the tree permitted values are upstream, downstream}
 of date through the tree}
 
 \item{max_depth}{A numeric, how far back should the tree go, this
-can be useful to truncate a very large tree. (default = 100)}
+can be useful to truncate a very large tree. (default = Inf)}
 
 \item{recursion_limit}{A numeric, limit for depth of tree, if the tree
 goes beyond this then an error is thrown. (default = 100)}

--- a/man/orderly_graph.Rd
+++ b/man/orderly_graph.Rd
@@ -11,7 +11,7 @@ orderly_graph(
   locate = TRUE,
   direction = "downstream",
   propagate = TRUE,
-  max_depth = 100,
+  recursion_limit = 100,
   show_all = FALSE,
   use = "archive"
 )
@@ -37,8 +37,8 @@ the tree permitted values are upstream, downstream}
 \item{propagate}{A boolean indicating if we want to propagate out
 of date through the tree}
 
-\item{max_depth}{A numeric, how far back should the tree go, this
-can be useful to truncate a very large tree. (default = 100)}
+\item{recursion_limit}{A numeric, limit for depth of tree, if the tree
+goes beyond this then an error is thrown. (default = 100)}
 
 \item{show_all}{A boolean, should we show all reports in the tree,
 not just the latest.}
@@ -47,6 +47,9 @@ not just the latest.}
 dependency tree.  Current valid values are \code{archive} (the
 default), which reads from archive reports and \code{src} which
 reads from the source reports.}
+
+\item{max_depth}{A numeric, how far back should the tree go, this
+can be useful to truncate a very large tree. (default = 100)}
 }
 \value{
 An orderly tree object with the root corresponding to the given

--- a/tests/testthat/test-dependency.R
+++ b/tests/testthat/test-dependency.R
@@ -576,3 +576,28 @@ test_that("src: set depth of dependencies and recursion limit", {
                              recursion_limit = 0),
                "The tree is very large or degenerate")
 })
+
+test_that("dependency latest with search query", {
+  dat <- prepare_orderly_query_example()
+  root <- dat$root
+
+  config <- orderly_config_$new(root)
+
+  p <- file.path(root, "src", "use_dependency", "orderly.yml")
+  txt <- readLines(p)
+  txt <- sub("latest", "latest(parameter:nmin < x)", txt, fixed = TRUE)
+  txt <- c(txt, c("parameters:",
+                  "  x:",
+                  "    default: 0.25"))
+  writeLines(txt, p)
+
+  tree <- orderly_graph("use_dependency", root = root, use = "src",
+                        propagate = FALSE, show_all = TRUE,
+                        direction = "upstream")
+  root <- tree$root
+  expect_equal(root$name, "use_dependency")
+  expect_length(root$children, 1)
+  child_1 <- root$children[[1]]
+  expect_equal(child_1$name, "other")
+  expect_length(child_1$children, 0)
+})

--- a/tests/testthat/test-dependency.R
+++ b/tests/testthat/test-dependency.R
@@ -212,7 +212,7 @@ test_that("infinite recursion", {
   writeLines(demo, file.path(path, "demo.yml"))
   run_orderly_demo(path)
 
-  expect_error(orderly_graph("example", max_depth = 1, root = path),
+  expect_error(orderly_graph("example", recursion_limit = 1, root = path),
                "The tree is very large or degenerate.")
 })
 
@@ -395,7 +395,7 @@ test_that("prevent excessive recursion", {
 
   config <- orderly_config_$new(path)
   expect_error(
-    orderly_graph_src("depend3", config, "upstream", max_depth = 1),
+    orderly_graph_src("depend3", config, "upstream", recursion_limit = 1),
     "The tree is very large or degenerate")
 })
 


### PR DESCRIPTION
instead of throwing an error