### PR TITLE
Small tweaks noticed on win builder

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.4.1
+Version: 1.4.2
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.4.2
+Version: 1.4.3
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research
@@ -46,7 +46,7 @@ Suggests:
     rmarkdown,
     testthat,
     vaultr (>= 1.0.4)
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 Roxygen: list(markdown = TRUE)
 VignetteBuilder: knitr
 Language: en-GB

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@
 
 # orderly 1.3.2
 
-* Allow partial pulling of orderly dependency trees, by passing `recursive = FALSE` to `orderly::orderly_pull_archive` and `orderly::orderly_pull_dependencies`. This can reduce the total amount of data transferred when you do not care as much about the integregity of the local archive (vimc-4320)
+* Allow partial pulling of orderly dependency trees, by passing `recursive = FALSE` to `orderly::orderly_pull_archive` and `orderly::orderly_pull_dependencies`. This can reduce the total amount of data transferred when you do not care as much about the integrity of the local archive (vimc-4320)
 
 # orderly 1.2.41
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# orderly 1.4.3
+
+* Orderly now only records git information where a `.git` directory is found at the orderly root (vimc-4866)
+
 # orderly 1.3.8
 
 * Prevent use of `rm(list = ls())` (or similar) at the top of scripts as this leads to hard-to-track errors, modifies the global environment and is [generally poor practice](https://www.tidyverse.org/blog/2017/12/workflow-vs-script/) (vimc-4810)

--- a/R/deduplicate.R
+++ b/R/deduplicate.R
@@ -17,13 +17,11 @@
 ##' case already.
 ##'
 ##' With "hard linking", two files with the same content can be
-##' updated so that both files point at the same physical bit of data
-##' (see [this Wikipedia page for more
-##' information](https://en.wikipedia.org/wiki/Hard_link).  This is
-##' great, as if the file is large, then only one copy needs to be
-##' stored.  However, this means that if a change is made to one copy
-##' of the file, it is immediately reflected in the other, but there
-##' is nothing to indicate that the files are linked!
+##' updated so that both files point at the same physical bit of data.
+##' This is great, as if the file is large, then only one copy needs
+##' to be stored.  However, this means that if a change is made to one
+##' copy of the file, it is immediately reflected in the other, but
+##' there is nothing to indicate that the files are linked!
 ##'
 ##' This approach is worth exploring if you have large files that are
 ##' outputs of one report and inputs to another, or large inputs

--- a/R/logging.R
+++ b/R/logging.R
@@ -36,24 +36,6 @@
 ##' # We are going to log things below
 ##' logging_was_enabled <- orderly::orderly_log_on()
 ##'
-##' path <- orderly::orderly_example("minimal")
-##'
-##' # By default we get both orderly log messages (e.g.,
-##' # "[name] example") and the output of R when it runs the report:
-##' orderly::orderly_run("example", root = path)
-##'
-##' # Passing FALSE to the echo argument suppresses R's output but not
-##' # orderly messages:
-##' orderly::orderly_run("example", root = path, echo = FALSE)
-##'
-##' # Disabling the log suppresses orderly's messages but still
-##' # displays R's output:
-##' orderly::orderly_log_off()
-##' orderly::orderly_run("example", root = path)
-##'
-##' # And using both will prevent all output
-##' orderly::orderly_run("example", root = path, echo = FALSE)
-##'
 ##' # About orderly log messages:
 ##' # Orderly log messages have the form "[title] message"
 ##' orderly::orderly_log_on()

--- a/R/remote.R
+++ b/R/remote.R
@@ -146,6 +146,7 @@ orderly_pull_archive <- function(name, id = "latest", root = NULL,
 
 orderly_pull_metadata <- function(name, id, root = NULL, locate = TRUE,
                                   remote = NULL) {
+  parameters <- NULL
   info <- pull_info(name, id, root, locate, remote, parameters)
   name <- info$name
   id <- info$id

--- a/R/util.R
+++ b/R/util.R
@@ -259,8 +259,7 @@ orderly_env <- function() {
 session_info <- function(path = ".") {
   list(session_info = utils::sessionInfo(),
        time = Sys.time(),
-       env = orderly_env(),
-       git = git_info(path))
+       env = orderly_env())
 }
 
 ## Because time handling is a total faff:
@@ -319,6 +318,9 @@ git_info_call <- function(root, args) {
 
 git_info <- function(root) {
   if (isTRUE(getOption("orderly.nogit", FALSE))) {
+    return(NULL)
+  }
+  if (is.null(root) || !file.exists(file.path(root, ".git"))) {
     return(NULL)
   }
   sha <- git_info_call(root, c("rev-parse", "HEAD"))

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 > 2. a soldier who carries orders or performs minor tasks for an officer.
 
 
-`orderly` is a package designed to help make analysis more [reproducible](https://en.wikipedia.org/wiki/Reproducibility).  Its principal aim is to automate a series of basic steps in the process of writing analyses, making it easy to:
+`orderly` is a package designed to help make analysis more reproducible.  Its principal aim is to automate a series of basic steps in the process of writing analyses, making it easy to:
 
 * track all inputs into an analysis (packages, code, and data resources)
 * store multiple versions of an analysis where it is repeated

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Then `orderly`:
 6. then runs the analysis
 7. verifies that the declared artefacts are produced
 
-It then stores metadata alongside the analysis including [md5 hashes](https://en.wikipedia.org/wiki/Hash_function) of all inputs and outputs, copies of data extracted from the database, a record of all R packages loaded at the end of the session, and (if using git) information about the git state (hash, branch and status).
+It then stores metadata alongside the analysis including hashes of all inputs and outputs, copies of data extracted from the database, a record of all R packages loaded at the end of the session, and (if using git) information about the git state (hash, branch and status).
 
 Then if one of the dependencies of a report changes (the used data, code, etc), we have metadata that can be queried to identify the likely source of the change.
 

--- a/man-roxygen/example-remote.R
+++ b/man-roxygen/example-remote.R
@@ -30,7 +30,7 @@ path_local <- orderly::orderly_example("demo")
 # a copy of the report "other", on which it depends:
 try(orderly::orderly_run("use_dependency", root = path_local))
 
-# We can "pull" depenencies of a report before running
+# We can "pull" dependencies of a report before running
 orderly::orderly_pull_dependencies("use_dependency", remote = remote,
                                    root = path_local)
 

--- a/man/orderly_deduplicate.Rd
+++ b/man/orderly_deduplicate.Rd
@@ -46,12 +46,11 @@ archive is behind OrderlyWeb this will almost certainly be the
 case already.
 
 With "hard linking", two files with the same content can be
-updated so that both files point at the same physical bit of data
-(see \href{https://en.wikipedia.org/wiki/Hard_link}{this Wikipedia page for more information}.  This is
-great, as if the file is large, then only one copy needs to be
-stored.  However, this means that if a change is made to one copy
-of the file, it is immediately reflected in the other, but there
-is nothing to indicate that the files are linked!
+updated so that both files point at the same physical bit of data.
+This is great, as if the file is large, then only one copy needs
+to be stored.  However, this means that if a change is made to one
+copy of the file, it is immediately reflected in the other, but
+there is nothing to indicate that the files are linked!
 
 This approach is worth exploring if you have large files that are
 outputs of one report and inputs to another, or large inputs

--- a/man/orderly_log.Rd
+++ b/man/orderly_log.Rd
@@ -48,24 +48,6 @@ format, etc.
 # We are going to log things below
 logging_was_enabled <- orderly::orderly_log_on()
 
-path <- orderly::orderly_example("minimal")
-
-# By default we get both orderly log messages (e.g.,
-# "[name] example") and the output of R when it runs the report:
-orderly::orderly_run("example", root = path)
-
-# Passing FALSE to the echo argument suppresses R's output but not
-# orderly messages:
-orderly::orderly_run("example", root = path, echo = FALSE)
-
-# Disabling the log suppresses orderly's messages but still
-# displays R's output:
-orderly::orderly_log_off()
-orderly::orderly_run("example", root = path)
-
-# And using both will prevent all output
-orderly::orderly_run("example", root = path, echo = FALSE)
-
 # About orderly log messages:
 # Orderly log messages have the form "[title] message"
 orderly::orderly_log_on()

--- a/man/orderly_pull_dependencies.Rd
+++ b/man/orderly_pull_dependencies.Rd
@@ -148,7 +148,7 @@ path_local <- orderly::orderly_example("demo")
 # a copy of the report "other", on which it depends:
 try(orderly::orderly_run("use_dependency", root = path_local))
 
-# We can "pull" depenencies of a report before running
+# We can "pull" dependencies of a report before running
 orderly::orderly_pull_dependencies("use_dependency", remote = remote,
                                    root = path_local)
 

--- a/man/orderly_remote_path.Rd
+++ b/man/orderly_remote_path.Rd
@@ -57,7 +57,7 @@ path_local <- orderly::orderly_example("demo")
 # a copy of the report "other", on which it depends:
 try(orderly::orderly_run("use_dependency", root = path_local))
 
-# We can "pull" depenencies of a report before running
+# We can "pull" dependencies of a report before running
 orderly::orderly_pull_dependencies("use_dependency", remote = remote,
                                    root = path_local)
 

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -1020,9 +1020,9 @@ test_that("failed run creates failed rds", {
   expect_true(file.exists(path_orderly_fail_rds(draft_dir)))
 
   failed_rds <- readRDS(path_orderly_fail_rds(draft_dir))
-  expect_equal(names(failed_rds),
-               c("session_info", "time", "env", "git", "error", "meta",
-                 "archive_version"))
+  expect_setequal(names(failed_rds),
+                  c("session_info", "time", "env", "git", "error", "meta",
+                    "archive_version"))
 
   expect_s3_class(failed_rds$error$error, "simpleError")
   expect_equal(failed_rds$error$error$message, "some error")

--- a/vignettes/orderly.Rmd
+++ b/vignettes/orderly.Rmd
@@ -48,7 +48,7 @@ knitr::knit_hooks$set(with_path = function(before, options, envir) {
 
 <!-- introduction begin -->
 
-`orderly` is a package designed to help make analysis more [reproducible](https://en.wikipedia.org/wiki/Reproducibility).  Its principal aim is to automate a series of basic steps in the process of writing analyses, making it easy to:
+`orderly` is a package designed to help make analysis more reproducible.  Its principal aim is to automate a series of basic steps in the process of writing analyses, making it easy to:
 
 * track all inputs into an analysis (packages, code, and data resources)
 * store multiple versions of an analysis where it is repeated

--- a/vignettes/orderly.Rmd
+++ b/vignettes/orderly.Rmd
@@ -104,7 +104,7 @@ Then `orderly`:
 6. then runs the analysis
 7. verifies that the declared artefacts are produced
 
-It then stores metadata alongside the analysis including [md5 hashes](https://en.wikipedia.org/wiki/Hash_function) of all inputs and outputs, copies of data extracted from the database, a record of all R packages loaded at the end of the session, and (if using git) information about the git state (hash, branch and status).
+It then stores metadata alongside the analysis including hashes of all inputs and outputs, copies of data extracted from the database, a record of all R packages loaded at the end of the session, and (if using git) information about the git state (hash, branch and status).
 
 Then if one of the dependencies of a report changes (the used data, code, etc), we have metadata that can be queried to identify the likely source of the change.
 

--- a/vignettes/patterns.Rmd
+++ b/vignettes/patterns.Rmd
@@ -48,7 +48,7 @@ However, we still must synchronise the reports that have been run.  Of course ev
 
 What we want is that after a particular version of a report has been run, it is easy for other people to start depending on it.  To achieve this we need a method for getting the archive from one person's computer to another.
 
-For this discussion we will assume two researchers ["Alice" and "Bob"](https://en.wikipedia.org/wiki/Alice_and_Bob) rather than "Researcher A" and "Researcher B".
+For this discussion we will assume two researchers "Alice" and "Bob" (rather than "Researcher A" and "Researcher B").
 
 Alice develops a report `report-a` on her computer by running `orderly::orderly_new("report-a")` and working with `orderly::orderly_develop_start()` and `orderly::orderly_run()` until she is happy with the results.  She then creates a pull request, and Bob approves it (probably after checking that the report runs on his machine too) and merges it.
 
@@ -66,7 +66,7 @@ remote:
       path: $ORDERLY_PATH_DEFAULT_REMOTE
 ```
 
-This tells `orderly` that we will use a file-based remote source (i.e., a shared copy of orderly) and that the path to this source is determined by the [Environment variable](https://en.wikipedia.org/wiki/Environment_variable) `ORDERLY_PATH_DEFAULT_REMOTE`.  Using an environment variable is necessary here as this path will certainly differ between Alice and Bob.
+This tells `orderly` that we will use a file-based remote source (i.e., a shared copy of orderly) and that the path to this source is determined by the Environment variable `ORDERLY_PATH_DEFAULT_REMOTE`.  Using an environment variable is necessary here as this path will certainly differ between Alice and Bob.
 
 To fill in the environment variable we create a file `orderly_envir.yml` (which should be added to `.gitignore`) containing the path to the shared source.  For Alice, this might look like
 
@@ -112,7 +112,7 @@ As above, we use a single "source tree", kept on GitHub or similar.  However, so
 
 1. A persistent copy of R running `orderly` that can run reports as needed
 2. A web server that exposes a user-friendly web portal showing versions of orderly reports and an HTTP API (this application is written in [Kotlin](https://kotlinlang.org))
-3. A [reverse proxy](https://en.wikipedia.org/wiki/Reverse_proxy) used to secure the application with https
+3. A reverse proxy used to secure the application with https
 
 This [diagram may help show how the pieces fit together](https://raw.githubusercontent.com/vimc/montagu-machine/master/docs/diagrams/OrderlyWeb%20architecture.png).
 

--- a/vignettes/remote.Rmd
+++ b/vignettes/remote.Rmd
@@ -25,7 +25,7 @@ The OrderlyWeb server software provides a number of things
 
 1. A persistent copy of R running `orderly` that can run reports as needed using the `orderly.server::orderly_runner` function
 2. A web server that exposes a user-friendly web portal showing versions of orderly reports and an http api (this application is written in [Kotlin](https://kotlinlang.org))
-3. A [reverse proxy](https://en.wikipedia.org/wiki/Reverse_proxy) used to secure the application with https
+3. A reverse proxy used to secure the application with https
 
 A [diagram may help show how the pieces fit together](https://raw.githubusercontent.com/vimc/montagu-machine/master/docs/diagrams/OrderlyWeb%20architecture.png)
 


### PR DESCRIPTION
Small QA things seen on win builder (https://win-builder.r-project.org/z4Ye9MEJqD0r/00check.log)

```
* checking CRAN incoming feasibility ... NOTE
Maintainer: 'Rich FitzJohn <rich.fitzjohn@gmail.com>'

Found the following (possibly) invalid URLs:
  URL: https://en.wikipedia.org/wiki/Hash_function
    From: inst/doc/orderly.html
          README.md
    Status: Error
    Message: Failed to connect to en.wikipedia.org port 443: Timed out
...
* checking R code for possible problems ... [22s] NOTE
orderly_pull_metadata: no visible binding for global variable
  'parameters'
Undefined global functions or variables:
  parameters
```

* removed wikipedia links, which is a pity. We can add it later but it will hold things up if it's flakey, or risk the package being pulled at the same time it grinds through a manual review even if it's a false positive (this has happened before)
* fixed the unbound variable issue (was never referenced, but dealt with tidily)
* also spelling fixes