### PR TITLE
Much clearer error message on query failure

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.2.37
+Version: 1.2.38
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# orderly 1.2.38
+
+* Much clearer error message where dependency resolution fails due to a query dependency (vimc-4499)
+
 # orderly 1.2.37
 
 * Add function `orderly_remote_status` to return details of currently running and queued reports on the remote queue.

--- a/R/remote.R
+++ b/R/remote.R
@@ -118,16 +118,30 @@ orderly_pull_archive <- function(name, id = "latest", root = NULL,
   if (id == "latest") {
     id <- latest_id(v)
   } else if (id_is_query(id)) {
-    id <- orderly_search(id, name, parameters, root = root, remote = remote)
-  }
-
-  if (!(id %in% v)) {
-    ## Confirm that the report does actually exist, working around
-    ## VIMC-1281:
-    stop(sprintf(
-      "Version '%s' not found at '%s': valid versions are:\n%s",
-      id, remote_name(remote), paste(sprintf("  - %s", v), collapse = "\n")),
-      call. = FALSE)
+    query <- id
+    id <-
+      orderly_search(id, name, parameters, root = root, remote = remote)
+    if (is.na(id)) {
+      msg <- c(
+        sprintf("Failed to find suitable version of '%s' with query:", name),
+        sprintf("  '%s'", query),
+        "and parameters",
+        sprintf("  - %s: %s", names(parameters),
+                vcapply(parameters, as.character)))
+      stop(paste(msg, collapse = "\n"), call. = FALSE)
+    }
+  } else {
+    ## We've been given a direct id so we just need to check that it
+    ## exists
+    if (!(id %in% v)) {
+      ## Confirm that the report does actually exist, working around
+      ## VIMC-1281:
+      stop(sprintf(
+        "Version '%s' of '%s' not found at '%s': valid versions are:\n%s",
+        id, name, remote_name(remote),
+        paste(sprintf("  - %s", v), collapse = "\n")),
+        call. = FALSE)
+    }
   }
 
   dest <- file.path(path_archive(config$root), name, id)

--- a/tests/testthat/test-dependency.R
+++ b/tests/testthat/test-dependency.R
@@ -603,7 +603,7 @@ test_that("dependency latest with search query", {
 })
 
 
-test_that("...", {
+test_that("Sensible error message if query fails", {
   dat <- prepare_orderly_query_example()
   remote <- orderly_remote_path(dat$root)
 
@@ -624,9 +624,8 @@ test_that("...", {
     "Failed to find suitable version of 'other' with query:")
 
   expect_error(
-    orderly_pull_dependencies("use_dependency", parameters = list(x = 0.05),
-                              remote = remote, root = path_local),
     orderly_pull_archive("other", "latest(parameter:nmin < x)",
                          parameters = list(x = 0.05),
-                         remote = remote, root = path_local))
+                         remote = remote, root = path_local),
+    "Failed to find suitable version of 'other' with query:")
 })

--- a/tests/testthat/test-dependency.R
+++ b/tests/testthat/test-dependency.R
@@ -629,6 +629,4 @@ test_that("...", {
     orderly_pull_archive("other", "latest(parameter:nmin < x)",
                          parameters = list(x = 0.05),
                          remote = remote, root = path_local))
-
-  orderly_search("1 == 1", "other", root = path_local, remote = remote)
 })

--- a/tests/testthat/test-dependency.R
+++ b/tests/testthat/test-dependency.R
@@ -601,3 +601,34 @@ test_that("dependency latest with search query", {
   expect_equal(child_1$name, "other")
   expect_length(child_1$children, 0)
 })
+
+
+test_that("...", {
+  dat <- prepare_orderly_query_example()
+  remote <- orderly_remote_path(dat$root)
+
+  path_local <- prepare_orderly_example("demo")
+  config <- orderly_config_$new(path_local)
+
+  p <- file.path(path_local, "src", "use_dependency", "orderly.yml")
+  txt <- readLines(p)
+  txt <- sub("latest", "latest(parameter:nmin < x)", txt, fixed = TRUE)
+  txt <- c(txt, c("parameters:",
+                  "  x:",
+                  "    default: 0.25"))
+  writeLines(txt, p)
+
+  expect_error(
+    orderly_pull_dependencies("use_dependency", parameters = list(x = 0.05),
+                              remote = remote, root = path_local),
+    "Failed to find suitable version of 'other' with query:")
+
+  expect_error(
+    orderly_pull_dependencies("use_dependency", parameters = list(x = 0.05),
+                              remote = remote, root = path_local),
+    orderly_pull_archive("other", "latest(parameter:nmin < x)",
+                         parameters = list(x = 0.05),
+                         remote = remote, root = path_local))
+
+  orderly_search("1 == 1", "other", root = path_local, remote = remote)
+})


### PR DESCRIPTION
Previously:

```
orderly_pull_dependencies("use_dependency", parameters = list(x = 0.05),
                            remote = remote, root = path_local)
Error: Version 'NA' not found at '/tmp/RtmpVm93uq/file2496161bcdf2': valid versions are:
  - 20210506-085109-de7f0302
  - 20210506-085110-419fde6e
  - 20210506-085110-7a8cd960
```

which is a problem because you don't even know what report it failed on, and the version information is no use. Now we get:

```
Error: Failed to find suitable version of 'other' with query:
  'latest(parameter:nmin < x)'
and parameters
  - x: 0.05
```

Better would be to find "close" parameter matches but that's nontrivial