### PR TITLE
Fix gitignore in orderly git example

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.2.34
+Version: 1.2.35
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/R/testing.R
+++ b/R/testing.R
@@ -271,7 +271,7 @@ prepare_orderly_git_example <- function(path = tempfile(), run_report = FALSE,
 
 
 prepare_basic_git <- function(path, quiet) {
-  file.copy(orderly_file("init/gitignore"), path)
+  orderly_use_gitignore(path, prompt = FALSE, show = FALSE)
   gert::git_init(path)
   withr::with_dir(
     path,

--- a/inst/init/gitignore
+++ b/inst/init/gitignore
@@ -17,3 +17,6 @@ orderly_envir.yml
 .Rhistory
 .Rdata
 .Rproj.user
+
+# Created by orderly.server
+runner


### PR DESCRIPTION
This is a helper used by orderly.server, the gitignore was saved as `gitignore` instead of `.gitignore` so wasn't being used. Also added `/runner` dir to gitignore which gets created by orderly.server