### PR TITLE
mrc-2416: Add backup to gitignore

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.2.39
+Version: 1.2.40
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/R/testing.R
+++ b/R/testing.R
@@ -208,8 +208,11 @@ build_git_demo <- function() {
   git_run(c("config", "user.email", "email@example.com"), root = path,
           check = TRUE)
   git_run(c("config", "user.name", "orderly"), root = path, check = TRUE)
-  writeLines(c("source.sqlite", "orderly.sqlite", "archive", "data", "draft",
-               "extra", "runner", "upstream", "backup"),
+  orderly_use_gitignore(path, prompt = FALSE, show = FALSE)
+  gitignore <- readLines(file.path(path, ".gitignore"))
+  ## Ignore "extra" dir created above and "upstream" used to store a remote git
+  ## repo for testing in orderly.server
+  writeLines(c(gitignore, "extra", "upstream"),
              file.path(path, ".gitignore"))
   git_run(c("add", "."), root = path, check = TRUE)
   git_run(c("add", "-f", "archive", "data", "draft"), root = path, check = TRUE)

--- a/R/testing.R
+++ b/R/testing.R
@@ -208,8 +208,8 @@ build_git_demo <- function() {
   git_run(c("config", "user.email", "email@example.com"), root = path,
           check = TRUE)
   git_run(c("config", "user.name", "orderly"), root = path, check = TRUE)
-  writeLines(c("source.sqlite", "orderly.sqlite",
-               "archive", "data", "draft", "extra", "runner", "upstream"),
+  writeLines(c("source.sqlite", "orderly.sqlite", "archive", "data", "draft",
+               "extra", "runner", "upstream", "backup"),
              file.path(path, ".gitignore"))
   git_run(c("add", "."), root = path, check = TRUE)
   git_run(c("add", "-f", "archive", "data", "draft"), root = path, check = TRUE)

--- a/inst/init/gitignore
+++ b/inst/init/gitignore
@@ -20,3 +20,4 @@ orderly_envir.yml
 
 # Created by orderly.server
 runner
+backup


### PR DESCRIPTION
This PR will
* Add `backup` to gitignore file
* Use this in `build_git_demo` adding additional lines only needed for testing

Not ideal that there are `orderly.server` specific things bleeding into the repo setup here but keen to get in a fix as this is blocking front end tests running on buildkite and there is already `orderly.server` specific things in the `gitignore`