### PR TITLE
Fix documentation for where to store templates

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.4.7
+Version: 1.4.8
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/R/new.R
+++ b/R/new.R
@@ -3,7 +3,7 @@
 ##' Details below for how these are configured and discovered by
 ##' orderly.
 ##'
-##' To create a custom template, create a directory `templates`
+##' To create a custom template, create a directory `template`
 ##' within your orderly root.  Within that directory create
 ##' directories containing all the files that you would like a report
 ##' to contain.  This *must* contain a file
@@ -29,7 +29,7 @@
 ##'
 ##' @param template The name of a template.  If `NULL` orderly
 ##'   will search for a template (see Details).  If given it must be
-##'   the name of a directory within a directory `templates` in
+##'   the name of a directory within a directory `template` in
 ##'   your project root.  The special label "orderly" will use
 ##'   orderly's builtin template.
 ##'

--- a/man/orderly_new.Rd
+++ b/man/orderly_new.Rd
@@ -23,7 +23,7 @@ be suppressed.}
 
 \item{template}{The name of a template.  If \code{NULL} orderly
 will search for a template (see Details).  If given it must be
-the name of a directory within a directory \code{templates} in
+the name of a directory within a directory \code{template} in
 your project root.  The special label "orderly" will use
 orderly's builtin template.}
 }
@@ -37,7 +37,7 @@ Details below for how these are configured and discovered by
 orderly.
 }
 \details{
-To create a custom template, create a directory \code{templates}
+To create a custom template, create a directory \code{template}
 within your orderly root.  Within that directory create
 directories containing all the files that you would like a report
 to contain.  This \emph{must} contain a file


### PR DESCRIPTION
There seemed to be a small error in the documentation. It said templates should go in the "templates" directory, but `has_template()` actually looks in the __template__ directory.