### PR TITLE
Add oldrel and 3.6 builds

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -26,6 +26,7 @@ jobs:
           - {os: macOS-latest, r: 'release'}
           - {os: ubuntu-20.04, r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
           - {os: ubuntu-20.04, r: 'devel', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+          - {os: ubuntu-20.04, r: 'oldrel', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -27,6 +27,7 @@ jobs:
           - {os: ubuntu-20.04, r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
           - {os: ubuntu-20.04, r: 'devel', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
           - {os: ubuntu-20.04, r: 'oldrel', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+          - {os: ubuntu-20.04, r: '3.6', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.3.3
+Version: 1.3.5
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# orderly 1.3.5
+
+* Fix backward compatibility with R 3.6.x, in the case of a report with zero of 2+ optional fields used (vimc-4766)
+
 # orderly 1.3.2
 
 * Allow partial pulling of orderly dependency trees, by passing `recursive = FALSE` to `orderly::orderly_pull_archive` and `orderly::orderly_pull_dependencies`. This can reduce the total amount of data transferred when you do not care as much about the integregity of the local archive (vimc-4320)

--- a/R/orderly_recipe.R
+++ b/R/orderly_recipe.R
@@ -342,6 +342,13 @@ recipe_validate_fields <- function(fields, config, filename) {
     if (config$fields$required[[i]] || !is.null(fields[[nm]])) {
       assert_scalar_character(fields[[nm]], sprintf("%s:%s", filename, nm))
     } else {
+      if (length(fields) == 0L) {
+        ## This is needed in for 3.6 compatibility, as '[[' assignment
+        ## into NULL with 3.6 coerces to character vector, while for
+        ## 4.0 and it coerces to list:
+        ## https://bugs.r-project.org/bugzilla/show_bug.cgi?id=17719
+        fields <- as.list(fields)
+      }
       fields[[nm]] <- NA_character_
     }
   }

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -1147,4 +1147,9 @@ test_that("Can run a report with no fields, when all are optional", {
   expect_equal(d$meta$extra_fields,
                data_frame(requester = NA_character_,
                           author = NA_character_))
+
+  orderly_commit(id, root = path)
+  con <- orderly_db("destination", root = path)
+  on.exit(DBI::dbDisconnect(con, add = TRUE, after = FALSE))
+  expect_equal(DBI::dbReadTable(con, "report_version")$id, id)
 })

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -1129,3 +1129,22 @@ test_that("orderly_run_internal can save workflow metadata", {
                data_frame(report_version = c(id, id2),
                           workflow_id = c("123", "123")))
 })
+
+
+test_that("Can run a report with no fields, when all are optional", {
+  path <- test_prepare_orderly_example("minimal")
+  on.exit(unlink(path, recursive = TRUE))
+
+  append_lines(
+    c("fields:", "  requester:",
+      "    required: false",
+      "  author:",
+      "    required: false"),
+    file.path(path, "orderly_config.yml"))
+
+  id <- orderly_run("example", root = path, echo = FALSE)
+  d <- readRDS(path_orderly_run_rds(file.path(path_draft(path), "example", id)))
+  expect_equal(d$meta$extra_fields,
+               data_frame(requester = NA_character_,
+                          author = NA_character_))
+})


### PR DESCRIPTION
See failing build for 778fc3f which replicates an issue that I could see on 3.6 locally. Different to the commit error, but I could not reproduce that (and had issues installing 3.6 into docker due to binary incompatibilities)

Version number set to merge after #294