### PR TITLE
vimc-4875: Add mode to batch run to continue on failure

### DIFF
--- a/R/batch.R
+++ b/R/batch.R
@@ -60,6 +60,7 @@ orderly_batch <- function(name = NULL, parameters = NULL,
     })
   }
   reports <- lapply(df2list(parameters), run_report)
-  bind_df <- function(...) rbind.data.frame(..., make.row.names = FALSE)
+  bind_df <- function(...) rbind.data.frame(..., make.row.names = FALSE,
+                                            stringsAsFactors = FALSE)
   do.call(bind_df, reports)
 }

--- a/R/batch.R
+++ b/R/batch.R
@@ -11,6 +11,12 @@
 ##' @param parameters Data frame of parameters passed to report. Each row
 ##'   represents a parameter set to be passed to one report run.
 ##'
+##' @param continue_on_error If FALSE then if one report run fails the
+##'   function will not attempt to run subsequent reports in the batch. If
+##'   TRUE subsequent parameter sets will be run. If the report run fails
+##'   during preparation e.g. because of missing parameters this will
+##'   error and stop all subsequent parameter sets.
+##'
 ##' @param ... Additional args passed to [orderly::orderly_run()]
 ##'
 ##' @seealso [orderly::orderly_run()] for details of report running
@@ -23,18 +29,38 @@
 ##' path <- orderly::orderly_example("demo")
 ##' params <- data.frame(nmin = c(0.2, 0.25))
 ##' ids <- orderly::orderly_batch("other", params, root = path)
-orderly_batch <- function(name = NULL, parameters = NULL, ...) {
+orderly_batch <- function(name = NULL, parameters = NULL,
+                          continue_on_error = TRUE, ...) {
   if (NROW(parameters) < 1) {
     stop("Parameters for a batch must be a data frame with at least one row")
   }
   batch_id <- ids::random_id()
-  reports <- lapply(df2list(parameters), function(parameter_set) {
-    id <- orderly_run_internal(name, parameters = parameter_set, ...,
-                               batch_id = batch_id)
-    c(id = id,
-      success = TRUE,
-      as.list(parameter_set))
-  })
+  run_report <- function(parameter_set) {
+    id_file <- tempfile()
+    tryCatch({
+      id <- orderly_run_internal(name, parameters = parameter_set, ...,
+                                 batch_id = batch_id, id_file = id_file)
+      message("\n")
+      c(id = id,
+        success = TRUE,
+        as.list(parameter_set))
+    }, error = function(e) {
+      if (!file.exists(id_file) || !continue_on_error) {
+        ## In this case that id_file doesn't exist it means run has
+        ## failed during run_read so some issue with args to
+        ## orderly_run_internal which have caused error before
+        ## ID can even be generated. Error early so  user can fix
+        ## issue with inputs.
+        stop(e)
+      }
+      message(sprintf("Report run failed: %s\n", e$message))
+      id <- readLines(id_file)
+      c(id = id,
+        success = FALSE,
+        as.list(parameter_set))
+    })
+  }
+  reports <- lapply(df2list(parameters), run_report)
   bind_df <- function(...) rbind.data.frame(..., make.row.names = FALSE)
   do.call(bind_df, reports)
 }

--- a/R/batch.R
+++ b/R/batch.R
@@ -28,8 +28,13 @@ orderly_batch <- function(name = NULL, parameters = NULL, ...) {
     stop("Parameters for a batch must be a data frame with at least one row")
   }
   batch_id <- ids::random_id()
-  vcapply(df2list(parameters), function(parameter_set) {
-    orderly_run_internal(name, parameters = parameter_set, ...,
-                         batch_id = batch_id)
+  reports <- lapply(df2list(parameters), function(parameter_set) {
+    id <- orderly_run_internal(name, parameters = parameter_set, ...,
+                               batch_id = batch_id)
+    c(id = id,
+      success = TRUE,
+      as.list(parameter_set))
   })
+  bind_df <- function(...) rbind.data.frame(..., make.row.names = FALSE)
+  do.call(bind_df, reports)
 }

--- a/R/batch.R
+++ b/R/batch.R
@@ -40,7 +40,6 @@ orderly_batch <- function(name = NULL, parameters = NULL,
     tryCatch({
       id <- orderly_run_internal(name, parameters = parameter_set, ...,
                                  batch_id = batch_id, id_file = id_file)
-      message("\n")
       c(id = id,
         success = TRUE,
         as.list(parameter_set))

--- a/R/main.R
+++ b/R/main.R
@@ -373,16 +373,23 @@ main_do_batch <- function(x) {
   git_pull_ref(pull, ref, config, message =
                  "Can't use --pull with --ref; perhaps you meant --fetch ?")
 
-  ids <- orderly_batch(name, parameters, root = config, instance = instance,
+  output <- orderly_batch(name, parameters, root = config, instance = instance,
                     ref = ref, fetch = fetch, message = message)
-  lapply(ids, function(id) {
+  lapply(output$id, function(id) {
     orderly_commit(id, name, config)
     path_rds <- path_orderly_run_rds(
       file.path(config$root, "archive", name, id))
     post_success(readRDS(path_rds), config)
   })
 
-  message("ids:", paste(ids, collapse = ", "))
+  col_names <- colnames(output)
+  for (row_num in seq_len(nrow(output))) {
+    row <- output[row_num, ]
+    out_text <- vcapply(seq_along(col_names), function(col_no) {
+      sprintf("%s: %s", col_names[col_no], row[col_no])
+    })
+    message(paste0(out_text, collapse = ", "))
+  }
 }
 
 

--- a/man/orderly_batch.Rd
+++ b/man/orderly_batch.Rd
@@ -4,7 +4,7 @@
 \alias{orderly_batch}
 \title{Run a batch of reports.}
 \usage{
-orderly_batch(name = NULL, parameters = NULL, ...)
+orderly_batch(name = NULL, parameters = NULL, continue_on_error = TRUE, ...)
 }
 \arguments{
 \item{name}{Name of the report to run (see
@@ -15,6 +15,12 @@ already set the working directory to be the source directory.}
 
 \item{parameters}{Data frame of parameters passed to report. Each row
 represents a parameter set to be passed to one report run.}
+
+\item{continue_on_error}{If FALSE then if one report run fails the
+function will not attempt to run subsequent reports in the batch. If
+TRUE subsequent parameter sets will be run. If the report run fails
+during preparation e.g. because of missing parameters this will
+error and stop all subsequent parameter sets.}
 
 \item{...}{Additional args passed to \code{\link[=orderly_run]{orderly_run()}}}
 }

--- a/tests/testthat/examples/batch/src/example/orderly.yml
+++ b/tests/testthat/examples/batch/src/example/orderly.yml
@@ -1,0 +1,11 @@
+data: ~
+script: script.R
+parameters:
+  a: ~
+  b: ~
+  c:
+    default: 1
+artefacts:
+  data:
+    description: A graph of things
+    filenames: results.rds

--- a/tests/testthat/examples/batch/src/example/script.R
+++ b/tests/testthat/examples/batch/src/example/script.R
@@ -1,5 +1,5 @@
-if (!is.numeric(b)) {
-  stop("b must be numeric")
+if (b == 2) {
+  stop("b cannot be 2")
 }
 
 saveRDS(list(a = a, b = b, c = c),

--- a/tests/testthat/examples/batch/src/example/script.R
+++ b/tests/testthat/examples/batch/src/example/script.R
@@ -1,0 +1,6 @@
+if (!is.numeric(b)) {
+  stop("b must be numeric")
+}
+
+saveRDS(list(a = a, b = b, c = c),
+        "results.rds")

--- a/tests/testthat/examples/workflow/source.R
+++ b/tests/testthat/examples/workflow/source.R
@@ -1,2 +1,0 @@
-function(con) {
-}

--- a/tests/testthat/examples/workflow/src/example/orderly.yml
+++ b/tests/testthat/examples/workflow/src/example/orderly.yml
@@ -1,5 +1,0 @@
-script: script.R
-artefacts:
-  staticgraph:
-    description: A graph of things
-    filenames: mygraph.png

--- a/tests/testthat/examples/workflow/src/example/script.R
+++ b/tests/testthat/examples/workflow/src/example/script.R
@@ -1,3 +1,0 @@
-png("mygraph.png")
-plot(1:10)
-dev.off()

--- a/tests/testthat/examples/workflow/workflows/broken_steps.yml
+++ b/tests/testthat/examples/workflow/workflows/broken_steps.yml
@@ -1,3 +1,0 @@
-steps:
-  - name: "example"
-    field: "value"

--- a/tests/testthat/examples/workflow/workflows/missing_name.yml
+++ b/tests/testthat/examples/workflow/workflows/missing_name.yml
@@ -1,2 +1,0 @@
-steps:
-  - field: "example"

--- a/tests/testthat/examples/workflow/workflows/missing_report.yml
+++ b/tests/testthat/examples/workflow/workflows/missing_report.yml
@@ -1,4 +1,0 @@
-steps:
-  - name: "example"
-  - name: "missing"
-  - name: "missing2"

--- a/tests/testthat/examples/workflow/workflows/missing_steps.yml
+++ b/tests/testthat/examples/workflow/workflows/missing_steps.yml
@@ -1,3 +1,0 @@
-stps:
-  - name: "example"
-  - name: "missing"

--- a/tests/testthat/test-batch.R
+++ b/tests/testthat/test-batch.R
@@ -54,3 +54,22 @@ test_that("return useful error if no parameters are passed", {
     orderly_batch("example", NULL),
     "Parameters for a batch must be a data frame with at least one row")
 })
+
+test_that("failure report in batch run does not fail subsequent report runs", {
+  path <- test_prepare_orderly_example("batch", testing = TRUE)
+
+  params <- data_frame(
+    a = c("one", "two", "three"),
+    b = c(1, "2", 3)
+  )
+  batch_id <- ids::random_id()
+  mockery::stub(orderly_batch, "ids::random_id", batch_id)
+  ids <- orderly_batch("example", parameters = params,
+                       root = path, echo = FALSE)
+  data <- lapply(ids, function(id) {
+    readRDS(path_orderly_run_rds(file.path(path, "draft", "example", id)))
+  })
+  invisible(lapply(data, function(d) {
+    expect_equal(d$meta$batch_id, batch_id)
+  }))
+})

--- a/tests/testthat/test-db.R
+++ b/tests/testthat/test-db.R
@@ -420,9 +420,9 @@ test_that("add batch info to db", {
   )
   batch_id <- ids::random_id()
   mockery::stub(orderly_batch, "ids::random_id", batch_id)
-  ids <- orderly_batch("example", parameters = params,
+  output <- orderly_batch("example", parameters = params,
                        root = path, echo = FALSE)
-  p <- lapply(ids, function(id) {
+  p <- lapply(output$id, function(id) {
     orderly_commit(id, root = path)
   })
 
@@ -433,7 +433,7 @@ test_that("add batch info to db", {
     data_frame(id = batch_id))
   expect_equal(
     DBI::dbReadTable(con, "report_version_batch"),
-    data_frame(report_version = ids, report_batch = rep(batch_id, 3)))
+    data_frame(report_version = output$id, report_batch = rep(batch_id, 3)))
 })
 
 

--- a/tests/testthat/test-main.R
+++ b/tests/testthat/test-main.R
@@ -613,7 +613,11 @@ test_that("batch", {
   expect_equal(res$options$parameters, data_frame(nmin = c(0, 0.2)))
   expect_equal(res$target, main_do_batch)
 
-  expect_message(res$target(res), "ids:[\\w\\d-]*")
+  messages <- capture_messages(res$target(res))
+  expect_match(messages[1], "id: [\\w\\d-]{24}, success: TRUE, nmin: 0\\n",
+               perl = TRUE)
+  expect_match(messages[2], "id: [\\w\\d-]{24}, success: TRUE, nmin: 0\\.2\\n",
+               perl = TRUE)
 
   d <- orderly_list_archive(path)
   expect_equal(nrow(d), 2L)


### PR DESCRIPTION
This will
* Update output from `orderly_batch` from a vector of ids to a data frame e.g.
```
id, success, param1, param2
123, TRUE, 0, "a"
456, FALSE, 0.2, "b"
```
* Add an arg to `orderly_batch` `continue_on_error` which is TRUE by default which will run subsequent reports if any in the batch run fail. Still errors early if it fails during preparation (before the report ID is available)
* Removes an old test setup for `workflow` which is no longer used

I couldn't decide if it would be better to continue from all errors and return e.g.
```
id, success, param1, param2
NA, FALSE, 0, "a"
NA, FALSE, 0.2, "b"
```
if they fail before the report ID is available. I think if 1 report fails before the report ID is available it is likely that all the others will too. If they fail during preparation is is usually because something about args isn't correct e.g. not providing required parameters