### PR TITLE
Update orderly demo script to include dependency reports in git example

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.4.3
+Version: 1.4.4
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/R/testing.R
+++ b/R/testing.R
@@ -221,8 +221,8 @@ build_git_demo <- function() {
 
   prev <- git_checkout_branch("other", root = path, create = TRUE)
 
-  file.rename(file.path(path, "extra", "other"),
-              file.path(path, "src", "other"))
+  file.rename(file.path(path, "extra", move),
+              file.path(path, "src", move))
   unlink(file.path(path, "extra"), recursive = TRUE)
   git_run(c("add", "."), root = path)
   git_run(c("commit", "-m", "'add-other'"), root = path)

--- a/inst/create_orderly_demo.sh
+++ b/inst/create_orderly_demo.sh
@@ -6,4 +6,3 @@ if [ "$#" -ne 1 ]; then
 fi
 DEST=$1
 Rscript -e "orderly:::create_orderly_demo(\"$DEST/demo\", git = TRUE)"
-Rscript -e "orderly:::prepare_orderly_git_example(\"$DEST/git\", TRUE)"

--- a/inst/create_orderly_demo.sh
+++ b/inst/create_orderly_demo.sh
@@ -5,4 +5,4 @@ if [ "$#" -ne 1 ]; then
     exit 1
 fi
 DEST=$1
-Rscript -e "orderly:::create_orderly_demo(\"$DEST/demo\", git = TRUE)"
+Rscript -e "orderly:::prepare_orderly_git_example(\"$DEST/demo\", TRUE)"

--- a/inst/create_orderly_demo.sh
+++ b/inst/create_orderly_demo.sh
@@ -5,4 +5,5 @@ if [ "$#" -ne 1 ]; then
     exit 1
 fi
 DEST=$1
-Rscript -e "orderly:::prepare_orderly_git_example(\"$DEST/demo\", TRUE)"
+Rscript -e "orderly:::create_orderly_demo(\"$DEST/demo\", git = TRUE)"
+Rscript -e "orderly:::prepare_orderly_git_example(\"$DEST/git\", TRUE)"


### PR DESCRIPTION
This simplifies the orderly test setup for OrderlyWeb
The `demo` dir will contain an orderly root with git and with reports have use dependencies `use_dependency` and `use_dependency_2`