### PR TITLE
Add pkgdown URL to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
              person("James", "Thompson", role = "aut"),
              person("Imperial College of Science, Technology and Medicine",
                     role = "cph"))
-URL: https://github.com/vimc/orderly
+URL: https://www.vaccineimpact.org/orderly/, https://github.com/vimc/orderly
 BugReports: https://github.com/vimc/orderly/issues
 SystemRequirements: git
 Imports:


### PR DESCRIPTION
Also, there's no pkgdown config file yet but it'd be good to have one and to add the URL to it as well (for e.g. Twitter metadata). :slightly_smiling_face: 