### PR TITLE
Remove demo test dir and run demo reports on other branch

### DIFF
--- a/R/testing.R
+++ b/R/testing.R
@@ -247,8 +247,8 @@ unzip_git_demo <- function(path = tempfile()) {
   path
 }
 
-prepare_orderly_git_example <- function(path = tempfile(), run_report = FALSE,
-                                        branch = "master") {
+prepare_orderly_git_example <- function(path = tempfile(), run_minimal = FALSE,
+                                        run_other = FALSE, branch = "master") {
   path_upstream <- file.path(path, "upstream")
   unzip_git_demo(path)
   unzip_git_demo(path_upstream)
@@ -261,14 +261,22 @@ prepare_orderly_git_example <- function(path = tempfile(), run_report = FALSE,
   git_run(c("branch", "--set-upstream-to", sprintf("origin/%s", branch),
             branch), path)
 
-  writeLines("new", file.path(path_upstream, "new"))
-  git_run(c("add", "."), path_upstream)
-  git_run(c("commit", "-m", "orderly"), path_upstream)
-
-  if (run_report) {
+  if (run_minimal) {
     id <- orderly_run("minimal", root = path)
     orderly_commit(id, root = path)
   }
+  if (run_other) {
+    git_checkout_branch("other", root = path)
+    run_orderly_demo(path, quiet = TRUE)
+    git_run(c("add", "."), root = path)
+    git_run(c("commit", "-m", '"run demo reports"'), root = path)
+    git_run(c("push", "--set-upstream", "origin", "other"), root = path)
+    git_checkout_branch(branch, root = path)
+  }
+
+  writeLines("new", file.path(path_upstream, "new"))
+  git_run(c("add", "."), path_upstream)
+  git_run(c("commit", "-m", "orderly"), path_upstream)
 
   c(origin = path_upstream, local = path)
 }

--- a/inst/create_orderly_demo.sh
+++ b/inst/create_orderly_demo.sh
@@ -5,5 +5,4 @@ if [ "$#" -ne 1 ]; then
     exit 1
 fi
 DEST=$1
-Rscript -e "orderly:::create_orderly_demo(\"$DEST/demo\", git = TRUE)"
-Rscript -e "orderly:::prepare_orderly_git_example(\"$DEST/git\", TRUE)"
+Rscript -e "orderly:::prepare_orderly_git_example(\"$DEST/git\", TRUE, TRUE)"

--- a/tests/testthat/test-z-demo.R
+++ b/tests/testthat/test-z-demo.R
@@ -26,13 +26,21 @@ test_that("orderly_demo", {
 
 test_that("git demo", {
   testthat::skip_on_cran()
-  path1 <- test_prepare_orderly_git_example(run_report = FALSE)
-  capture.output(path2 <- test_prepare_orderly_git_example(run_report = TRUE))
+  path1 <- test_prepare_orderly_git_example(run_minimal = FALSE)
+  capture.output(path2 <- test_prepare_orderly_git_example(run_minimal = TRUE))
+  capture.output(path3 <- test_prepare_orderly_git_example(run_other = TRUE))
 
   expect_equal(
     nrow(orderly_list2(root = path1[["local"]], draft = FALSE)), 0)
   expect_equal(
     nrow(orderly_list2(root = path2[["local"]], draft = FALSE)), 1)
+  expect_true(
+    nrow(orderly_list2(root = path3[["local"]], draft = FALSE)) > 20)
+  expect_true(all(
+    c("minimal", "other", "global", "use_dependency", "changelog",
+      "use_resource", "multi-artefact", "multifile-artefact", "html",
+      "interactive", "use_resource_dir", "connection", "spaces", "view") %in%
+      orderly_list2(root = path3[["local"]], draft = FALSE)$name))
 })
 
 


### PR DESCRIPTION
**N.B. We should not merge this until orderly-web tests are updated and working again, it is going to potentially break lots of stuff**

This PR will
* Remove `demo` dir from `create_orderly_demo.sh` test setup which is used by orderly-web
* Run the demo reports on the `other` branch in the `git` directory (so the report_version required have records in the database)

This does change some of the git state in `git` directory. Namely previously we had

Locally
master: initial-import
other: initial-import  -- add-other

In upstream
master: initial-import -- orderly
other: initial-import -- add-other

We now have

Locally
master:   initial-import
other:  initial-import  -- add-other -- run demo reports

In upstream
master: initial-import -- orderly
other: initial-import -- add-other -- run demo reports