### PR TITLE
Add an example report to orderly demo which includes a default parameter

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.4.5
+Version: 1.4.6
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/inst/examples/demo/src/default-param/README.md
+++ b/inst/examples/demo/src/default-param/README.md
@@ -1,0 +1,1 @@
+This is a report

--- a/inst/examples/demo/src/default-param/orderly.yml
+++ b/inst/examples/demo/src/default-param/orderly.yml
@@ -1,0 +1,14 @@
+parameters:
+  nmin:
+    default: 0.5
+  disease:
+    default: HepB
+script: script.R
+artefacts:
+  - staticgraph:
+      description: A summary graaph
+      filenames: graph.png
+displayname: default param report
+
+author: Dr Serious
+requester: ACME

--- a/inst/examples/demo/src/default-param/script.R
+++ b/inst/examples/demo/src/default-param/script.R
@@ -1,0 +1,4 @@
+png("graph.png")
+par(mar = c(4, 4, 4, .5))
+barplot(nmin, main = disease)
+dev.off()


### PR DESCRIPTION
Requested by @LekanAnni for testing something in orderly web. Atm there is no demo report with a default parameter.

I've checked this doesn't affect any of the orderly.server tests