### PR TITLE
Return more informative error from deduplication

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.4.4
+Version: 1.4.5
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/R/deduplicate.R
+++ b/R/deduplicate.R
@@ -83,6 +83,7 @@ orderly_deduplicate_info <- function(config) {
                           files$filename,
                           fsep = "/")
 
+  paths <- file.path(config$root, "archive", files$path)
   ## Information about the physical files, so we can work out which
   ## files are already hardlinked
   files <- cbind(

--- a/R/deduplicate.R
+++ b/R/deduplicate.R
@@ -79,6 +79,13 @@ orderly_deduplicate_info <- function(config) {
                           fsep = "/")
 
   paths <- file.path(config$root, "archive", files$path)
+  exists <- vlapply(paths, file.exists)
+  if (any(!exists)) {
+    stop(paste0("Cannot deduplicate archive as database references files ",
+                "which don't exist, this could be because they have been ",
+                "pulled from an archive with recursive = FALSE"))
+  }
+
   ## Information about the physical files, so we can work out which
   ## files are already hardlinked
   files <- cbind(

--- a/R/deduplicate.R
+++ b/R/deduplicate.R
@@ -103,10 +103,10 @@ orderly_deduplicate_info <- function(config) {
     unname(tapply(files$inode, files$hash, function(x) x[[1L]]))[i]
 
   ## Quick check:
-  cannot_deduplicate <- all(vlapply(split(files, files$hash), function(x) {
+  can_deduplicate <- all(vlapply(split(files, files$hash), function(x) {
     all(x$inode_first == x$inode[[1]])
   }))
-  if (cannot_deduplicate) {
+  if (!can_deduplicate) {
     stop(paste("Cannot deduplicate archive as database references files",
                 "which don't exist."))
   }

--- a/R/deduplicate.R
+++ b/R/deduplicate.R
@@ -104,7 +104,7 @@ orderly_deduplicate_info <- function(config) {
 
   ## Quick check:
   can_deduplicate <- all(vlapply(split(files, files$hash), function(x) {
-    all(x$inode_first == x$inode[[1]])
+    isTRUE(all(x$inode_first == x$inode[[1]]))
   }))
   if (!can_deduplicate) {
     stop(paste("Cannot deduplicate archive as database references files",

--- a/docker/build_website
+++ b/docker/build_website
@@ -22,6 +22,7 @@ DB_NAME=orderly
 SCHEMASPY_NAME=vimc/orderly-schemaspy
 
 DOCS_DIR=$PACKAGE_ROOT/docs
+VIGNETTES_DIR=$PACKAGE_ROOT/vignettes
 
 docker build \
        --build-arg ORDERLY_BASE=$ORDERLY_BASE \
@@ -65,6 +66,7 @@ docker run --rm \
        --network=$DB_NW \
        -w /orderly \
        -v $DOCS_DIR:/orderly/docs \
+       -v $VIGNETTES_DIR:/orderly/vignettes \
        --user "$USER_STR" \
        $ORDERLY_DEV \
        Rscript -e 'pkgdown::build_site(document = FALSE)'

--- a/tests/testthat/test-deduplicate.R
+++ b/tests/testthat/test-deduplicate.R
@@ -184,9 +184,9 @@ test_that("deduplicate fails if file is missing", {
 
   unlink(file.path(path, "archive", "minimal", id1, "script.R"))
 
-  expect_error(orderly_deduplicate_info(orderly_config(path), paste(
+  expect_error(orderly_deduplicate_info(orderly_config(path)), paste(
     "Cannot deduplicate archive as database references files",
-    "which don't exist.")))
+    "which don't exist."))
 })
 
 test_that("deduplicate fails if report pulled from remote recursive FALSE", {

--- a/tests/testthat/test-deduplicate.R
+++ b/tests/testthat/test-deduplicate.R
@@ -184,8 +184,20 @@ test_that("deduplicate fails if file is missing", {
 
   unlink(file.path(path, "archive", "minimal", id1, "script.R"))
 
-  expect_error(orderly_deduplicate_info(orderly_config(path), paste0(
-    "Cannot deduplicate archive as database references files ",
-    "which don't exist, this could be because they have been ",
-    "pulled from an archive with recursive = FALSE ")))
+  expect_error(orderly_deduplicate_info(orderly_config(path), paste(
+    "Cannot deduplicate archive as database references files",
+    "which don't exist.")))
+})
+
+test_that("deduplicate fails if report pulled from remote recursive FALSE", {
+  skip_on_cran()
+  dat <- prepare_orderly_remote_example()
+  id3 <- orderly_run("depend", root = dat$path_remote, echo = FALSE)
+  orderly_commit(id3, root = dat$path_remote)
+
+  orderly_pull_archive("depend", root = dat$config, remote = dat$remote,
+                       recursive = FALSE)
+  expect_error(orderly_deduplicate_info(dat$config), paste(
+    "Cannot deduplicate archive reports have been pulled from",
+    "remote with recursive = FALSE."))
 })

--- a/tests/testthat/test-deduplicate.R
+++ b/tests/testthat/test-deduplicate.R
@@ -172,3 +172,20 @@ test_that("relink error handling", {
   expect_error(relink(from, to), "Some error linking")
   expect_true(all(fs::file_info(c(from, to))$inode == info))
 })
+
+
+test_that("deduplicate fails if file is missing", {
+  skip_on_cran()
+  path <- orderly_example("demo")
+  id1 <- orderly_run("minimal", root = path, echo = FALSE)
+  id2 <- orderly_run("minimal", root = path, echo = FALSE)
+  orderly_commit(id1, root = path)
+  orderly_commit(id2, root = path)
+
+  unlink(file.path(path, "archive", "minimal", id1, "script.R"))
+
+  expect_error(orderly_deduplicate_info(orderly_config(path), paste0(
+    "Cannot deduplicate archive as database references files ",
+    "which don't exist, this could be because they have been ",
+    "pulled from an archive with recursive = FALSE ")))
+})


### PR DESCRIPTION
I've put this error in as soon as we list the paths to fail early. And not removed the 
```
stopifnot(all(vlapply(split(files, files$hash), function(x)
    all(x$inode_first == x$inode[[1]]))))
```
which is what Oli has been seeing error previously. I can remove it if you think no longer relevant