### PR TITLE
vimc-6487: Tidy unpredictable search behaviour with orderly_pull_archive and orderly_push_archive

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.4.8
+Version: 1.4.9
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# orderly 1.4.9
+
+* Remove `parameters` arg from `orderly_pull_archive` as it was causing confusion for users (vimc-6487)
+* Add support for calling `orderly_push_archive` with a search query as the `id` (vimc-6487)
+
 # orderly 1.4.7
 
 * Add `orderly_cancel_remote` which can be used to cancel one or more reports running on a remote via its key (mrc-3167)

--- a/R/remote.R
+++ b/R/remote.R
@@ -158,7 +158,8 @@ orderly_pull_archive_internal <- function(name, id = "latest", root = NULL,
 
 orderly_pull_metadata <- function(name, id, root = NULL, locate = TRUE,
                                   remote = NULL) {
-  info <- pull_info(name, id, root, locate, remote)
+  parameters <- NULL
+  info <- pull_info(name, id, root, locate, remote, parameters)
   name <- info$name
   id <- info$id
   config <- info$config

--- a/R/remote.R
+++ b/R/remote.R
@@ -106,9 +106,10 @@ orderly_pull_dependencies <- function(name = NULL, root = NULL, locate = TRUE,
 ##' @rdname orderly_pull_dependencies
 ##'
 ##' @param id The report identifier (for `orderly_pull_archive` and
-##'   `orderly_push_archive`). Can be a specific report `id`, `latest` to get
-##'   most recent or full search query see [orderly::orderly_search()].
-##'   Defaults to using the latest report.
+##'   `orderly_push_archive`). Can be a specific report `id` or `latest` to get
+##'   the most recent version or a full search query see
+##'   [orderly::orderly_search()] for details. Defaults to using the
+##'   latest report.
 orderly_pull_archive <- function(name, id = "latest", root = NULL,
                                  locate = TRUE, remote = NULL,
                                  recursive = TRUE) {

--- a/man/orderly_pull_dependencies.Rd
+++ b/man/orderly_pull_dependencies.Rd
@@ -21,7 +21,6 @@ orderly_pull_archive(
   root = NULL,
   locate = TRUE,
   remote = NULL,
-  parameters = NULL,
   recursive = TRUE
 )
 
@@ -70,8 +69,11 @@ the direct reports, along with metadata for the dependencies;
 this will be potentially much faster, but leaves your archive in
 a more fragile state.}
 
-\item{id}{The identifier (for \code{orderly_pull_archive}).  The default is
-to use the latest report.}
+\item{id}{The report identifier (for \code{orderly_pull_archive} and
+\code{orderly_push_archive}). Can be a specific report \code{id} or \code{latest} to get
+the most recent version or a full search query see
+\code{\link[=orderly_search]{orderly_search()}} for details. Defaults to using the
+latest report.}
 }
 \value{
 No return value, these functions are called only for their

--- a/tests/testthat/test-dependency.R
+++ b/tests/testthat/test-dependency.R
@@ -624,8 +624,19 @@ test_that("Sensible error message if query fails", {
     "Failed to find suitable version of 'other' with query:")
 
   expect_error(
-    orderly_pull_archive("other", "latest(parameter:nmin < x)",
-                         parameters = list(x = 0.05),
+    orderly_pull_archive("other", "latest(parameter:nmin < 0.05)",
                          remote = remote, root = path_local),
-    "Failed to find suitable version of 'other' with query:")
+    paste0("Failed to find suitable version of 'other' with query:\n",
+           "  'latest(parameter:nmin < 0.05)'"),
+    fixed = TRUE)
+
+  expect_error(
+    orderly_pull_archive_internal("other", "latest(parameter:nmin < x)",
+                                  parameters = list(x = 0.05),
+                                  remote = remote, root = path_local),
+    paste0("Failed to find suitable version of 'other' with query:\n",
+           "  'latest(parameter:nmin < x)'\n",
+           "and parameters\n",
+           "  - x: 0.05"),
+    fixed = TRUE)
 })

--- a/tests/testthat/test-remote-path.R
+++ b/tests/testthat/test-remote-path.R
@@ -314,24 +314,6 @@ test_that("pull archive using query", {
 })
 
 
-test_that("pull archive using query and parameters", {
-  dat <- prepare_orderly_query_example()
-  remote <- orderly_remote_path(dat$root)
-
-  root <- test_prepare_orderly_example("demo")
-  expect_error(
-    orderly_pull_archive("other", "latest(parameter:nmin < n)", root = root,
-                         remote = remote),
-    "Query parameter 'n' not found in supplied parameters")
-
-  orderly_pull_archive("other", "latest(parameter:nmin < n)", root = root,
-                       remote = remote, parameters = list(n = 0.25))
-  expect_equal(
-    orderly_list_archive(root),
-    data_frame(name = "other", id = dat$ids[[2]]))
-})
-
-
 test_that("pull dependencies that use a query", {
   dat <- prepare_orderly_query_example()
   remote <- orderly_remote_path(dat$root)

--- a/tests/testthat/test-remote-path.R
+++ b/tests/testthat/test-remote-path.R
@@ -314,6 +314,25 @@ test_that("pull archive using query", {
 })
 
 
+test_that("pull archive using query and parameters", {
+  dat <- prepare_orderly_query_example()
+  remote <- orderly_remote_path(dat$root)
+
+  root <- test_prepare_orderly_example("demo")
+  expect_error(
+    orderly_pull_archive_internal("other", "latest(parameter:nmin < n)",
+                                  root = root, remote = remote),
+    "Query parameter 'n' not found in supplied parameters")
+
+  orderly_pull_archive_internal("other", "latest(parameter:nmin < n)",
+                                root = root, remote = remote,
+                                parameters = list(n = 0.25))
+  expect_equal(
+    orderly_list_archive(root),
+    data_frame(name = "other", id = dat$ids[[2]]))
+})
+
+
 test_that("pull dependencies that use a query", {
   dat <- prepare_orderly_query_example()
   remote <- orderly_remote_path(dat$root)

--- a/tests/testthat/test-remote-path.R
+++ b/tests/testthat/test-remote-path.R
@@ -253,9 +253,9 @@ test_that("push report with explicit ID", {
 test_that("push report with search query", {
   skip_on_cran_windows()
   ours <- test_prepare_orderly_example("demo")
-  id1 <- orderly_run("other", parameters = list(nmin= 0.25),
+  id1 <- orderly_run("other", parameters = list(nmin = 0.25),
                      root = ours, echo = FALSE)
-  id2 <- orderly_run("other", parameters = list(nmin= 0.5),
+  id2 <- orderly_run("other", parameters = list(nmin = 0.5),
                     root = ours, echo = FALSE)
   orderly_commit(id1, root = ours)
   orderly_commit(id2, root = ours)

--- a/tests/testthat/test-remote-path.R
+++ b/tests/testthat/test-remote-path.R
@@ -291,6 +291,21 @@ test_that("Fail to push if not supported", {
 })
 
 
+test_that("fail to push when version not found", {
+  skip_on_cran_windows()
+  ours <- test_prepare_orderly_example("demo")
+  theirs <- test_prepare_orderly_example("demo")
+
+  remote <- orderly_remote_path(theirs)
+  expect_error(
+    orderly_push_archive("other", "latest(parameter:nmin == 0.25)",
+                         root = ours, remote = remote),
+    paste0("Failed to find suitable version of 'other' with query:\n",
+           "  'latest(parameter:nmin == 0.25)'"),
+    fixed = TRUE)
+})
+
+
 test_that("fetch remote metadata", {
   dat <- prepare_orderly_remote_example()
   base <- normalizePath(file.path(dat$path_remote, "archive"))


### PR DESCRIPTION
This PR does 2 things
* Supports search query as `id` arg to `orderly_push_archive` (which is what the docs suggested was already working)
* Removes `parameter` arg from `orderly_pull_archive`, saw users trying to use this as `orderly_pull_archive("report_name", parameters = list(nmin = 0.5))` to pull the latest report where a param had a value. I think the `parameters` arg to this is generally quite confusing and I'm not sure what the use case is here? In `orderly_pull_dependencies` it makes sense as the search query is set in the `orderly.yml` itself whereas with `orderly_pull_archive` the user sets the query term so they could just write `latest(parameter:nmin == 0.5)` instead of using `id = "latest(parameter:nmin == n)", parameters = list(nmin = 0.5)`. Could be a use case for that that I have not thought about but I think fairly confusing taking both args atm.