### PR TITLE
Workaround for zip_list on large files

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.3.7
+Version: 1.3.8
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -133,7 +133,7 @@ orderly_bundle_import <- function(path, root = NULL, locate = TRUE) {
 
   name <- info$name
   id <- info$id
-  contents <- zip::zip_list(path)$filename
+  contents <- zip_list2(path)$filename
 
   if (!(sprintf("%s/pack/orderly_run.rds", id) %in% contents)) {
     stop("This does not look like a complete bundle (one that has been run)")
@@ -190,12 +190,12 @@ orderly_bundle_status <- function(path) {
 
 orderly_bundle_complete <- function(path) {
   re <- "^[0-9]{8}-[0-9]{6}-[[:xdigit:]]{8}/pack/orderly_run.rds$"
-  any(grepl(re, zip::zip_list(path)$filename))
+  any(grepl(re, zip_list2(path)$filename))
 }
 
 
 orderly_bundle_info <- function(path) {
-  id <- fs::path_split(zip::zip_list(path)$filename[[1]])[[1]]
+  id <- fs::path_split(zip_list2(path)$filename[[1]])[[1]]
 
   tmp <- tempfile()
   dir_create(tmp)

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -209,3 +209,20 @@ orderly_bundle_info <- function(path) {
                    path, e$message), call. = FALSE))
   readRDS(file.path(tmp, "info.rds"))
 }
+
+
+## This is a temporary workaround for zip, which has an issue running
+## zip_list on large archives. Fix for zip will be submitted in a PR
+## soon.
+zip_list2 <- function(path) {
+  tryCatch(zip::zip_list(path),
+           error = function(e)
+             tryCatch(zip_list_base(path),
+                      error = function(e2) stop(e)))
+}
+
+
+zip_list_base <- function(path) {
+  list <- utils::unzip(path, list = TRUE)
+  data.frame(filename = list$Name, stringsAsFactors = FALSE)
+}

--- a/tests/testthat/test-bundle.R
+++ b/tests/testthat/test-bundle.R
@@ -318,3 +318,53 @@ test_that("failed bundle run writes out failed rds", {
   expect_match(failed_rds$error$trace[length(failed_rds$error$trace)],
                'stop\\("some error"\\)')
 })
+
+
+test_that("zip list helper safely lists", {
+  skip_on_cran()
+  path <- test_prepare_orderly_example("minimal")
+  on.exit(unlink(path, recursive = TRUE))
+  path_bundles <- tempfile()
+  res <- orderly_bundle_pack(path_bundles, "example", root = path)
+  l1 <- zip::zip_list(res$path)$filename
+  l2 <- zip_list2(res$path)$filename
+  l3 <- zip_list_base(res$path)$filename
+
+  expect_equal(l1, l2)
+  expect_setequal(l3, l1)
+})
+
+
+test_that("fall back error handling", {
+  skip_on_cran()
+  skip_if_not_installed("mockery")
+
+  d <- data.frame(filename = "x")
+  mock_zip_zip_list <- mockery::mock(
+    d,
+    stop("some zip error"),
+    stop("some zip error"))
+  mock_base_zip_list <- mockery::mock(
+    d,
+    stop("some base error"))
+
+  mockery::stub(zip_list2, "zip::zip_list", mock_zip_zip_list)
+  mockery::stub(zip_list2, "zip_list_base", mock_base_zip_list)
+
+  expect_equal(zip_list2("path"), d)
+  mockery::expect_called(mock_zip_zip_list, 1)
+  mockery::expect_called(mock_base_zip_list, 0)
+
+  expect_equal(zip_list2("path"), d)
+  mockery::expect_called(mock_zip_zip_list, 2)
+  mockery::expect_called(mock_base_zip_list, 1)
+
+  expect_error(zip_list2("path"), "some zip error")
+  mockery::expect_called(mock_zip_zip_list, 3)
+  mockery::expect_called(mock_base_zip_list, 2)
+
+  expect_equal(mockery::mock_args(mock_zip_zip_list),
+               rep(list(list("path")), 3))
+  expect_equal(mockery::mock_args(mock_base_zip_list),
+               rep(list(list("path")), 2))
+})


### PR DESCRIPTION
This is temporary, and we may not merge it depending on how the fix to zip goes (see https://github.com/r-lib/zip/pull/79)

Let's merge for now and remove once zip is updated on CRAN