### PR TITLE
Add report_version_instance table to store info about db instances report ran against

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.2.32
+Version: 1.2.33
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/R/db2.R
+++ b/R/db2.R
@@ -8,7 +8,7 @@
 ## namespace/module feature so that implementation details can be
 ## hidden away a bit further.
 
-orderly_schema_version <- "1.2.6"
+orderly_schema_version <- "1.2.33"
 orderly_schema_table <- "orderly_schema"
 orderly_table_list <- "orderly_schema_tables"
 
@@ -439,6 +439,17 @@ report_data_import <- function(con, name, id, config) {
       workflow_id = dat_rds$meta$workflow$id
     )
     DBI::dbWriteTable(con, "report_version_workflow", report_version_workflow,
+                      append = TRUE)
+  }
+
+  ## DB instance:
+  if (!is.null(dat_rds$meta$instance)) {
+    report_version_instance <- data_frame(
+      report_version = id,
+      type = names(dat_rds$meta$instance),
+      instance = unname(unlist(dat_rds$meta$instance))
+    )
+    DBI::dbWriteTable(con, "report_version_instance", report_version_instance,
                       append = TRUE)
   }
 

--- a/R/db2.R
+++ b/R/db2.R
@@ -457,7 +457,8 @@ report_data_import <- function(con, name, id, config) {
       row
     }
     report_version_instance <- lapply(names(dat_rds$meta$instance), build_row)
-    report_version_instance <- do.call(rbind, report_version_instance)
+    report_version_instance <- do.call(rbind.data.frame,
+                                       report_version_instance)
     if (!is.null(report_version_instance)) {
       DBI::dbWriteTable(con, "report_version_instance", report_version_instance,
                         append = TRUE)

--- a/R/db2.R
+++ b/R/db2.R
@@ -448,10 +448,11 @@ report_data_import <- function(con, name, id, config) {
     instances <- lapply(names(dat_rds$meta$instance), function(type) {
       dat_rds$meta$instance[[type]]
     })
+    names(instances) <- names(dat_rds$meta$instance)
     instances <- instances[!vlapply(instances, is.null)]
     if (length(instances) > 0) {
       report_version_instance <- data_frame(
-        id = id,
+        report_version = id,
         type = names(instances),
         instance = list_to_character(instances))
       DBI::dbWriteTable(con, "report_version_instance", report_version_instance,

--- a/R/db2.R
+++ b/R/db2.R
@@ -449,7 +449,6 @@ report_data_import <- function(con, name, id, config) {
       dat_rds$meta$instance[[type]]
     })
     instances <- instances[!vlapply(instances, is.null)]
-    browser()
     if (length(instances) > 0) {
       report_version_instance <- data_frame(
         id = id,

--- a/R/db2.R
+++ b/R/db2.R
@@ -445,21 +445,16 @@ report_data_import <- function(con, name, id, config) {
   ## DB instance:
   if (!is.null(dat_rds$meta$instance)) {
     ## Only add row where instance is set
-    build_row <- function(type) {
-      instance <- dat_rds$meta$instance[[type]]
-      row <- NULL
-      if (!is.null(instance)) {
-        row <- list(report_version = id,
-                    type = type,
-                    instance = instance
-        )
-      }
-      row
-    }
-    report_version_instance <- lapply(names(dat_rds$meta$instance), build_row)
-    report_version_instance <- do.call(rbind.data.frame,
-                                       report_version_instance)
-    if (!is.null(report_version_instance)) {
+    instances <- lapply(names(dat_rds$meta$instance), function(type) {
+      dat_rds$meta$instance[[type]]
+    })
+    instances <- instances[!vlapply(instances, is.null)]
+    browser()
+    if (length(instances) > 0) {
+      report_version_instance <- data_frame(
+        id = id,
+        type = names(instances),
+        instance = list_to_character(instances))
       DBI::dbWriteTable(con, "report_version_instance", report_version_instance,
                         append = TRUE)
     }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,7 +33,7 @@ RUN install2.r \
   yaml \
   zip
 
-RUN Rscript -e 'remove.packages("BH")'
+RUN Rscript -e 'remove.packages("BH")' || true
 
 # Install Pandoc
 ENV PANDOC_VERSION "2.7.3"

--- a/inst/database/schema.yml
+++ b/inst/database/schema.yml
@@ -139,6 +139,13 @@ report_version_package:
     - package_name: {type: TEXT}
     - package_version: {type: TEXT}
 
+# Database instances the report version pulled data from
+report_version_instance:
+  columns:
+    - report_version: {fk: report_version.id}
+    - type: {type: TEXT}
+    - instance: {type: TEXT}
+
 # Values here will be populated by orderly as we keep a list in the
 # package and we should not repeat that definition.
 artefact_format:


### PR DESCRIPTION
Does this need any migration test? I think the specific migration tests are for migrations to the archive? But here this is just db update which will be managed automatically by running `orderly_rebuild` I believe? 