### PR TITLE
Return filename from orderly_bundle_run

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.4.0
+Version: 1.4.1
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -115,7 +115,7 @@ orderly_bundle_run <- function(path, workdir = tempfile(), echo = TRUE,
 
   zip <- zip_dir(file.path(workdir, id))
   unlink(file.path(workdir, id), recursive = TRUE)
-  list(id = id, path = zip)
+  list(id = id, path = zip, filename = basename(zip))
 }
 
 

--- a/tests/testthat/test-bundle.R
+++ b/tests/testthat/test-bundle.R
@@ -17,6 +17,7 @@ test_that("pack bundle", {
   workdir <- tempfile()
   zip <- orderly_bundle_run(res$path, workdir, echo = FALSE)
   expect_equal(dir(workdir), basename(zip$path))
+  expect_equal(dir(workdir), zip$filename)
   orderly_bundle_import(zip$path, root = path2)
 
   expect_equal(orderly_list_archive(path2),
@@ -59,6 +60,7 @@ test_that("can run a bundle in place if wanted", {
 
   zip <- orderly_bundle_run(res$path, path_bundles, echo = FALSE)
   expect_true(same_path(zip$path, res$path))
+  expect_equal(zip$filename, basename(zip$path))
 
   l2 <- orderly_bundle_list(path_bundles)
   l1$status <- "complete"


### PR DESCRIPTION
This PR will add `filename` to return value from `orderly_bundle_run` so that if users are running bundles on different OS from their local one they can easily get the filename. As currently returned path e.g. on windows `"Q:\\contexts\\output\\20210921-093050-3c0953ad.zip"` when importing on linux this won't work and trying to construct the linux path from this is challenging because `basename` won't work.