### PR TITLE
Prevent use of rm(list = ls()) in scripts

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.3.7
+Version: 1.3.8
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# orderly 1.3.8
+
+* Prevent use of `rm(list = ls())` (or similar) at the top of scripts as this leads to hard-to-track errors, modifies the global environment and is [generally poor practice](https://www.tidyverse.org/blog/2017/12/workflow-vs-script/) (vimc-4810)
+
 # orderly 1.3.5
 
 * Fix backward compatibility with R 3.6.x, in the case of a report with zero of 2+ optional fields used (vimc-4766)

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -1153,3 +1153,18 @@ test_that("Can run a report with no fields, when all are optional", {
   on.exit(DBI::dbDisconnect(con, add = TRUE, after = FALSE))
   expect_equal(DBI::dbReadTable(con, "report_version")$id, id)
 })
+
+
+test_that("prevent use of 'rm(list = ls())' at top level", {
+  path <- test_prepare_orderly_example("minimal")
+  on.exit(unlink(path, recursive = TRUE))
+
+  path_src <- file.path(path, "src", "example", "script.R")
+  src <- readLines(path_src)
+  writeLines(c("rm(list = ls(all = TRUE))", src), path_src)
+
+  expect_error(
+    orderly_run("example", root = path),
+    "Do not use 'rm(list = ls())' or similar in your script",
+    fixed = TRUE)
+})


### PR DESCRIPTION
As reported by @jeffeaton, this errors on scripts that use `rm(list = ls())` or similar. If this is to annoying we could hide this behind an option, though it's hard to immediately see a good reason to allow it.