### PR TITLE
Attempt all parameter sets in orderly_batch when continue_on_error TRUE

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly
 Title: Lightweight Reproducible Reporting
-Version: 1.5.1
+Version: 1.5.2
 Description: Order, create and store reports from R.  By defining a
     lightweight interface around the inputs and outputs of an
     analysis, a lot of the repetitive work for reproducible research

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# orderly 1.5.2
+
+* `orderly_batch` will now attempt to run all parameter sets when `continue_on_error` is `TRUE`. Previously it would fail early if dependency resolution failed. However we want to attempt these in the case that a user has a parameterised dependency.
+
 # orderly 1.5.0
 
 * Add `prepare_git_example_from_source` which can be used to generate a git controlled orderly directory

--- a/man/orderly_batch.Rd
+++ b/man/orderly_batch.Rd
@@ -18,9 +18,7 @@ represents a parameter set to be passed to one report run.}
 
 \item{continue_on_error}{If FALSE then if one report run fails the
 function will not attempt to run subsequent reports in the batch. If
-TRUE subsequent parameter sets will be run. If the report run fails
-during preparation e.g. because of missing parameters this will
-error and stop all subsequent parameter sets.}
+TRUE subsequent parameter sets will be run.}
 
 \item{...}{Additional args passed to \code{\link[=orderly_run]{orderly_run()}}}
 }

--- a/tests/testthat/test-batch.R
+++ b/tests/testthat/test-batch.R
@@ -109,7 +109,7 @@ test_that("failure report in batch run does not fail subsequent report runs", {
   }))
 })
 
-test_that("failure report in batch run does not fail subsequent report runs when id unknown", {
+test_that("orderly_batch attempts subsequent report runs even when id unknown", {
   dat <- prepare_orderly_query_example()
   root <- dat$root
 

--- a/tests/testthat/test-batch.R
+++ b/tests/testthat/test-batch.R
@@ -109,10 +109,9 @@ test_that("failure report in batch run does not fail subsequent report runs", {
   }))
 })
 
-test_that("orderly_batch attempts subsequent report runs even when id unknown", {
+test_that("batch attempts subsequent report runs even when id unknown", {
   dat <- prepare_orderly_query_example()
   root <- dat$root
-
   config <- orderly_config_$new(root)
 
   p <- file.path(root, "src", "use_dependency", "orderly.yml")


### PR DESCRIPTION
Previously we were failing early if e.g. dependency resolution failed meaning when a report used parameterised dependencies it would not attempt later runs when they could pass successfully.
