### PR TITLE
Remove git info from metadata to avoid dupe info

### DIFF
--- a/R/info.R
+++ b/R/info.R
@@ -46,10 +46,10 @@ orderly_info <- function(id, name, root = NULL, locate = TRUE) {
   ## Read rds
   ## Parse info out into nice format
   git <- NULL
-  if (!is.null(info$meta$git)) {
+  if (!is.null(info$git)) {
     git <- list(
-      branch = info$meta$git$branch,
-      ref = info$meta$git$sha_short
+      branch = info$git$branch,
+      ref = info$git$sha_short
     )
   }
   error <- NULL

--- a/R/orderly_version.R
+++ b/R/orderly_version.R
@@ -352,7 +352,6 @@ orderly_version <- R6::R6Class(
            elapsed = as.numeric(private$time$elapsed, "secs"),
            changelog = private$changelog,
            tags = private$tags,
-           git = private$preflight_info$git,
            batch_id = private$batch_id,
            workflow = private$workflow_id,
            data = private$postflight_info$data_info,
@@ -362,8 +361,7 @@ orderly_version <- R6::R6Class(
     write_orderly_run_rds = function() {
       session <- withr::with_envvar(private$envvar, session_info())
       session$meta <- private$metadata()
-      ## NOTE: git is here twice for some reason see VIMC-4613
-      session$git <- session$meta$git
+      session$git <- private$preflight_info$git
       session$archive_version <- cache$current_archive_version
       saveRDS(session, path_orderly_run_rds(private$workdir))
     },
@@ -386,8 +384,7 @@ orderly_version <- R6::R6Class(
       }
       session$error <- list(error = error, trace = trace)
       session$meta <- private$metadata()
-      ## NOTE: git is here twice for some reason see VIMC-4613
-      session$git <- session$meta$git
+      session$git <- private$preflight_info$git
       session$archive_version <- cache$current_archive_version
       saveRDS(session, path_orderly_fail_rds(private$workdir))
     }

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -1019,8 +1019,8 @@ test_that("failed run creates failed rds", {
 
   expect_equal(failed_rds$archive_version, cache$current_archive_version)
 
-  expect_equal(failed_rds$meta$git$branch, "master")
-  expect_equal(failed_rds$meta$git$status, " M src/minimal/script.R")
+  expect_equal(failed_rds$git$branch, "master")
+  expect_equal(failed_rds$git$status, " M src/minimal/script.R")
 })
 
 test_that("fail during cleanup creates failed rds", {


### PR DESCRIPTION
See previous discussion https://github.com/vimc/orderly/pull/273#discussion_r581923674

It looks like it is less disruptive to remove git from `meta$git` and only have it at path `git`, but happy to move if we think it fits beta as `meta$git`